### PR TITLE
Cache xpath results

### DIFF
--- a/masci_tools/io/parsers/fleur/fleur_schema/fleur_schema_parser_functions.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/fleur_schema_parser_functions.py
@@ -25,12 +25,21 @@ _INPUT_TYPE = 'FleurInputType'
 
 #We define some decorators to cache results to not repeat too many similar xpath calls or recursive function calls
 
-def cache_xpath_construction(func):
+def _cache_xpath_construction(func):
+    """
+    Decorator for the `_get_xpath` and `_get_attrib_xpath` functions to speed up the parsing of
+    xml schemas by caching results
+    """
 
     results = {}
 
     @wraps(func)
     def wrapper(xmlschema, namespaces, name, **kwargs):
+        """
+        This function produces a hash from all the arguments modifying the behaviour
+        and looks up results in dict based on this hash. If the version of the schema
+        is different than before or the dict contains more than 1024 entries the cache is cleared
+        """
 
         version = str(xmlschema.xpath('/xsd:schema/@version', namespaces=namespaces)[0])
         root_tag = str(xmlschema.xpath('/xsd:schema/xsd:element/@name', namespaces=namespaces)[0])
@@ -50,17 +59,24 @@ def cache_xpath_construction(func):
                 return res
             results[version][hash_args] = res
 
-
         return results[version][hash_args].copy()
 
     return wrapper
 
-def cache_xpath_eval(func):
 
+def _cache_xpath_eval(func):
+    """
+    Decorator for the `_xpath_eval` function to speed up concrete xpath calls on the schema
+    """
     results = {}
 
     @wraps(func)
     def wrapper(xmlschema, xpath, namespaces):
+        """
+        This function produces a hash from all the arguments modifying the behaviour
+        and looks up results in dict based on this hash. If the version of the schema
+        is different than before or the dict contains more than 1024 entries the cache is cleared
+        """
 
         version = str(xmlschema.xpath('/xsd:schema/@version', namespaces=namespaces)[0])
         root_tag = str(xmlschema.xpath('/xsd:schema/xsd:element/@name', namespaces=namespaces)[0])
@@ -79,16 +95,19 @@ def cache_xpath_eval(func):
                 return res
             results[version][hash_args] = res
 
-
         return results[version][hash_args].copy()
 
     return wrapper
 
-@cache_xpath_eval
-def xpath_eval(xmlschema, xpath, namespaces):
+@_cache_xpath_eval
+def _xpath_eval(xmlschema, xpath, namespaces):
     """
     Wrapper around the xpath calls in this module. Used for caching the
     results
+
+    :param xmlschema: xmltree representing the schema
+    :param xpath: str, xpath expression to evaluate
+    :param namespaces: dictionary with the defined namespaces
     """
     return xmlschema.xpath(xpath, namespaces=namespaces)
 
@@ -202,10 +221,10 @@ def _analyse_type_elem(xmlschema, namespaces, type_elem, base_types, convert_to_
                         if detected_base_type in basic_types_mapping:
                             possible_base_types.append(detected_base_type)
                     else:
-                        next_type_elems = xpath_eval(xmlschema,f"//xsd:simpleType[@name='{detected_base_type}']",
+                        next_type_elems = _xpath_eval(xmlschema,f"//xsd:simpleType[@name='{detected_base_type}']",
                                                           namespaces=namespaces)
                         if len(next_type_elems) == 0:
-                            next_type_elems = xpath_eval(xmlschema,
+                            next_type_elems = _xpath_eval(xmlschema,
                                 f"//xsd:complexType[@name='{detected_base_type}']/xsd:simpleContent",
                                 namespaces=namespaces)
                             if len(next_type_elems) == 0:
@@ -262,10 +281,10 @@ def _get_length(xmlschema, namespaces, type_name):
              if a list with no restriction is found return 'unbounded',
              if neither are found return 1
     """
-    type_elem = xpath_eval(xmlschema,f"//xsd:simpleType[@name='{type_name}']", namespaces=namespaces)
+    type_elem = _xpath_eval(xmlschema,f"//xsd:simpleType[@name='{type_name}']", namespaces=namespaces)
     if len(type_elem) == 0:
         #I know that this is not general but this is the only other case than simpleType, which occurs at the moment
-        type_elem = xpath_eval(xmlschema,f"//xsd:complexType[@name='{type_name}']/xsd:simpleContent/xsd:extension/@base",
+        type_elem = _xpath_eval(xmlschema,f"//xsd:complexType[@name='{type_name}']/xsd:simpleContent/xsd:extension/@base",
                                     namespaces=namespaces)
         if len(type_elem) == 0:
             return 1
@@ -289,7 +308,7 @@ def _get_length(xmlschema, namespaces, type_name):
 
     return 1
 
-@cache_xpath_construction
+@_cache_xpath_construction
 def _get_xpath(xmlschema,
                namespaces,
                tag_name,
@@ -325,12 +344,12 @@ def _get_xpath(xmlschema,
 
     #Get all possible starting points
     if ref is not None:
-        startPoints = xpath_eval(xmlschema,f"//xsd:group[@ref='{ref}']", namespaces=namespaces)
+        startPoints = _xpath_eval(xmlschema,f"//xsd:group[@ref='{ref}']", namespaces=namespaces)
     else:
         if enforce_end_type is None:
-            startPoints = xpath_eval(xmlschema,f"//xsd:element[@name='{tag_name}']", namespaces=namespaces)
+            startPoints = _xpath_eval(xmlschema,f"//xsd:element[@name='{tag_name}']", namespaces=namespaces)
         else:
-            startPoints = xpath_eval(xmlschema,f"//xsd:element[@name='{tag_name}' and @type='{enforce_end_type}']",
+            startPoints = _xpath_eval(xmlschema,f"//xsd:element[@name='{tag_name}' and @type='{enforce_end_type}']",
                                           namespaces=namespaces)
     if stop_non_unique:
         startPoints_copy = startPoints.copy()
@@ -365,11 +384,11 @@ def _get_xpath(xmlschema,
                 possible_paths.add(grouppath)
         else:
             if stop_non_unique:
-                currentelem = xpath_eval(xmlschema,
+                currentelem = _xpath_eval(xmlschema,
                     f"//xsd:element[@type='{next_type}' and @maxOccurs=1] | //xsd:element[@type='{next_type}' and not(@maxOccurs)]",
                     namespaces=namespaces)
             else:
-                currentelem = xpath_eval(xmlschema,f"//xsd:element[@type='{next_type}']", namespaces=namespaces)
+                currentelem = _xpath_eval(xmlschema,f"//xsd:element[@type='{next_type}']", namespaces=namespaces)
 
             if len(currentelem) == 0:
                 continue
@@ -396,7 +415,21 @@ def _get_xpath(xmlschema,
 
 
 def _get_contained_attribs(xmlschema, namespaces, elem, optional=False):
+    """
+    Get all defined attributes contained in the given etree Element of the schema
 
+    :param xmlschema: xmltree representing the schema
+    :param namespaces: dictionary with the defined namespaces
+    :param elem: etree Element to analyse
+    :param optional: bool, if True only the attributes which have use='optional'
+                     are added and their default value (defaults to None) is returned in a
+                     :py:class:`masci_tools.util.case_insensitive_dict.CaseInsensitiveDict`
+
+    :raises: AssertionError if case insensitivity lead to lost information
+
+    :returns: CaseInsensitiveDict (optional=True) or CaseInsensitiveFrozenSet with
+              the attribute names
+    """
     attrib_list = []
     for child in elem:
         child_type = _remove_xsd_namespace(child.tag, namespaces)
@@ -418,7 +451,18 @@ def _get_contained_attribs(xmlschema, namespaces, elem, optional=False):
 
 
 def _get_optional_tags(xmlschema, namespaces, elem):
+    """
+    Get all defined tags contained in the given etree Element of the schema
+    with minOccurs=0
 
+    :param xmlschema: xmltree representing the schema
+    :param namespaces: dictionary with the defined namespaces
+    :param elem: etree Element to analyse
+
+    :raises: AssertionError if case insensitivity lead to lost information
+
+    :returns: CaseInsensitiveFrozenSet with the tag names
+    """
     optional_list = []
     for child in elem:
         child_type = _remove_xsd_namespace(child.tag, namespaces)
@@ -439,7 +483,16 @@ def _get_optional_tags(xmlschema, namespaces, elem):
 
 
 def _is_simple(namespaces, elem):
+    """
+    Determine if a given etree element is simple (only contains attributes or text (no sub elements))
 
+    :param namespaces: dictionary with the defined namespaces
+    :param elem: etree Element to analyse
+
+    :raises: ValueError if an unknown type is encountered
+
+    :returns: bool determining, whether the element is simple
+    """
     simple = True
     for child in elem:
         child_type = _remove_xsd_namespace(child.tag, namespaces)
@@ -455,6 +508,19 @@ def _is_simple(namespaces, elem):
 
 
 def _get_simple_tags(xmlschema, namespaces, elem, input_mapping=None):
+    """
+    Get all defined tags contained in the given etree Element of the schema
+    which can only contain attributes or text (no sub elements)
+
+    :param xmlschema: xmltree representing the schema
+    :param namespaces: dictionary with the defined namespaces
+    :param elem: etree Element to analyse
+    :param input_mapping: dict, with the defined types from the input schema
+
+    :raises: AssertionError if case insensitivity lead to lost information
+
+    :returns: CaseInsensitiveFrozenSet with the tag names
+    """
 
     if input_mapping is None:
         input_mapping = {}
@@ -470,11 +536,11 @@ def _get_simple_tags(xmlschema, namespaces, elem, input_mapping=None):
                 simple_list.append(child.attrib['name'])
                 continue
 
-            type_elem = xpath_eval(xmlschema,f"//xsd:simpleType[@name='{child.attrib['type']}']", namespaces=namespaces)
+            type_elem = _xpath_eval(xmlschema,f"//xsd:simpleType[@name='{child.attrib['type']}']", namespaces=namespaces)
             if len(type_elem) != 0:
                 simple_list.append(child.attrib['name'])
             else:
-                type_elem = xpath_eval(xmlschema,f"//xsd:complexType[@name='{child.attrib['type']}']", namespaces=namespaces)
+                type_elem = _xpath_eval(xmlschema,f"//xsd:complexType[@name='{child.attrib['type']}']", namespaces=namespaces)
                 if len(type_elem) == 0:
                     simple_list.append(child.attrib['name'])
                 elif _is_simple(namespaces, type_elem[0]):
@@ -491,7 +557,18 @@ def _get_simple_tags(xmlschema, namespaces, elem, input_mapping=None):
 
 
 def _get_several_tags(xmlschema, namespaces, elem):
+    """
+    Get all defined tags contained in the given etree Element of the schema
+    which can occur multiple times (maxOccurs!=1)
 
+    :param xmlschema: xmltree representing the schema
+    :param namespaces: dictionary with the defined namespaces
+    :param elem: etree Element to analyse
+
+    :raises: AssertionError if case insensitivity lead to lost information
+
+    :returns: CaseInsensitiveFrozenSet with the tag names
+    """
     several_list = []
     for child in elem:
         child_type = _remove_xsd_namespace(child.tag, namespaces)
@@ -518,7 +595,19 @@ def _get_several_tags(xmlschema, namespaces, elem):
 
 
 def _get_text_tags(xmlschema, namespaces, elem, simple_elements):
+    """
+    Get all defined tags contained in the given etree Element of the schema
+    which can contain text
 
+    :param xmlschema: xmltree representing the schema
+    :param namespaces: dictionary with the defined namespaces
+    :param elem: etree Element to analyse
+    :param simple_elements: dict with all known types of test elements
+
+    :raises: AssertionError if case insensitivity lead to lost information
+
+    :returns: CaseInsensitiveFrozenSet with the tag names
+    """
     text_list = []
     for child in elem:
         child_type = _remove_xsd_namespace(child.tag, namespaces)
@@ -536,7 +625,7 @@ def _get_text_tags(xmlschema, namespaces, elem, simple_elements):
 
     return text_set
 
-@cache_xpath_construction
+@_cache_xpath_construction
 def _get_attrib_xpath(xmlschema,
                       namespaces,
                       attrib_name,
@@ -557,7 +646,7 @@ def _get_attrib_xpath(xmlschema,
              otherwise a list with all possible paths is returned
     """
     possible_paths = set()
-    attribute_tags = xpath_eval(xmlschema,f"//xsd:attribute[@name='{attrib_name}']", namespaces=namespaces)
+    attribute_tags = _xpath_eval(xmlschema,f"//xsd:attribute[@name='{attrib_name}']", namespaces=namespaces)
     for attrib in attribute_tags:
         parent_type, parent_tag = _get_parent_fleur_type(attrib, namespaces, stop_non_unique=stop_non_unique)
         if parent_type is None:
@@ -572,11 +661,11 @@ def _get_attrib_xpath(xmlschema,
                 continue
 
         if stop_non_unique:
-            element_tags = xpath_eval(xmlschema,
+            element_tags = _xpath_eval(xmlschema,
                 f"//xsd:element[@type='{start_type}' and @maxOccurs=1]/@name | //xsd:element[@type='{start_type}' and not(@maxOccurs)]/@name",
                 namespaces=namespaces)
         else:
-            element_tags = xpath_eval(xmlschema,f"//xsd:element[@type='{start_type}']/@name", namespaces=namespaces)
+            element_tags = _xpath_eval(xmlschema,f"//xsd:element[@type='{start_type}']/@name", namespaces=namespaces)
 
         for tag in element_tags:
             tag_paths = _get_xpath(xmlschema,
@@ -613,7 +702,7 @@ def _get_sequence_order(xmlschema, namespaces, sequence_elem):
             for elem in new_order:
                 elem_order.append(elem)
         elif child_type == 'group':
-            group = xpath_eval(xmlschema,f"//xsd:group[@name='{child.attrib['ref']}']/xsd:sequence", namespaces=namespaces)
+            group = _xpath_eval(xmlschema,f"//xsd:group[@name='{child.attrib['ref']}']/xsd:sequence", namespaces=namespaces)
             new_order = _get_sequence_order(xmlschema, namespaces, group[0])
             for elem in new_order:
                 elem_order.append(elem)
@@ -635,7 +724,7 @@ def extract_attribute_types(xmlschema, namespaces, **kwargs):
     :return: possible types of the attributes in a dictionary, if multiple
              types are possible a list is inserted for the tag
     """
-    possible_attrib = xpath_eval(xmlschema,'//xsd:attribute', namespaces=namespaces)
+    possible_attrib = _xpath_eval(xmlschema,'//xsd:attribute', namespaces=namespaces)
 
     base_types = _get_base_types()
 
@@ -684,7 +773,7 @@ def get_tag_paths(xmlschema, namespaces, **kwargs):
     stop_iteration = kwargs.get('stop_iteration', False)
     iteration_root = kwargs.get('iteration_root', False)
 
-    possible_tags = set(xpath_eval(xmlschema,'//xsd:element/@name', namespaces=namespaces))
+    possible_tags = set(_xpath_eval(xmlschema,'//xsd:element/@name', namespaces=namespaces))
     tag_paths = CaseInsensitiveDict()
     for tag in sorted(possible_tags):
         paths = _get_xpath(xmlschema, namespaces, tag, stop_iteration=stop_iteration, iteration_root=iteration_root)
@@ -710,7 +799,7 @@ def get_unique_attribs(xmlschema, namespaces, **kwargs):
     iteration_root = kwargs.get('iteration_root', False)
 
     settable = CaseInsensitiveDict()
-    possible_attrib = set(xpath_eval(xmlschema,'//xsd:attribute/@name', namespaces=namespaces))
+    possible_attrib = set(_xpath_eval(xmlschema,'//xsd:attribute/@name', namespaces=namespaces))
     for attrib in sorted(possible_attrib):
         path = _get_attrib_xpath(xmlschema,
                                  namespaces,
@@ -764,7 +853,7 @@ def get_unique_path_attribs(xmlschema, namespaces, **kwargs):
         settable_contains_key = 'unique_path_attribs'
 
     settable = CaseInsensitiveDict()
-    possible_attrib = set(xpath_eval(xmlschema,'//xsd:attribute/@name', namespaces=namespaces))
+    possible_attrib = set(_xpath_eval(xmlschema,'//xsd:attribute/@name', namespaces=namespaces))
     for attrib in sorted(possible_attrib):
         if attrib in kwargs[settable_key]:
             continue
@@ -814,7 +903,7 @@ def get_other_attribs(xmlschema, namespaces, **kwargs):
         settable_contains_key = 'unique_path_attribs'
 
     other = CaseInsensitiveDict()
-    possible_attrib = set(xpath_eval(xmlschema,'//xsd:attribute/@name', namespaces=namespaces))
+    possible_attrib = set(_xpath_eval(xmlschema,'//xsd:attribute/@name', namespaces=namespaces))
     for attrib in sorted(possible_attrib):
         path = _get_attrib_xpath(xmlschema,
                                  namespaces,
@@ -857,7 +946,7 @@ def get_omittable_tags(xmlschema, namespaces, **kwargs):
     :return: list of tags, containing only a sequence of one allowed tag
     """
 
-    possible_tags = xpath_eval(xmlschema,'//xsd:element', namespaces=namespaces)
+    possible_tags = _xpath_eval(xmlschema,'//xsd:element', namespaces=namespaces)
 
     omittable_tags = []
     for tag in possible_tags:
@@ -865,7 +954,7 @@ def get_omittable_tags(xmlschema, namespaces, **kwargs):
         tag_name = tag.attrib['name']
 
         if tag_name not in omittable_tags:
-            type_elem = xpath_eval(xmlschema,f"//xsd:complexType[@name='{tag_type}']", namespaces=namespaces)
+            type_elem = _xpath_eval(xmlschema,f"//xsd:complexType[@name='{tag_type}']", namespaces=namespaces)
             if len(type_elem) == 0:
                 continue
             type_elem = type_elem[0]
@@ -904,7 +993,7 @@ def get_basic_elements(xmlschema, namespaces, **kwargs):
              meaning a dicationary with possible base types and evtl. length restriction
     """
 
-    elements = xpath_eval(xmlschema,'//xsd:element', namespaces=namespaces)
+    elements = _xpath_eval(xmlschema,'//xsd:element', namespaces=namespaces)
 
     base_types = _get_base_types()
 
@@ -958,8 +1047,8 @@ def get_basic_types(xmlschema, namespaces, **kwargs):
     :return: dictionary with type names and their corresponding type_definition
              meaning a dicationary with possible base types and evtl. length restriction
     """
-    basic_type_elems = xpath_eval(xmlschema,'//xsd:simpleType[@name]', namespaces=namespaces)
-    complex_type_elems = xpath_eval(xmlschema,'//xsd:complexType/xsd:simpleContent', namespaces=namespaces)
+    basic_type_elems = _xpath_eval(xmlschema,'//xsd:simpleType[@name]', namespaces=namespaces)
+    complex_type_elems = _xpath_eval(xmlschema,'//xsd:complexType/xsd:simpleContent', namespaces=namespaces)
 
     for elem in complex_type_elems:
         basic_type_elems.append(elem)
@@ -1011,7 +1100,7 @@ def get_tag_info(xmlschema, namespaces, **kwargs):
     """
     Get all important information about the tags
         - allowed attributes
-        - contained tags (simple (only attributes), optional, several, order)
+        - contained tags (simple (only attributes), optional (with default values), several, order, text tags)
 
     :param xmlschema: xmltree representing the schema
     :param namespaces: dictionary with the defined namespaces
@@ -1024,7 +1113,7 @@ def get_tag_info(xmlschema, namespaces, **kwargs):
 
     tag_info = {}
 
-    possible_tags = xpath_eval(xmlschema,'//xsd:element', namespaces=namespaces)
+    possible_tags = _xpath_eval(xmlschema,'//xsd:element', namespaces=namespaces)
 
     for tag in possible_tags:
 
@@ -1041,7 +1130,7 @@ def get_tag_info(xmlschema, namespaces, **kwargs):
 
         tag_path = list(tag_path)
 
-        type_elem = xpath_eval(xmlschema,f"//xsd:complexType[@name='{type_tag}']", namespaces=namespaces)
+        type_elem = _xpath_eval(xmlschema,f"//xsd:complexType[@name='{type_tag}']", namespaces=namespaces)
         if len(type_elem) == 0:
             continue
         type_elem = type_elem[0]
@@ -1075,7 +1164,7 @@ def get_root_tag(xmlschema, namespaces, **kwargs):
 
     :return: name of the single element defined in the first level of the schema
     """
-    return str(xpath_eval(xmlschema,'/xsd:schema/xsd:element/@name', namespaces=namespaces)[0])
+    return str(_xpath_eval(xmlschema,'/xsd:schema/xsd:element/@name', namespaces=namespaces)[0])
 
 
 def get_input_tag(xmlschema, namespaces, **kwargs):
@@ -1087,4 +1176,4 @@ def get_input_tag(xmlschema, namespaces, **kwargs):
 
     :return: name of the element with the type 'FleurInputType'
     """
-    return xpath_eval(xmlschema,f"//xsd:element[@type='{_INPUT_TYPE}']/@name", namespaces=namespaces)[0]
+    return _xpath_eval(xmlschema,f"//xsd:element[@type='{_INPUT_TYPE}']/@name", namespaces=namespaces)[0]

--- a/masci_tools/io/parsers/fleur/fleur_schema/fleur_schema_parser_functions.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/fleur_schema_parser_functions.py
@@ -16,7 +16,6 @@ functions to extract information about the fleur schema input or output
 from lxml import etree
 from masci_tools.util.case_insensitive_dict import CaseInsensitiveDict, CaseInsensitiveFrozenSet
 from functools import wraps
-import copy
 
 #These types have infinite recursive paths and CANNOT BE PARSED in the path generation
 _RECURSIVE_TYPES = ['CompositeTimerType']
@@ -87,7 +86,10 @@ def cache_xpath_eval(func):
 
 @cache_xpath_eval
 def xpath_eval(xmlschema, xpath, namespaces):
-
+    """
+    Wrapper around the xpath calls in this module. Used for caching the
+    results
+    """
     return xmlschema.xpath(xpath, namespaces=namespaces)
 
 


### PR DESCRIPTION
Some optimizations in `fleur_schema_parser_functions`. The runtime is dominated by the xpath construction functions and the actual xpath calls (since they are mostly relative and very general)

This pull request adds caching for these functions and cuts the runtime by a factor 3