### PR TITLE
Expose n_mmp_mat low level manipulation without inp.xml

### DIFF
--- a/docs/source/module_guide/code.rst
+++ b/docs/source/module_guide/code.rst
@@ -69,6 +69,13 @@ Functions/Classes for loading/validating fleur XML files
 .. automodule:: masci_tools.io.io_fleurxml
    :members:
 
+Helper functions for the ``n_mmp_mat`` file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: masci_tools.io.io_nmmpmat
+   :members:
+
+
 General HDF5 parser
 -------------------------
 

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -536,7 +536,7 @@ class FleurXMLModifier:
         :param species_name: string, name of the species you want to change
         :param orbital: integer, orbital quantum number of the LDA+U procedure to be modified
         :param spin: integer, specifies which spin block should be modified
-        :param occStates: list, sets the diagonal elements of the density matrix and everything
+        :param state_occupations: list, sets the diagonal elements of the density matrix and everything
                           else to zero
         :param denmat: matrix, specify the density matrix explicitely
         :param phi: float, optional angle (radian), by which to rotate the density matrix before writing it

--- a/masci_tools/io/io_nmmpmat.py
+++ b/masci_tools/io/io_nmmpmat.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+# Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
+#                All rights reserved.                                         #
+# This file is part of the Masci-tools package.                               #
+# (Material science tools)                                                    #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/judftteam/masci-tools.   #
+# For further information on the license, see the LICENSE.txt file.           #
+# For further information please visit http://judft.de/.                      #
+#                                                                             #
+###############################################################################
+"""
+Simple IO routines for creating text for nmmp_mat files
+"""
+import numpy as np
+
+def format_nmmpmat(denmat, orbital=None ,phi=None, theta=None):
+    """
+    Format a given 7x7 complex numpy array into the format for the n_mmp_mat file
+
+    Results in list of 14 strings. Every 2 lines correspond to one row in array
+    Real and imaginary parts are formatted with 20.13f in alternating order
+
+    :param denmat: numpy array (7x7) and complex for formatting
+
+    :raises ValueError: If denmat has wrong shape or datatype
+
+    :returns: list of str formatted in lines for the n_mmp_mat file
+    """
+
+    if denmat.shape != (7,7):
+        raise ValueError(f'Matrix has wrong shape for formatting: {denmat.shape}')
+
+    if denmat.dtype != complex:
+        raise ValueError(f'Matrix has wrong dtype for formatting: {denmat.dtype}')
+
+    #Now we generate the text in the format expected in the n_mmp_mat file
+    nmmp_lines = []
+    for row in denmat:
+
+        nmmp_lines.append(''.join([f'{x.real:20.13f}{x.imag:20.13f}' for x in row[:3]]) + f'{row[3].real:20.13f}')
+        nmmp_lines.append(f'{row[3].imag:20.13f}' + ''.join([f'{x.real:20.13f}{x.imag:20.13f}' for x in row[4:]]))
+
+    return nmmp_lines
+
+def rotate_nmmpmat_block(denmat, orbital, phi=None, theta=None):
+    """
+    Rotate the given 7x7 complex numpy array with the d-wigner matrix
+    corresponding to the given orbital and angles
+
+    :param denmat: complex numpy array of shape 7x7
+    :param orbital: int of the orbital for the current block
+    :param phi: float, angle (radian), by which to rotate the density matrix
+    :param theta: float, angle (radian), by which to rotate the density matrix
+
+    :returns: denmat rotated by the d-wigner matrix
+    """
+    from masci_tools.io.common_functions import get_wigner_matrix
+
+    if theta is None and phi is None:
+        return denmat
+
+    if phi is None:
+        phi = 0.0
+    if theta is None:
+        theta = 0.0
+
+    d_wigner = get_wigner_matrix(orbital, phi, theta)
+    #Rotate the density matrix
+    denmat = d_wigner.T.conj().dot(denmat.dot(d_wigner))
+
+    return denmat
+
+
+def write_nmmpmat(orbital, denmat, phi=None, theta=None):
+    """
+    Generate list of str for n_mmp_mat file from given numpy array
+
+    :param orbital: int of the orbital for the current block
+    :param denmat: complex numpy array of shape (2*orbital+1 x 2*orbital+1) with the wanted occupations
+    :param phi: float, angle (radian), by which to rotate the density matrix
+    :param theta: float, angle (radian), by which to rotate the density matrix
+
+    :returns: list of str formatted in lines for the n_mmp_mat file
+    """
+
+    denmat_padded = np.zeros((7, 7), dtype=complex)
+    denmat_padded[3 - orbital:4 + orbital, 3 - orbital:4 + orbital] = denmat
+
+    if theta is not None or phi is not None:
+        denmat_padded = rotate_nmmpmat_block(denmat_padded, orbital, phi=phi, theta=theta)
+
+    return format_nmmpmat(denmat_padded, orbital=orbital, phi=phi, theta=theta)
+
+def write_nmmpmat_from_states(orbital, state_occupations, phi=None, theta=None):
+    """
+    Generate list of str for n_mmp_mat file from diagonal occupations
+
+    :param orbital: int of the orbital for the current block
+    :param state_occupations: list like with length 2*orbital+1 with the occupations of the diagonals
+    :param phi: float, angle (radian), by which to rotate the density matrix
+    :param theta: float, angle (radian), by which to rotate the density matrix
+
+    :returns: list of str formatted in lines for the n_mmp_mat file
+    """
+
+    #diagonal density matrix
+    denmat = np.zeros((2*orbital+1, 2*orbital+1), dtype=complex)
+
+    for i, occ in enumerate(state_occupations):
+        denmat[i, i] = occ
+
+    return write_nmmpmat(orbital, denmat, phi=phi, theta=theta)
+
+
+def write_nmmpmat_from_orbitals(orbital, orbital_occupations, phi=None, theta=None):
+    """
+    Generate list of str for n_mmp_mat file from orbital occupations
+
+    orbital occupations are provided in the following order
+    (expressed as the spherical harmonics since it can be used for all orbitals):
+
+        - Y_l^0
+        - 1/sqrt(2) (Y_l^-1 + Y_l^1)
+        - i/sqrt(2) (Y_l^-1 - Y_l^1)
+        - 1/sqrt(2) (Y_l^-2 + Y_l^2)
+        - i/sqrt(2) (Y_l^-2 - Y_l^2)
+        - and so on ...
+
+    :param orbital: int of the orbital for the current block
+    :param orbital_occupations: list like with length 2*orbital+1 with the occupations of the orbitals
+    :param phi: float, angle (radian), by which to rotate the density matrix
+    :param theta: float, angle (radian), by which to rotate the density matrix
+
+    :returns: list of str formatted in lines for the n_mmp_mat file
+    """
+
+    denmat = np.zeros((2*orbital+1, 2*orbital+1), dtype=complex)
+
+    for index, occ in enumerate(orbital_occupations):
+
+        if index == 0:
+            denmat[orbital, orbital] = occ
+        else:
+            m = (index+1)//2
+            if index % 2 == 1:
+                denmat[orbital - m, orbital - m] += 1/2 * occ
+                denmat[orbital + m, orbital + m] += 1/2 * occ
+                denmat[orbital + m, orbital - m] += 1/2 * occ
+                denmat[orbital - m, orbital + m] += 1/2 * occ
+            else:
+                denmat[orbital - m, orbital - m] += 1/2 * occ
+                denmat[orbital + m, orbital + m] += 1/2 * occ
+                denmat[orbital + m, orbital - m] -= 1/2 * occ
+                denmat[orbital - m, orbital + m] -= 1/2 * occ
+
+
+    return write_nmmpmat(orbital, denmat, phi=phi, theta=theta)
+
+
+def read_nmmpmat_block(nmmp_lines, block_index):
+    """
+    Convert 14 line block of given nmmp_lines into 7x7 complex numpy array
+
+    :param nmmplines: list of lines in the n_mmp_mat file
+    :param block_index: int specifying which 14 line block to convert
+
+    :returns: 7x7 complex numpy array of the numbers in the given block
+    """
+    denmat = np.zeros((7,7), dtype=complex)
+
+    start_row = block_index * 14
+
+    for index, line in enumerate(nmmp_lines[start_row:start_row + 14]):
+        currentRow = index // 2
+        if index % 2 == 0:
+            rowData = [float(x) for x in line.split()]
+        else:
+            rowData.extend([float(x) for x in line.split()])
+            rowData = [
+                num[0] + 1j * num[1] for indx, num in enumerate(zip(rowData[:-1], rowData[1:])) if indx % 2 == 0
+            ]
+            denmat[currentRow, :] += np.array(rowData)
+
+    return denmat

--- a/masci_tools/tests/test_fleurxmlmodifier.py
+++ b/masci_tools/tests/test_fleurxmlmodifier.py
@@ -144,7 +144,7 @@ def test_fleurxmlmodifier_nmmpmat():
     from masci_tools.io.fleurxmlmodifier import FleurXMLModifier
 
     fm = FleurXMLModifier()
-    fm.set_nmmpmat('Ga-1', orbital=2, spin=1, occStates=[1, 2, 3, 4, 5])
+    fm.set_nmmpmat('Ga-1', orbital=2, spin=1, state_occupations=[1, 2, 3, 4, 5])
     fm.set_nmmpmat('As-2', orbital=1, spin=1, denmat=[[1, -2, 3], [4, -5, 6], [7, -8, 9]])
 
     # Does not validate

--- a/masci_tools/tests/test_xml_setters_nmmpmat.py
+++ b/masci_tools/tests/test_xml_setters_nmmpmat.py
@@ -23,7 +23,7 @@ def test_set_nmmpmat_nofile(load_inpxml, file_regression):
                              species_name='Ga-1',
                              orbital=2,
                              spin=1,
-                             occStates=[1, 2, 3, 4, 5])
+                             state_occupations=[1, 2, 3, 4, 5])
     nmmp_lines = set_nmmpmat(xmltree,
                              nmmp_lines,
                              schema_dict,
@@ -50,7 +50,7 @@ def test_set_nmmpmat_file(load_inpxml, file_regression):
                              species_name='Ga-1',
                              orbital=2,
                              spin=1,
-                             occStates=[1, 2, 3, 4, 5])
+                             state_occupations=[1, 2, 3, 4, 5])
     nmmp_lines = set_nmmpmat(xmltree,
                              nmmp_lines,
                              schema_dict,
@@ -75,7 +75,7 @@ def test_set_nmmpmat_file_get_wigner_matrix(load_inpxml, file_regression):
                              species_name='Ga-1',
                              orbital=1,
                              spin=1,
-                             occStates=[1, 0, 1],
+                             state_occupations=[1, 0, 1],
                              theta=np.pi / 2.0)
     nmmp_lines = set_nmmpmat(xmltree,
                              nmmp_lines,
@@ -103,7 +103,7 @@ def test_rotate_nmmpmat(load_inpxml, file_regression):
                              species_name='Ga-1',
                              orbital=1,
                              spin=1,
-                             occStates=[1, 0, 1])
+                             state_occupations=[1, 0, 1])
     nmmp_lines = set_nmmpmat(xmltree,
                              nmmp_lines,
                              schema_dict,
@@ -144,7 +144,7 @@ def test_validate_nmmpmat(load_inpxml):
                              species_name='Ga-1',
                              orbital=2,
                              spin=1,
-                             occStates=[1, 2, 3, 4, 5])
+                             state_occupations=[1, 2, 3, 4, 5])
     nmmp_lines = set_nmmpmat(xmltree,
                              nmmp_lines,
                              schema_dict,

--- a/masci_tools/util/xml/xml_setters_nmmpmat.py
+++ b/masci_tools/util/xml/xml_setters_nmmpmat.py
@@ -16,11 +16,10 @@ for LDA+U
 """
 
 from masci_tools.util.schema_dict_util import get_tag_xpath
-from masci_tools.io.io_nmmpmat import write_nmmpmat, write_nmmpmat_from_states
 import numpy as np
 
 def set_nmmpmat(xmltree, nmmplines, schema_dict, species_name, orbital, spin,\
-                state_occupations=None, denmat=None, phi=None, theta=None):
+                state_occupations=None, orbital_occupations=None, denmat=None, phi=None, theta=None):
     """Routine sets the block in the n_mmp_mat file specified by species_name, orbital and spin
     to the desired density matrix
 
@@ -43,6 +42,7 @@ def set_nmmpmat(xmltree, nmmplines, schema_dict, species_name, orbital, spin,\
     """
     from masci_tools.util.xml.common_xml_util import eval_xpath, get_xml_attribute
     from masci_tools.util.schema_dict_util import evaluate_attribute, eval_simple_xpath
+    from masci_tools.io.io_nmmpmat import write_nmmpmat, write_nmmpmat_from_states, write_nmmpmat_from_orbitals
 
     #All lda+U procedures have to be considered since we need to keep the order
     species_base_path = get_tag_xpath(schema_dict, 'species')
@@ -69,8 +69,13 @@ def set_nmmpmat(xmltree, nmmplines, schema_dict, species_name, orbital, spin,\
 
     if state_occupations is not None:
         new_nmmpmat_entry = write_nmmpmat_from_states(orbital, state_occupations, phi=phi, theta=theta)
+    elif orbital_occupations is not None:
+        new_nmmpmat_entry = write_nmmpmat_from_orbitals(orbital, orbital_occupations, phi=phi, theta=theta)
     elif denmat is not None:
         new_nmmpmat_entry = write_nmmpmat(orbital, denmat, phi=phi, theta=theta)
+    else:
+        raise ValueError('Invalid definition of density matrix. Provide either state_occupations, '
+                         'orbital_occupations or denmat')
 
     #Check that numRows matches the number of lines in nmmp_lines_copy
     #If not either there was an n_mmp_mat file present in Fleurinp before and a lda+u calculation


### PR DESCRIPTION
Move low-level formatting/setting and rotating of n_mmp_mat entries to separate module so that they can be easily used without a xml to create a custom n_mmp_mat file

Support for:
   - Rotating the density matrix block
   - Converting block from n_mmp_mat to 7x7 complex numpy array
   - Specifying a density matrix via complete numpy array, diagonal elements or occupations of atomic orbitals (separate, if wished there could also be combined setting routine)