### PR TITLE
Redesign of logging and error handling in XML parser functions

### DIFF
--- a/docs/source/devel_guide/fleur_parser.rst
+++ b/docs/source/devel_guide/fleur_parser.rst
@@ -56,6 +56,7 @@ The following are possible:
   :text: Will parse the text of the given tag
   :numberNodes: Will return the number of nodes for the given tag
   :exists: Will return, whether the given tag exists
+  :attrib_exists: Will return, whether the given attribute exists
   :allAttribs: Will parse all known attributes at the given tag
                into a dictionary
   :parentAttribs: Will parse all known attributes at the given tag

--- a/docs/source/module_guide/tools.rst
+++ b/docs/source/module_guide/tools.rst
@@ -41,6 +41,12 @@ Basic IO helper functions
 .. automodule:: masci_tools.io.hdf5_util
    :members:
 
+Logging Utility
+----------------
+
+.. automodule:: masci_tools.util.logging_util
+   :members:
+
 Fleur parser utility
 ----------------------
 

--- a/docs/source/user_guide/fleur_parser.rst
+++ b/docs/source/user_guide/fleur_parser.rst
@@ -83,14 +83,13 @@ If only a small amount of information is required from the input or output files
 
 .. code-block:: python
 
-   from lxml import etree
-   from masci_tools.io.parsers.fleur.fleur_schema import InputSchemaDict
+   from masci_tools.io.io_fleurxml import load_inpxml
    from masci_tools.util.schema_dict_util import read_constants #Read in predefined constants
    from masci_tools.util.schema_dict_util import evaluate_attribute, eval_simple_xpath
 
    #First we create a xml-tree from the input file and load the desired input schema dictionary
-   root = etree.parse('/path/to/inp.xml').getroot()
-   schema_dict = InputSchemaDict.fromVersion(root.xpath('//@fleurInputVersion')[0])
+   xmltree, schema_dict = load_inpxml('/path/to/inp.xml')
+   root = xmltree.getroot()
 
    #For the input file there can be predefined contants
    constants = read_constants(root, schema_dict)

--- a/masci_tools/__init__.py
+++ b/masci_tools/__init__.py
@@ -11,4 +11,8 @@
 '''
 masci-tools
 '''
+import logging
+
 __version__ = '0.4.2'
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
@@ -60,6 +60,7 @@ def inpxml_parser(inpxmlfile, version=None, parser_info_out=None, strict=False, 
                                          INFO='parser_info',
                                          DEBUG='parser_debug',
                                          CRITICAL='parser_critical',
+                                         ignore_unknown_levels=True,
                                          level=logging_level)
 
         logger.addHandler(parser_log_handler)

--- a/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
@@ -19,9 +19,11 @@ from pprint import pprint
 from masci_tools.io.parsers.fleur.fleur_schema.schema_dict import InputSchemaDict
 from masci_tools.util.xml.common_xml_util import clear_xml, validate_xml, convert_xml_attribute, convert_xml_text, eval_xpath
 from masci_tools.util.schema_dict_util import read_constants
+from masci_tools.util.logging_util import DictHandler
+import logging
 
 
-def inpxml_parser(inpxmlfile, version=None, parser_info_out=None):
+def inpxml_parser(inpxmlfile, version=None, parser_info_out=None, strict=False, debug=False):
     """
     Parses the given inp.xml file to a python dictionary utilizing the schema
     defined by the version number to validate and corretly convert to the dictionary
@@ -29,6 +31,7 @@ def inpxml_parser(inpxmlfile, version=None, parser_info_out=None):
     :param inpxmlfile: either path to the inp.xml file, opened file handle or a xml etree to be parsed
     :param version: version string to enforce that a given schema is used
     :param parser_info_out: dict, with warnings, info, errors, ...
+    :param strict: bool if True  and no parser_info_out is provided any encountered error will immediately be raised
 
     :return: python dictionary with the parsed inp.xml
 
@@ -38,11 +41,34 @@ def inpxml_parser(inpxmlfile, version=None, parser_info_out=None):
 
     """
 
-    if parser_info_out is None:
-        parser_info_out = {'parser_warnings': []}
+    __parser_version__ = '0.3.0'
+    logger = logging.getLogger(__name__)
 
-    parser_version = '0.2.0'
-    parser_info_out['parser_info'] = f'Masci-Tools Fleur inp.xml Parser v{parser_version}'
+    parser_log_handler = None
+    if parser_info_out is not None or not strict:
+        if parser_info_out is None:
+            parser_info_out = {}
+
+        logging_level = logging.INFO
+        if debug:
+            logging_level = logging.DEBUG
+        logger.setLevel(logging_level)
+
+        parser_log_handler = DictHandler(parser_info_out,
+                                         WARNING='parser_warnings',
+                                         ERROR='parser_errors',
+                                         INFO='parser_info',
+                                         DEBUG='parser_debug',
+                                         CRITICAL='parser_critical',
+                                         level=logging_level)
+
+        logger.addHandler(parser_log_handler)
+
+    if strict:
+        logger = None
+
+    if logger is not None:
+        logger.info('Masci-Tools Fleur inp.xml Parser v%s', __parser_version__)
 
     if isinstance(inpxmlfile, etree._ElementTree):
         xmltree = inpxmlfile
@@ -51,43 +77,58 @@ def inpxml_parser(inpxmlfile, version=None, parser_info_out=None):
         try:
             xmltree = etree.parse(inpxmlfile, parser)
         except etree.XMLSyntaxError as msg:
+            if logger is not None:
+                logger.exception('Failed to parse input file')
             raise ValueError(f'Failed to parse input file: {msg}') from msg
 
     if version is None:
-        version = eval_xpath(xmltree, '//@fleurInputVersion', parser_info_out=parser_info_out)
+        version = eval_xpath(xmltree, '//@fleurInputVersion', logger=logger)
         version = str(version)
         if version is None:
+            if logger is not None:
+                logger.error('Failed to extract inputVersion')
             raise ValueError('Failed to extract inputVersion')
 
-    parser_info_out['fleur_inp_version'] = version
-    schema_dict = InputSchemaDict.fromVersion(version, parser_info_out=parser_info_out)
+    if logger is not None:
+        logger.info('Got Fleur input file with file version %s', version)
+    schema_dict = InputSchemaDict.fromVersion(version, logger=logger)
 
     ignore_validation = schema_dict['inp_version'] != version
 
     xmltree = clear_xml(xmltree)
     root = xmltree.getroot()
 
-    constants = read_constants(root, schema_dict)
+    constants = read_constants(root, schema_dict, logger=logger)
 
     try:
         validate_xml(xmltree, schema_dict.xmlschema, error_header='Input file does not validate against the schema')
     except etree.DocumentInvalid as err:
         errmsg = str(err)
-        parser_info_out['parser_warnings'].append(errmsg)
+        logger.warning(errmsg)
         if not ignore_validation:
+            if logger is not None:
+                logger.exception(errmsg)
             raise ValueError(errmsg) from err
 
     if schema_dict.xmlschema.validate(xmltree) or ignore_validation:
-        inp_dict = inpxml_todict(root, schema_dict, constants, parser_info_out=parser_info_out)
+        inp_dict = inpxml_todict(root, schema_dict, constants, logger=logger)
     else:
-        parser_info_out['parser_warnings'].append('Input file does not validate against the schema: Reason is unknown')
+        msg = 'Input file does not validate against the schema: Reason is unknown'
+        if logger is not None:
+            logger.warning(msg)
         if not ignore_validation:
-            raise ValueError('Input file does not validate against the schema: Reason is unknown')
+            if logger is not None:
+                logger.exception(msg)
+            raise ValueError(msg)
+
+    if parser_log_handler is not None:
+        if logger is not None:
+            logger.removeHandler(parser_log_handler)
 
     return inp_dict
 
 
-def inpxml_todict(parent, schema_dict, constants, omitted_tags=False, base_xpath=None, parser_info_out=None):
+def inpxml_todict(parent, schema_dict, constants, omitted_tags=False, base_xpath=None, logger=None):
     """
     Recursive operation which transforms an xml etree to
     python nested dictionaries and lists.
@@ -105,9 +146,6 @@ def inpxml_todict(parent, schema_dict, constants, omitted_tags=False, base_xpath
     :return: a python dictionary
     """
 
-    if parser_info_out is None:
-        parser_info_out = {'parser_warnings': []}
-
     #Check if this is the first call to this routine
     if base_xpath is None:
         base_xpath = f'/{parent.tag}'
@@ -118,34 +156,29 @@ def inpxml_todict(parent, schema_dict, constants, omitted_tags=False, base_xpath
         # Now we have to convert lazy fortan style into pretty things for the Database
         for key in return_dict:
             if key in schema_dict['attrib_types']:
-                conversion_warnings = []
                 return_dict[key], suc = convert_xml_attribute(return_dict[key],
                                                               schema_dict['attrib_types'][key],
                                                               constants,
-                                                              conversion_warnings=conversion_warnings)
-                if not suc:
-                    parser_info_out['parser_warnings'].append(
-                        f"Failed to convert attribute '{key}': "
-                        'Below are the warnings raised from convert_xml_attribute')
-                    for warning in conversion_warnings:
-                        parser_info_out['parser_warnings'].append(warning)
+                                                              logger=logger)
+                if not suc and logger is not None:
+                    logger.warning("Failed to convert attribute '%s' Got: '%s'", key, return_dict[key])
 
     if parent.text:
         # has text, but we don't want all the '\n' s and empty stings in the database
         if parent.text.strip() != '':  # might not be the best solutions
             if parent.tag not in schema_dict['simple_elements']:
+                if logger is not None:
+                    logger.error('Something is wrong in the schema_dict: %s is not in simple_elements, but it has text',
+                                 parent.tag)
                 raise ValueError(
                     f'Something is wrong in the schema_dict: {parent.tag} is not in simple_elements, but it has text')
-            conversion_warnings = []
+
             converted_text, suc = convert_xml_text(parent.text,
                                                    schema_dict['simple_elements'][parent.tag],
                                                    constants,
-                                                   conversion_warnings=conversion_warnings)
-            if not suc:
-                parser_info_out['parser_warnings'].append(f"Failed to convert text of '{parent.tag}': "
-                                                          'Below are the warnings raised from convert_xml_text')
-                for warning in conversion_warnings:
-                    parser_info_out['parser_warnings'].append(warning)
+                                                   logger=logger)
+            if not suc and logger is not None:
+                logger.warning("Failed to text of '%s' Got: '%s'", parent.tag, parent.text)
 
             if not return_dict:
                 return_dict = converted_text
@@ -169,7 +202,7 @@ def inpxml_todict(parent, schema_dict, constants, omitted_tags=False, base_xpath
                                         constants,
                                         base_xpath=new_base_xpath,
                                         omitted_tags=omitt_contained_tags,
-                                        parser_info_out=parser_info_out)
+                                        logger=logger)
 
         if element.tag in tag_info['several']:
             # make a list, otherwise the tag will be overwritten in the dict
@@ -193,12 +226,17 @@ def inpxml_todict(parent, schema_dict, constants, omitted_tags=False, base_xpath
                         if key not in return_dict:
                             return_dict[key] = []
                         elif not isinstance(return_dict[key], list):  #Key seems to be defined already
+                            if logger is not None:
+                                logger.error('%s cannot be extracted to the next level', key)
                             raise ValueError(f'{key} cannot be extracted to the next level')
                         return_dict[key].append(value)
                 for key in new_return_dict.keys():
                     if key in ['text_value', 'text_label']:
                         continue
                     if len(return_dict[key]) != len(return_dict[element.tag]):
+                        if logger is not None:
+                            logger.error(
+                                'Extracted optional argument %s at the moment only label is supported correctly', key)
                         raise ValueError(
                             f'Extracted optional argument {key} at the moment only label is supported correctly')
             else:

--- a/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
@@ -85,6 +85,7 @@ def outxml_parser(outxmlfile,
                                          INFO='parser_info',
                                          DEBUG='parser_debug',
                                          CRITICAL='parser_critical',
+                                         ignore_unknown_levels=True,
                                          level=logging_level)
 
         logger.addHandler(parser_log_handler)

--- a/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
@@ -293,7 +293,7 @@ def outxml_parser(outxmlfile,
     iteration_logger = OutParserLogAdapter(logger, logger_info)
 
     for node in iteration_nodes:
-        iteration_number = evaluate_attribute(node, outschema_dict, 'overallNumber', optional=True)
+        iteration_number = evaluate_attribute(node, outschema_dict, 'numberForCurrentRun', optional=True)
 
         if iteration_number is not None:
             logger_info['iteration'] = iteration_number

--- a/masci_tools/io/parsers/fleur/fleur_schema/fleur_schema_parser_functions.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/fleur_schema_parser_functions.py
@@ -44,7 +44,7 @@ def _cache_xpath_construction(func):
         version = str(xmlschema.xpath('/xsd:schema/@version', namespaces=namespaces)[0])
         root_tag = str(xmlschema.xpath('/xsd:schema/xsd:element/@name', namespaces=namespaces)[0])
 
-        arg_tuple = (version,root_tag,name, kwargs.get('enforce_end_type', ''), kwargs.get('ref', '')) + \
+        arg_tuple = (version, root_tag, name, kwargs.get('enforce_end_type', ''), kwargs.get('ref', '')) + \
                     tuple(key for key in kwargs if kwargs.get(key, False))
 
         hash_args = hash(arg_tuple)

--- a/masci_tools/io/parsers/fleur/fleur_schema/schema_dict.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/schema_dict.py
@@ -137,7 +137,7 @@ def _get_latest_available_version(output_schema):
 
                 latest_version = max(latest_version, convert_str_version_number(folder))
 
-    return '.'.join(map(str,latest_version))
+    return '.'.join(map(str, latest_version))
 
 
 class SchemaDict(LockableDict):
@@ -311,7 +311,7 @@ class InputSchemaDict(SchemaDict):
         """
         from masci_tools.util.xml.common_xml_util import convert_str_version_number
 
-        return convert_str_version_number(self.get('inp_version',''))
+        return convert_str_version_number(self.get('inp_version', ''))
 
 
 class OutputSchemaDict(SchemaDict):
@@ -471,7 +471,7 @@ class OutputSchemaDict(SchemaDict):
         """
         from masci_tools.util.xml.common_xml_util import convert_str_version_number
 
-        return convert_str_version_number(self.get('inp_version',''))
+        return convert_str_version_number(self.get('inp_version', ''))
 
     @property
     def out_version(self):
@@ -480,4 +480,4 @@ class OutputSchemaDict(SchemaDict):
         """
         from masci_tools.util.xml.common_xml_util import convert_str_version_number
 
-        return convert_str_version_number(self.get('out_version',''))
+        return convert_str_version_number(self.get('out_version', ''))

--- a/masci_tools/io/parsers/fleur/fleur_schema/schema_dict.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/schema_dict.py
@@ -251,12 +251,12 @@ class InputSchemaDict(SchemaDict):
     __version__ = '0.1.0'
 
     @classmethod
-    def fromVersion(cls, version, parser_info_out=None, no_cache=False):
+    def fromVersion(cls, version, logger=None, no_cache=False):
         """
         load the FleurInputSchema dict for the specified version
 
         :param version: str with the desired version, e.g. '0.33'
-        :param parser_info_out: dict with warnings, errors and information, ...
+        :param logger: logger object for warnings, errors and information, ...
 
         :return: InputSchemaDict object with the information for the provided version
         """
@@ -271,9 +271,9 @@ class InputSchemaDict(SchemaDict):
                 message = f'No FleurInputSchema.xsd found at {schema_file_path}'
                 raise FileNotFoundError(message)
             else:
-                if parser_info_out is not None:
-                    parser_info_out['parser_warnings'].append(
-                        f"No Input Schema available for version '{version}'; falling back to '{latest_version}'")
+                if logger is not None:
+                    logger.warning("No Input Schema available for version '%s'; falling back to '%s'", version,
+                                   latest_version)
                 else:
                     warnings.warn(
                         f"No Input Schema available for version '{version}'; falling back to '{latest_version}'")
@@ -294,7 +294,6 @@ class InputSchemaDict(SchemaDict):
         load the FleurInputSchema dict for the specified FleurInputSchema file
 
         :param path: path to the input schema file
-        :param parser_info_out: dict with warnings, errors and information, ...
 
         :return: InputSchemaDict object with the information for the provided file
         """
@@ -365,13 +364,13 @@ class OutputSchemaDict(SchemaDict):
     __version__ = '0.1.0'
 
     @classmethod
-    def fromVersion(cls, version, inp_version=None, parser_info_out=None, no_cache=False):
+    def fromVersion(cls, version, inp_version=None, logger=None, no_cache=False):
         """
         load the FleurOutputSchema dict for the specified version
 
         :param version: str with the desired version, e.g. '0.33'
         :param inp_version: str with the desired input version, e.g. '0.33' (defaults to version)
-        :param parser_info_out: dict with warnings, errors and information, ...
+        :param logger: logger object for warnings, errors and information, ...
 
         :return: OutputSchemaDict object with the information for the provided versions
         """
@@ -391,9 +390,9 @@ class OutputSchemaDict(SchemaDict):
                 message = f'No FleurOutputSchema.xsd found at {schema_file_path}'
                 raise FileNotFoundError(message)
             else:
-                if parser_info_out is not None:
-                    parser_info_out['parser_warnings'].append(
-                        f"No Output Schema available for version '{version}'; falling back to '{latest_version}'")
+                if logger is not None:
+                    logger.warning("No Output Schema available for version '%s'; falling back to '%s'", version,
+                                   latest_version)
                 else:
                     warnings.warn(
                         f"No Output Schema available for version '{version}'; falling back to '{latest_version}'")
@@ -409,9 +408,9 @@ class OutputSchemaDict(SchemaDict):
                 message = f'No FleurInputSchema.xsd found at {inpschema_file_path}'
                 raise FileNotFoundError(message)
             else:
-                if parser_info_out is not None:
-                    parser_info_out['parser_warnings'].append(
-                        f"No Input Schema available for version '{inp_version}'; falling back to '{latest_inpversion}'")
+                if logger is not None:
+                    logger.warning("No Input Schema available for version '%s'; falling back to '%s'", inp_version,
+                                   latest_inpversion)
                 else:
                     warnings.warn(
                         f"No Input Schema available for version '{inp_version}'; falling back to '{latest_inpversion}'")
@@ -420,9 +419,9 @@ class OutputSchemaDict(SchemaDict):
                 inpschema_file_path = os.path.abspath(os.path.join(PACKAGE_DIRECTORY, fleur_inpschema_path))
                 inp_version = latest_inpversion
 
-        if inp_version != version and parser_info_out is not None:
-            parser_info_out['parser_warnings'].append(
-                f'Creating OutputSchemaDict object for differing versions (out: {version}; inp: {inp_version})')
+        if inp_version != version and logger is not None:
+            logger.info('Creating OutputSchemaDict object for differing versions (out: %s; inp: %s)', version,
+                        inp_version)
 
         if (version, inp_version) in cls.__schema_dict_cache and not no_cache:
             return cls.__schema_dict_cache[(version, inp_version)]
@@ -441,7 +440,6 @@ class OutputSchemaDict(SchemaDict):
 
         :param path: str path to the FleurOutputSchema file
         :param inp_path: str path to the FleurInputSchema file (defaults to same folder as path)
-        :param parser_info_out: dict with warnings, errors and information, ...
 
         :return: OutputSchemaDict object with the information for the provided files
         """

--- a/masci_tools/io/parsers/fleur/outxml_conversions.py
+++ b/masci_tools/io/parsers/fleur/outxml_conversions.py
@@ -23,7 +23,7 @@ from masci_tools.io.common_functions import convert_to_pystd
 
 
 @conversion_function
-def convert_total_energy(out_dict, parser_info_out=None):
+def convert_total_energy(out_dict, logger):
     """
     Convert total energy to eV
     """
@@ -32,6 +32,7 @@ def convert_total_energy(out_dict, parser_info_out=None):
 
     if total_energy is None:
         if 'energy_hartree' in out_dict:
+            logger.warning('convert_total_energy cannot convert None to eV')
             out_dict['energy'] = None
             out_dict['energy_units'] = 'eV'
         return out_dict
@@ -45,13 +46,14 @@ def convert_total_energy(out_dict, parser_info_out=None):
     if total_energy is not None:
         out_dict['energy'].append(total_energy * HTR_TO_EV)
     else:
+        logger.warning('convert_total_energy cannot convert None to eV')
         out_dict['energy'].append(None)
 
     return out_dict
 
 
 @conversion_function
-def calculate_total_magnetic_moment(out_dict, parser_info_out=None):
+def calculate_total_magnetic_moment(out_dict, logger):
     """
     Calculate the the total magnetic moment per cell
 
@@ -60,6 +62,7 @@ def calculate_total_magnetic_moment(out_dict, parser_info_out=None):
     total_charge = out_dict.get('spin_dependent_charge_total', None)
 
     if total_charge is None:
+        logger.warning('calculate_total_magnetic_moment got None')
         return out_dict
 
     total_charge = total_charge[-1]
@@ -73,43 +76,41 @@ def calculate_total_magnetic_moment(out_dict, parser_info_out=None):
 
 
 @conversion_function
-def calculate_walltime(out_dict, parser_info_out=None):
+def calculate_walltime(out_dict, logger):
     """
     Calculate the walltime from start and end time
 
     :param out_dict: dict with the already parsed information
-    :param parser_info_out: dict, with warnings, info, errors, ...
+    :param logger: logger object for logging warnings, errors, if not provided all errors will be raised
     """
-    if parser_info_out is None:
-        parser_info_out = {'parser_warnings': []}
 
     if out_dict['start_date']['time'] is not None:
         starttimes = out_dict['start_date']['time'].split(':')
     else:
         starttimes = [0, 0, 0]
         msg = 'Starttime was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        parser_info_out['parser_warnings'].append(msg)
+        logger.warning(msg)
 
     if out_dict['end_date']['time'] is not None:
         endtimes = out_dict['end_date']['time'].split(':')
     else:
         endtimes = [0, 0, 0]
         msg = 'Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        parser_info_out['parser_warnings'].append(msg)
+        logger.warning(msg)
 
     if out_dict['start_date']['date'] is not None:
         start_date = out_dict['start_date']['date']
     else:
         start_date = None
         msg = 'Startdate was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        parser_info_out['parser_warnings'].append(msg)
+        logger.warning(msg)
 
     if out_dict['end_date']['date'] is not None:
         end_date = out_dict['end_date']['date']
     else:
         end_date = None
         msg = 'Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        parser_info_out['parser_warnings'].append(msg)
+        logger.warning(msg)
 
     offset = 0
     if start_date is not None and end_date is not None:
@@ -130,7 +131,7 @@ def calculate_walltime(out_dict, parser_info_out=None):
 
 
 @conversion_function
-def convert_ldau_definitions(out_dict, parser_info_out=None):
+def convert_ldau_definitions(out_dict, logger):
     """
     Convert the parsed information from LDA+U into a more readable dict
 
@@ -174,7 +175,7 @@ def convert_ldau_definitions(out_dict, parser_info_out=None):
 
 
 @conversion_function
-def convert_relax_info(out_dict, parser_info_out=None):
+def convert_relax_info(out_dict, logger):
     """
     Convert the general relaxation information
 
@@ -202,7 +203,7 @@ def convert_relax_info(out_dict, parser_info_out=None):
 
 
 @conversion_function
-def convert_forces(out_dict, parser_info_out=None):
+def convert_forces(out_dict, logger):
     """
     Convert the parsed forces from a iteration
 

--- a/masci_tools/io/parsers/fleur/outxml_conversions.py
+++ b/masci_tools/io/parsers/fleur/outxml_conversions.py
@@ -32,7 +32,8 @@ def convert_total_energy(out_dict, logger):
 
     if total_energy is None:
         if 'energy_hartree' in out_dict:
-            logger.warning('convert_total_energy cannot convert None to eV')
+            if logger is not None:
+                logger.warning('convert_total_energy cannot convert None to eV')
             out_dict['energy'] = None
             out_dict['energy_units'] = 'eV'
         return out_dict
@@ -46,7 +47,8 @@ def convert_total_energy(out_dict, logger):
     if total_energy is not None:
         out_dict['energy'].append(total_energy * HTR_TO_EV)
     else:
-        logger.warning('convert_total_energy cannot convert None to eV')
+        if logger is not None:
+            logger.warning('convert_total_energy cannot convert None to eV')
         out_dict['energy'].append(None)
 
     return out_dict
@@ -62,7 +64,8 @@ def calculate_total_magnetic_moment(out_dict, logger):
     total_charge = out_dict.get('spin_dependent_charge_total', None)
 
     if total_charge is None:
-        logger.warning('calculate_total_magnetic_moment got None')
+        if logger is not None:
+            logger.warning('calculate_total_magnetic_moment got None')
         return out_dict
 
     total_charge = total_charge[-1]
@@ -89,28 +92,32 @@ def calculate_walltime(out_dict, logger):
     else:
         starttimes = [0, 0, 0]
         msg = 'Starttime was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        logger.warning(msg)
+        if logger is not None:
+            logger.warning(msg)
 
     if out_dict['end_date']['time'] is not None:
         endtimes = out_dict['end_date']['time'].split(':')
     else:
         endtimes = [0, 0, 0]
         msg = 'Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        logger.warning(msg)
+        if logger is not None:
+            logger.warning(msg)
 
     if out_dict['start_date']['date'] is not None:
         start_date = out_dict['start_date']['date']
     else:
         start_date = None
         msg = 'Startdate was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        logger.warning(msg)
+        if logger is not None:
+            logger.warning(msg)
 
     if out_dict['end_date']['date'] is not None:
         end_date = out_dict['end_date']['date']
     else:
         end_date = None
         msg = 'Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        logger.warning(msg)
+        if logger is not None:
+            logger.warning(msg)
 
     offset = 0
     if start_date is not None and end_date is not None:

--- a/masci_tools/io/parsers/hdf5/reader.py
+++ b/masci_tools/io/parsers/hdf5/reader.py
@@ -24,6 +24,7 @@ AttribTransformation = namedtuple('AttribTransformation', ['name', 'attrib_name'
 
 logger = logging.getLogger(__name__)
 
+
 class HDF5Reader:
     """Class for reading in data from hdf5 files using a specified recipe
 
@@ -181,7 +182,7 @@ class HDF5Reader:
 
         if recipe is None:
             msg = 'Using the HDF5Reader without a recipe falling back to simple HDF reader'
-            logging.warn(msg)
+            logging.warning(msg)
             warnings.warn(msg)
             res = read_hdf_simple(self._file)
             logger.info('Finished reading .hdf file')

--- a/masci_tools/tests/conftest.py
+++ b/masci_tools/tests/conftest.py
@@ -19,3 +19,41 @@ def load_inpxml():
         return tree, schema_dict
 
     return _load_inpxml
+
+
+@pytest.fixture
+def clean_parser_log():
+    """Clean parser logs for consistent testing"""
+
+    def _clean_parser_log(info_dict):
+
+        clean_dict = {}
+        clean_dict['parser_info'] = info_dict.pop('parser_info', [])
+        clean_dict['parser_warnings'] = info_dict.pop('parser_warnings', [])
+        clean_dict['parser_errors'] = info_dict.pop('parser_errors', [])
+
+        return clean_dict
+
+    return _clean_parser_log
+
+
+@pytest.fixture(scope='session', autouse=True)
+def disable_parser_tracebacks():
+    """Disable logging of tracebacks in parser logs Thanks to
+       https://stackoverflow.com/questions/54605699/python-logging-disable-stack-trace"""
+    import logging
+
+    class TracebackInfoFilter(logging.Filter):
+        """Clear or restore the exception on log records"""
+
+        def filter(self, record):
+            record._exc_info_hidden, record.exc_info = record.exc_info, None
+            # clear the exception traceback text cache, if created.
+            record.exc_text = None
+            return True
+
+    inp_logger = logging.getLogger('masci_tools.io.parsers.fleur.fleur_inpxml_parser')
+    out_logger = logging.getLogger('masci_tools.io.parsers.fleur.fleur_outxml_parser')
+
+    inp_logger.addFilter(TracebackInfoFilter())
+    out_logger.addFilter(TracebackInfoFilter())

--- a/masci_tools/tests/conftest.py
+++ b/masci_tools/tests/conftest.py
@@ -59,7 +59,7 @@ def disable_parser_tracebacks():
     inp_logger.addFilter(traceback_filter)
     out_logger.addFilter(traceback_filter)
 
-    yield #Now all tests run
+    yield  #Now all tests run
 
     inp_logger.removeFilter(traceback_filter)
     out_logger.removeFilter(traceback_filter)

--- a/masci_tools/tests/conftest.py
+++ b/masci_tools/tests/conftest.py
@@ -37,7 +37,7 @@ def clean_parser_log():
     return _clean_parser_log
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.yield_fixture(scope='session', autouse=True)
 def disable_parser_tracebacks():
     """Disable logging of tracebacks in parser logs Thanks to
        https://stackoverflow.com/questions/54605699/python-logging-disable-stack-trace"""
@@ -55,5 +55,11 @@ def disable_parser_tracebacks():
     inp_logger = logging.getLogger('masci_tools.io.parsers.fleur.fleur_inpxml_parser')
     out_logger = logging.getLogger('masci_tools.io.parsers.fleur.fleur_outxml_parser')
 
-    inp_logger.addFilter(TracebackInfoFilter())
-    out_logger.addFilter(TracebackInfoFilter())
+    traceback_filter = TracebackInfoFilter()
+    inp_logger.addFilter(traceback_filter)
+    out_logger.addFilter(traceback_filter)
+
+    yield #Now all tests run
+
+    inp_logger.removeFilter(traceback_filter)
+    out_logger.removeFilter(traceback_filter)

--- a/masci_tools/tests/test_common_xml_util.py
+++ b/masci_tools/tests/test_common_xml_util.py
@@ -6,79 +6,12 @@ import pytest
 import os
 from masci_tools.util.constants import FLEUR_DEFINED_CONSTANTS
 from pprint import pprint
+import logging
 
 TEST_FOLDER = os.path.dirname(os.path.abspath(__file__))
 CLEAR_XML_TEST_FILE = os.path.abspath(os.path.join(TEST_FOLDER, 'files/fleur/test_clear.xml'))
 
-
-def test_convert_to_float():
-    """
-    Test of the convert_to_float function
-    """
-    from masci_tools.util.xml.common_xml_util import convert_to_float
-
-    ret_val, suc = convert_to_float('0.45')
-    assert suc
-    assert pytest.approx(ret_val) == 0.45
-
-    ret_val, suc = convert_to_float('1.5324324e-9')
-    assert suc
-    assert pytest.approx(ret_val) == 1.5324324e-9
-
-    warnings = []
-    ret_val, suc = convert_to_float({}, conversion_warnings=warnings)
-    assert not suc
-    assert ret_val == {}
-    assert warnings == ["Could not convert: '{}' to float, TypeError"]
-
-    warnings = []
-    ret_val, suc = convert_to_float('1,23', conversion_warnings=warnings)
-    assert not suc
-    assert ret_val == '1,23'
-    assert warnings == ["Could not convert: '1,23' to float, ValueError"]
-
-    warnings = []
-    ret_val, suc = convert_to_float('.325352', conversion_warnings=warnings)
-    assert suc
-    assert pytest.approx(ret_val) == .325352
-    assert warnings == []
-
-
-def test_convert_to_int():
-    """
-    Test of the convert_to_int function
-    """
-    from masci_tools.util.xml.common_xml_util import convert_to_int
-
-    ret_val, suc = convert_to_int('1241412')
-    assert suc
-    assert ret_val == 1241412
-
-    ret_val, suc = convert_to_int('-9999999999999999999999')
-    assert suc
-    assert ret_val == -9999999999999999999999
-
-    ret_val, suc = convert_to_int('12031')
-    assert suc
-    assert ret_val == 12031
-
-    warnings = []
-    ret_val, suc = convert_to_int((), conversion_warnings=warnings)
-    assert not suc
-    assert ret_val == ()
-    assert warnings == ["Could not convert: '()' to int, TypeError"]
-
-    warnings = []
-    ret_val, suc = convert_to_int('1.231', conversion_warnings=warnings)
-    assert not suc
-    assert ret_val == '1.231'
-    assert warnings == ["Could not convert: '1.231' to int, ValueError"]
-
-    warnings = []
-    ret_val, suc = convert_to_int('213', conversion_warnings=warnings)
-    assert suc
-    assert ret_val == 213
-    assert warnings == []
+LOGGER = logging.getLogger(__name__)
 
 
 def test_convert_from_fortran_bool():
@@ -91,32 +24,16 @@ def test_convert_from_fortran_bool():
     FALSE_ITEMS = ('F', 'f', False)
 
     for true_item in TRUE_ITEMS:
-        ret_val, suc = convert_from_fortran_bool(true_item)
-        assert suc
-        assert ret_val
+        assert convert_from_fortran_bool(true_item)
 
     for false_item in FALSE_ITEMS:
-        ret_val, suc = convert_from_fortran_bool(false_item)
-        assert suc
-        assert not ret_val
+        assert not convert_from_fortran_bool(false_item)
 
-    warnings = []
-    ret_val, suc = convert_from_fortran_bool('TEST', conversion_warnings=warnings)
-    assert not suc
-    assert ret_val == 'TEST'
-    assert warnings == ["Could not convert: 'TEST' to boolean, which is not 'True', 'False', 't', 'T', 'F' or 'f'"]
+    with pytest.raises(ValueError, match="Could not convert: 'TEST' to boolean"):
+        convert_from_fortran_bool('TEST')
 
-    warnings = []
-    ret_val, suc = convert_from_fortran_bool({}, conversion_warnings=warnings)
-    assert not suc
-    assert ret_val == {}
-    assert warnings == ["Could not convert: '{}' to boolean, only accepts str or boolean"]
-
-    warnings = []
-    ret_val, suc = convert_from_fortran_bool(True, conversion_warnings=warnings)
-    assert suc
-    assert ret_val
-    assert warnings == []
+    with pytest.raises(TypeError, match="Could not convert: '{}' to boolean"):
+        convert_from_fortran_bool({})
 
 
 def test_convert_to_fortran_bool():
@@ -129,37 +46,19 @@ def test_convert_to_fortran_bool():
     FALSE_ITEMS = (False, 'False', 'f', 'F')
 
     for item in TRUE_ITEMS:
-        res, suc = convert_to_fortran_bool(item)
-        assert suc
-        assert res == 'T'
+        assert convert_to_fortran_bool(item) == 'T'
 
     for item in FALSE_ITEMS:
-        res, suc = convert_to_fortran_bool(item)
-        assert suc
-        assert res == 'F'
+        assert convert_to_fortran_bool(item) == 'F'
 
-    warnings = []
-    res, suc = convert_to_fortran_bool('True', conversion_warnings=warnings)
-    assert suc
-    assert res == 'T'
-    assert warnings == []
+    with pytest.raises(ValueError, match='A string: NOT_A_BOOL for a boolean was given,'):
+        convert_to_fortran_bool('NOT_A_BOOL')
 
-    warnings = []
-    res, suc = convert_to_fortran_bool('NOT_A_BOOL', conversion_warnings=warnings)
-    assert not suc
-    assert res is None
-    assert warnings == [
-        "A string: NOT_A_BOOL for a boolean was given, which is not 'True','False', 't', 'T', 'F' or 'f'"
-    ]
-
-    warnings = []
-    res, suc = convert_to_fortran_bool((), conversion_warnings=warnings)
-    assert not suc
-    assert res is None
-    assert warnings == ['convert_to_fortran_bool accepts only a string or bool as argument, given () ']
+    with pytest.raises(TypeError, match='convert_to_fortran_bool accepts only a string or bool as argument'):
+        convert_to_fortran_bool(())
 
 
-def test_eval_xpath():
+def test_eval_xpath(caplog):
     """
     Test of the eval_xpath function
     """
@@ -184,24 +83,20 @@ def test_eval_xpath():
     assert len(include_tags) == 2
     assert isinstance(include_tags[0], etree._Element)
 
-    parser_info_out = {'parser_warnings': []}
-    species_z = eval_xpath(root, "//species[@name='Cu-1']/@atomicNumber", parser_info_out=parser_info_out)
+    species_z = eval_xpath(root, "//species[@name='Cu-1']/@atomicNumber")
     assert species_z == '29'
-    assert parser_info_out == {'parser_warnings': []}
 
-    parser_info_out = {'parser_warnings': []}
-    ldau_tags = eval_xpath(root, "//species[@name='Cu-1']/ldaU", parser_info_out=parser_info_out)
+    ldau_tags = eval_xpath(root, "//species[@name='Cu-1']/ldaU")
     assert ldau_tags == []
-    assert parser_info_out == {'parser_warnings': []}
 
-    parser_info_out = {'parser_warnings': []}
-    ldau_tags = eval_xpath(root, "//species/[@name='Cu-1']/ldaU", parser_info_out=parser_info_out)
-    assert ldau_tags == []
-    assert parser_info_out == {
-        'parser_warnings': [
-            "There was a XpathEvalError on the xpath: //species/[@name='Cu-1']/ldaU \n Either it does not exist, or something is wrong with the expression."
-        ]
-    }
+    with pytest.raises(ValueError, match='There was a XpathEvalError on the xpath:'):
+        ldau_tags = eval_xpath(root, "//species/[@name='Cu-1']/ldaU")
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError, match='There was a XpathEvalError on the xpath:'):
+            ldau_tags = eval_xpath(root, "//species/[@name='Cu-1']/ldaU", logger=LOGGER)
+
+    assert 'There was a XpathEvalError on the xpath:' in caplog.text
 
 
 def test_clear_xml():
@@ -249,7 +144,7 @@ def test_clear_xml():
     assert len(symmetry_tags) == 16
 
 
-def test_get_xml_attribute():
+def test_get_xml_attribute(caplog):
     """
     Test of the clear_xml function
     """
@@ -262,44 +157,36 @@ def test_get_xml_attribute():
     scfLoop = eval_xpath(root, '//scfLoop')
     assert get_xml_attribute(scfLoop, 'alpha') == '.05000000'
     assert get_xml_attribute(scfLoop, 'itmax') == '1'
+    assert get_xml_attribute(scfLoop, 'maxIterBroyd') == '99'
 
-    parser_info_out = {'parser_warnings': []}
-    assert get_xml_attribute(scfLoop, 'maxIterBroyd', parser_info_out=parser_info_out) == '99'
-    assert parser_info_out == {'parser_warnings': []}
+    with pytest.raises(ValueError, match='Tried to get attribute: "TEST" from element scfLoop.'):
+        get_xml_attribute(scfLoop, 'TEST')
 
-    parser_info_out = {'parser_warnings': []}
-    assert get_xml_attribute(scfLoop, 'TEST', parser_info_out=parser_info_out) is None
-    assert parser_info_out == {
-        'parser_warnings': [
-            'Tried to get attribute: "TEST" from element scfLoop.\n I recieved "None", maybe the attribute does not exist'
-        ]
-    }
+    with caplog.at_level(logging.WARNING):
+        assert get_xml_attribute(scfLoop, 'TEST', logger=LOGGER) is None
+    assert 'Tried to get attribute: "TEST" from element scfLoop.' in caplog.text
 
-    parser_info_out = {'parser_warnings': []}
-    assert get_xml_attribute(xmltree, 'TEST', parser_info_out=parser_info_out) is None
-    assert parser_info_out == {
-        'parser_warnings': [
-            'Can not get attributename: "TEST" from node of type <class \'lxml.etree._ElementTree\'>, because node is not an element of etree.'
-        ]
-    }
+    with pytest.raises(TypeError,
+                       match='Can not get attributename: "TEST" from node of type <class \'lxml.etree._ElementTree\'>'):
+        get_xml_attribute(xmltree, 'TEST')
+
+    with caplog.at_level(logging.WARNING):
+        assert get_xml_attribute(xmltree, 'TEST', logger=LOGGER) is None
+    assert 'Can not get attributename: "TEST" from node of type <class \'lxml.etree._ElementTree\'>' in caplog.text
 
 
-TEST_STRINGS = ['1.2314', 'all', ['all', '213', '-12'], ['PI', 'NOT_PI', '1.2'], ['F', 'T']]
+TEST_STRINGS = ['1.2314', 'all', ['all', '213', '-12'], ['PI', 'NOT_PI', '1.2'], ['F', 'T'], ['F', 'T']]
 
-TEST_TYPES = [['float'], ['int', 'string'], ['int', 'string'], ['float', 'float_expression'], ['int', 'switch']]
+TEST_TYPES = [['float'], ['int', 'string'], ['int', 'string'], ['float', 'float_expression'], ['int'],
+              ['int', 'switch']]
 
 TEST_RESULTS = [(pytest.approx(1.2314), True), ('all', True), (['all', 213, -12], True),
-                (['PI', 'NOT_PI', pytest.approx(1.2)], False), ([False, True], True)]
+                (['PI', 'NOT_PI', pytest.approx(1.2)], False), (['F', 'T'], False), ([False, True], True)]
 
-TEST_WARNINGS = [
-    [], ["Could not convert: 'all' to int, ValueError"], ["Could not convert: 'all' to int, ValueError"],
-    [
-        "Could not convert: 'PI' to float, ValueError",
-        "Could not evaluate expression 'PI' The following error was raised: Unknown string expression: PI",
-        "Could not convert: 'NOT_PI' to float, ValueError",
-        "Could not evaluate expression 'NOT_PI' The following error was raised: Unknown string expression: NOT"
-    ], ["Could not convert: 'F' to int, ValueError", "Could not convert: 'T' to int, ValueError"]
-]
+TEST_WARNINGS = [[], [], [], [
+    "Could not convert 'PI'",
+    "Could not convert 'NOT_PI'",
+], ["Could not convert 'F'", "Could not convert 'T'"]]
 
 
 @pytest.mark.parametrize('string_attr,types,results', zip(TEST_STRINGS, TEST_TYPES, TEST_RESULTS))
@@ -311,28 +198,36 @@ def test_convert_xml_attribute(string_attr, types, results):
 
     expected_val, expected_suc = results
 
-    ret_val, suc = convert_xml_attribute(string_attr, types, FLEUR_DEFINED_CONSTANTS)
-    assert ret_val == expected_val
-    assert suc == expected_suc
+    if not expected_suc:
+        with pytest.raises(ValueError, match='Could not convert'):
+            ret_val, suc = convert_xml_attribute(string_attr, types, FLEUR_DEFINED_CONSTANTS)
+    else:
+        ret_val, suc = convert_xml_attribute(string_attr, types, FLEUR_DEFINED_CONSTANTS)
+
+        assert ret_val == expected_val
+        assert suc == expected_suc
 
 
 @pytest.mark.parametrize('string_attr,types,results, warnings',
                          zip(TEST_STRINGS, TEST_TYPES, TEST_RESULTS, TEST_WARNINGS))
-def test_convert_xml_attribute_warnings(string_attr, types, results, warnings):
+def test_convert_xml_attribute_warnings(caplog, string_attr, types, results, warnings):
     """
     Test of the convert_xml_attribute function
     """
     from masci_tools.util.xml.common_xml_util import convert_xml_attribute
 
     expected_val, expected_suc = results
-    conversion_warnings = []
-    ret_val, suc = convert_xml_attribute(string_attr,
-                                         types,
-                                         FLEUR_DEFINED_CONSTANTS,
-                                         conversion_warnings=conversion_warnings)
+
+    with caplog.at_level(logging.WARNING):
+        ret_val, suc = convert_xml_attribute(string_attr, types, FLEUR_DEFINED_CONSTANTS, logger=LOGGER)
     assert ret_val == expected_val
     assert suc == expected_suc
-    assert conversion_warnings == warnings
+
+    if len(warnings) == 0:
+        assert caplog.text == ''
+    else:
+        for expected_warning in warnings:
+            assert expected_warning in caplog.text
 
 
 TEST_ATTR_VALUES = [1.2134, 'all', ['all', 213, '-12'], ['3.14', 'NOT_PI', 1.2], [False, 'True']]
@@ -342,15 +237,7 @@ TEST_ATTR_TYPES = [['float'], ['int', 'string'], ['int', 'string'], ['float', 'f
 TEST_ATTR_RESULTS = [('1.2134000000', True), ('all', True), (['all', '213', '-12'], True),
                      (['3.14', 'NOT_PI', '1.2000000000'], True), (['F', 'T'], True)]
 
-TEST_ATTR_WARNINGS = [
-    [], [], [],
-    [
-        "Could not convert to float string '3.14' The following error was raised: Unknown format code 'f' for object of type 'str'",
-        "Could not convert to float string '3.14' The following error was raised: Unknown format code 'f' for object of type 'str'",
-        "Could not convert to float string 'NOT_PI' The following error was raised: Unknown format code 'f' for object of type 'str'",
-        "Could not convert to float string 'NOT_PI' The following error was raised: Unknown format code 'f' for object of type 'str'"
-    ], []
-]
+TEST_ATTR_WARNINGS = [[], [], [], [], []]
 
 
 @pytest.mark.parametrize('attr_value,types,results', zip(TEST_ATTR_VALUES, TEST_ATTR_TYPES, TEST_ATTR_RESULTS))
@@ -361,15 +248,18 @@ def test_convert_attribute_to_xml(attr_value, types, results):
     from masci_tools.util.xml.common_xml_util import convert_attribute_to_xml
 
     expected_val, expected_suc = results
-
-    ret_val, suc = convert_attribute_to_xml(attr_value, types)
-    assert ret_val == expected_val
-    assert suc == expected_suc
+    if not expected_suc:
+        with pytest.raises(ValueError):
+            ret_val, suc = convert_attribute_to_xml(attr_value, types)
+    else:
+        ret_val, suc = convert_attribute_to_xml(attr_value, types)
+        assert ret_val == expected_val
+        assert suc == expected_suc
 
 
 @pytest.mark.parametrize('attr_value,types,results,warnings',
                          zip(TEST_ATTR_VALUES, TEST_ATTR_TYPES, TEST_ATTR_RESULTS, TEST_ATTR_WARNINGS))
-def test_convert_attribute_to_xml_warnings(attr_value, types, results, warnings):
+def test_convert_attribute_to_xml_warnings(caplog, attr_value, types, results, warnings):
     """
     Test of the convert_xml_attribute function
     """
@@ -377,11 +267,16 @@ def test_convert_attribute_to_xml_warnings(attr_value, types, results, warnings)
 
     expected_val, expected_suc = results
 
-    conversion_warnings = []
-    ret_val, suc = convert_attribute_to_xml(attr_value, types, conversion_warnings=conversion_warnings)
+    with caplog.at_level(logging.WARNING):
+        ret_val, suc = convert_attribute_to_xml(attr_value, types, logger=LOGGER)
     assert ret_val == expected_val
     assert suc == expected_suc
-    assert conversion_warnings == warnings
+
+    if len(warnings) == 0:
+        assert caplog.text == ''
+    else:
+        for expected_warning in warnings:
+            assert expected_warning in caplog.text
 
 
 TEST_TEXT_STRINGS = [
@@ -426,18 +321,12 @@ TEST_TEXT_RESULTS = [(pytest.approx([0.0, 0.7853981633974483, 6.3121]), True), (
                                                                                              0.0]], False),
                      ([[False, 'asd'], [True]], True), ([[12, 213, 4215, 412], [12, 213, 4215, 412, 123, 14124]], True)]
 
-TEST_TEXT_WARNINGS = [[], ["Failed to convert '0.0 Pi/4.0 6.3121', no matching definition found "], [],
+TEST_TEXT_WARNINGS = [[], ["Failed to convert '0.0 Pi/4.0 6.3121', no matching definition found"], [],
                       [
-                          "Could not convert: '0.0 Pi/4.0 6.3121' to float, ValueError",
-                          "Could not evaluate expression '0.0 Pi/4.0 6.3121' The following error was "
-                          'raised: Cannot parse number: Found two decimal points'
-                      ],
-                      [
-                          "Could not convert: 'all' to float, ValueError",
-                          "Could not evaluate expression 'all' The following error was raised: Unknown "
-                          'string expression: all', "Could not convert: 'Pi/*4.0' to float, ValueError",
-                          "Could not evaluate expression 'Pi/*4.0' The following error was raised: "
-                          'Invalid Expression: Operator following operator'
+                          "Could not convert '0.0 Pi/4.0 6.3121'",
+                      ], [
+                          "Could not convert 'all'",
+                          "Could not convert 'Pi/*4.0'",
                       ], [], []]
 
 
@@ -451,14 +340,18 @@ def test_convert_xml_text(string_text, definitions, results):
 
     expected_val, expected_suc = results
 
-    ret_val, suc = convert_xml_text(string_text, definitions, FLEUR_DEFINED_CONSTANTS)
-    assert ret_val == expected_val
-    assert suc == expected_suc
+    if not expected_suc:
+        with pytest.raises(ValueError):
+            ret_val, suc = convert_xml_text(string_text, definitions, FLEUR_DEFINED_CONSTANTS)
+    else:
+        ret_val, suc = convert_xml_text(string_text, definitions, FLEUR_DEFINED_CONSTANTS)
+        assert ret_val == expected_val
+        assert suc == expected_suc
 
 
 @pytest.mark.parametrize('string_text,definitions,results,warnings',
                          zip(TEST_TEXT_STRINGS, TEST_DEFINITIONS, TEST_TEXT_RESULTS, TEST_TEXT_WARNINGS))
-def test_convert_xml_text_warnings(string_text, definitions, results, warnings):
+def test_convert_xml_text_warnings(caplog, string_text, definitions, results, warnings):
     """
     Test of the convert_xml_attribute function
     """
@@ -466,15 +359,15 @@ def test_convert_xml_text_warnings(string_text, definitions, results, warnings):
 
     expected_val, expected_suc = results
 
-    conversion_warnings = []
-
-    ret_val, suc = convert_xml_text(string_text,
-                                    definitions,
-                                    FLEUR_DEFINED_CONSTANTS,
-                                    conversion_warnings=conversion_warnings)
+    with caplog.at_level(logging.WARNING):
+        ret_val, suc = convert_xml_text(string_text, definitions, FLEUR_DEFINED_CONSTANTS, logger=LOGGER)
     assert ret_val == expected_val
     assert suc == expected_suc
-    assert conversion_warnings == warnings
+    if len(warnings) == 0:
+        assert caplog.text == ''
+    else:
+        for expected_warning in warnings:
+            assert expected_warning in caplog.text
 
 
 TEST_TEXT_VALUES = [[0.0, 'Pi/4.0', 6.3121], [0.0, 'Pi/4.0', 6.3121], [0.0, 'Pi/4.0', 6.3121], [0.0, 'Pi/4.0', 6.3121],
@@ -487,8 +380,8 @@ TEST_TEXT_XML_STRINGS = [(' 0.0000000000000 Pi/4.0  6.3121000000000', True), (''
                                                                                                     'T'], True),
                          (['12 213 4215 412', '12 213 4215 412 123 14124'], True)]
 
-TEST_TEXT_XML_WARNINGS = [[], ["Failed to convert '[0.0, 'Pi/4.0', 6.3121]', no matching definition found "], [],
-                          ["Failed to convert '[0.0, 'Pi/4.0', 6.3121]', no matching definition found "], [], [], []]
+TEST_TEXT_XML_WARNINGS = [[], ["Failed to convert '[0.0, 'Pi/4.0', 6.3121]', no matching definition found"], [],
+                          ["Failed to convert '[0.0, 'Pi/4.0', 6.3121]', no matching definition found"], [], [], []]
 
 
 @pytest.mark.parametrize('text_value,definitions, results',
@@ -500,15 +393,18 @@ def test_convert_text_to_xml(text_value, definitions, results):
     from masci_tools.util.xml.common_xml_util import convert_text_to_xml
 
     expected_val, expected_suc = results
-
-    ret_val, suc = convert_text_to_xml(text_value, definitions)
-    assert ret_val == expected_val
-    assert suc == expected_suc
+    if not expected_suc:
+        with pytest.raises(ValueError):
+            ret_val, suc = convert_text_to_xml(text_value, definitions)
+    else:
+        ret_val, suc = convert_text_to_xml(text_value, definitions)
+        assert ret_val == expected_val
+        assert suc == expected_suc
 
 
 @pytest.mark.parametrize('text_value,definitions, results, warnings',
                          zip(TEST_TEXT_VALUES, TEST_DEFINITIONS, TEST_TEXT_XML_STRINGS, TEST_TEXT_XML_WARNINGS))
-def test_convert_text_to_xml_warnings(text_value, definitions, results, warnings):
+def test_convert_text_to_xml_warnings(caplog, text_value, definitions, results, warnings):
     """
     Test of the convert_xml_attribute function
     """
@@ -516,11 +412,15 @@ def test_convert_text_to_xml_warnings(text_value, definitions, results, warnings
 
     expected_val, expected_suc = results
 
-    conversion_warnings = []
-    ret_val, suc = convert_text_to_xml(text_value, definitions, conversion_warnings=conversion_warnings)
+    with caplog.at_level(logging.WARNING):
+        ret_val, suc = convert_text_to_xml(text_value, definitions, logger=LOGGER)
     assert ret_val == expected_val
     assert suc == expected_suc
-    assert conversion_warnings == warnings
+    if len(warnings) == 0:
+        assert caplog.text == ''
+    else:
+        for expected_warning in warnings:
+            assert expected_warning in caplog.text
 
 
 def test_split_off_tag():

--- a/masci_tools/tests/test_fleur_inpxml_parser.py
+++ b/masci_tools/tests/test_fleur_inpxml_parser.py
@@ -105,26 +105,26 @@ def test_inpxml_todict(data_regression, inpxmlfilepath):
     data_regression.check(inp_dict)
 
 
-def test_inpxml_todict_warnings(data_regression):
+def test_inpxml_todict_warnings(data_regression, clean_parser_log):
     """
     test if valid inp.xml files are translated to the correct inp_dict
     """
 
     input_invalid_attr = os.path.abspath(os.path.join(inpxmlfilefolder, 'files/fleur/inp_invalid_attributes.xml'))
-    warnings = {'parser_warnings': []}
+    warnings = {}
 
     #The parser shoul not raise and just log all the failed conversions
     inp_dict = inpxml_parser(input_invalid_attr, parser_info_out=warnings)
-    data_regression.check({'input_dict': inp_dict, 'warnings': warnings})
+    data_regression.check({'input_dict': inp_dict, 'warnings': clean_parser_log(warnings)})
 
 
-def test_inpxml_newer_version(data_regression):
+def test_inpxml_newer_version(data_regression, clean_parser_log):
     """
     test if valid inp.xml files with not yet existent versions are parsed correctly (fall back to latest available)
     """
 
     INPXML_FILEPATH = os.path.abspath(os.path.join(inpxmlfilefolder, 'files/fleur/input_newer_version.xml'))
-    warnings = {'parser_warnings': []}
+    warnings = {}
     #The parser shoul not raise and just log all the failed conversions
     inp_dict = inpxml_parser(INPXML_FILEPATH, parser_info_out=warnings)
-    data_regression.check({'input_dict': inp_dict, 'warnings': warnings})
+    data_regression.check({'input_dict': inp_dict, 'warnings': clean_parser_log(warnings)})

--- a/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_newer_version.yml
+++ b/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_newer_version.yml
@@ -276,8 +276,10 @@ input_dict:
       supercellZ: 1
       unfoldBand: false
 warnings:
-  fleur_inp_version: '0.36'
-  parser_info: Masci-Tools Fleur inp.xml Parser v0.2.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur inp.xml Parser v0.3.0
+  - Got Fleur input file with file version 0.36
   parser_warnings:
   - No Input Schema available for version '0.36'; falling back to '0.34'
   - "Input file does not validate against the schema: \nLine 2: Element 'fleurInput',\

--- a/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_todict_warnings.yml
+++ b/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_todict_warnings.yml
@@ -276,20 +276,21 @@ input_dict:
       supercellZ: 1
       unfoldBand: false
 warnings:
-  fleur_inp_version: '0.33'
-  parser_info: Masci-Tools Fleur inp.xml Parser v0.2.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur inp.xml Parser v0.3.0
+  - Got Fleur input file with file version 0.33
   parser_warnings:
-  - 'Failed to convert attribute ''GmaxXC'': Below are the warnings raised from convert_xml_attribute'
-  - 'Could not evaluate expression ''2..041'' The following error was raised: Cannot
-    parse number: Found two decimal points'
-  - 'Failed to convert attribute ''minDistance'': Below are the warnings raised from
-    convert_xml_attribute'
-  - 'Could not evaluate expression ''1e5'' The following error was raised: Unknown
-    string expression: e'
-  - 'Failed to convert text of ''qss'': Below are the warnings raised from convert_xml_text'
-  - 'Could not evaluate expression ''pi*2.0'' The following error was raised: Unknown
-    string expression: pi'
-  - 'Could not evaluate expression ''cos1.0)'' The following error was raised: Invalid
-    expression: Expected Bracket after function name'
-  - 'Could not evaluate expression ''Pi/(3.0-3.0)'' The following error was raised:
-    Undefined Expression: Division by zero'
+  - 'Could not convert ''2..041''. The following errors occurred:'
+  - '   Cannot parse number: Found two decimal points'
+  - 'Failed to convert attribute ''GmaxXC'' Got: ''2..041'''
+  - 'Could not convert ''1e5''. The following errors occurred:'
+  - '   Unknown string expression: e'
+  - 'Failed to convert attribute ''minDistance'' Got: ''1e5'''
+  - 'Could not convert ''pi*2.0''. The following errors occurred:'
+  - '   Unknown string expression: pi'
+  - 'Could not convert ''cos1.0)''. The following errors occurred:'
+  - '   Invalid expression: Expected Bracket after function name'
+  - 'Could not convert ''Pi/(3.0-3.0)''. The following errors occurred:'
+  - '   Undefined Expression: Division by zero'
+  - 'Failed to text of ''qss'' Got: '' pi*2.0 cos1.0) Pi/(3.0-3.0) '''

--- a/masci_tools/tests/test_fleur_outxml_conversions.py
+++ b/masci_tools/tests/test_fleur_outxml_conversions.py
@@ -3,6 +3,9 @@
 Tests for fleur outxml_parser specific conversion functions
 """
 import pytest
+import logging
+
+LOGGER = logging.getLogger(__name__)
 
 TEST_DICTS = [{
     'end_date': {
@@ -81,55 +84,45 @@ TEST_DICTS = [{
 TEST_WALLTIMES = [14, 448, 20446, 86400, 1786884, -60681, 60695, 0]
 
 TEST_WARNINGS = [
-    {
-        'parser_warnings': []
-    },
-    {
-        'parser_warnings': []
-    },
-    {
-        'parser_warnings': []
-    },
-    {
-        'parser_warnings': []
-    },
-    {
-        'parser_warnings': []
-    },
-    {
-        'parser_warnings': [
+    [],
+    [],
+    [],
+    [],
+    [],
+    [
             'Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!',
             'Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!'
         ]
-    },
-    {
-        'parser_warnings': [
+    ,
+    [
             'Starttime was unparsed, inp.xml prob not complete, do not believe the walltime!',
             'Startdate was unparsed, inp.xml prob not complete, do not believe the walltime!'
         ]
-    },
-    {
-        'parser_warnings': [
+    ,
+    [
             'Starttime was unparsed, inp.xml prob not complete, do not believe the walltime!',
             'Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!',
             'Startdate was unparsed, inp.xml prob not complete, do not believe the walltime!',
             'Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!'
         ]
-    },
 ]
 
 
 @pytest.mark.parametrize('input_dict, walltime, warnings', zip(TEST_DICTS, TEST_WALLTIMES, TEST_WARNINGS))
-def test_calculate_walltime(input_dict, walltime, warnings):
+def test_calculate_walltime(caplog, input_dict, walltime, warnings):
     """
    Test of the calculate_walltime function
    """
     from masci_tools.io.parsers.fleur.outxml_conversions import calculate_walltime
 
-    parser_warnings = {'parser_warnings': []}
-    out_dict = calculate_walltime(input_dict, parser_info_out=parser_warnings)
+    with caplog.at_level(logging.WARNING):
+        out_dict = calculate_walltime(input_dict, logger=LOGGER)
 
-    assert out_dict['walltime_units'] == 'seconds'
-    assert out_dict['walltime'] == walltime
-    print(parser_warnings)
-    assert parser_warnings == warnings
+        assert out_dict['walltime_units'] == 'seconds'
+        assert out_dict['walltime'] == walltime
+
+    if len(warnings) == 0:
+        assert caplog.text == ''
+    else:
+        for expected_warning in warnings:
+            assert expected_warning in caplog.text

--- a/masci_tools/tests/test_fleur_outxml_conversions.py
+++ b/masci_tools/tests/test_fleur_outxml_conversions.py
@@ -83,29 +83,21 @@ TEST_DICTS = [{
 
 TEST_WALLTIMES = [14, 448, 20446, 86400, 1786884, -60681, 60695, 0]
 
-TEST_WARNINGS = [
-    [],
-    [],
-    [],
-    [],
-    [],
-    [
-            'Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!',
-            'Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        ]
-    ,
-    [
-            'Starttime was unparsed, inp.xml prob not complete, do not believe the walltime!',
-            'Startdate was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        ]
-    ,
-    [
-            'Starttime was unparsed, inp.xml prob not complete, do not believe the walltime!',
-            'Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!',
-            'Startdate was unparsed, inp.xml prob not complete, do not believe the walltime!',
-            'Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!'
-        ]
-]
+TEST_WARNINGS = [[], [], [], [], [],
+                 [
+                     'Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!',
+                     'Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!'
+                 ],
+                 [
+                     'Starttime was unparsed, inp.xml prob not complete, do not believe the walltime!',
+                     'Startdate was unparsed, inp.xml prob not complete, do not believe the walltime!'
+                 ],
+                 [
+                     'Starttime was unparsed, inp.xml prob not complete, do not believe the walltime!',
+                     'Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!',
+                     'Startdate was unparsed, inp.xml prob not complete, do not believe the walltime!',
+                     'Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!'
+                 ]]
 
 
 @pytest.mark.parametrize('input_dict, walltime, warnings', zip(TEST_DICTS, TEST_WALLTIMES, TEST_WARNINGS))

--- a/masci_tools/tests/test_fleur_outxml_parser.py
+++ b/masci_tools/tests/test_fleur_outxml_parser.py
@@ -39,7 +39,7 @@ def test_outxml_valid_outxml(outxmlfilepath):
     #Parse before
     parser = etree.XMLParser(attribute_defaults=True, encoding='utf-8')
     xmltree = etree.parse(outxmlfilepath, parser)
-    out_dict = outxml_parser(xmltree, strict=True)
+    out_dict = outxml_parser(xmltree)
 
     assert out_dict is not None
     assert isinstance(out_dict, dict)
@@ -47,14 +47,14 @@ def test_outxml_valid_outxml(outxmlfilepath):
 
     #call with contextmanager
     with open(outxmlfilepath, 'r') as outfile:
-        out_dict = outxml_parser(outfile, strict=True)
+        out_dict = outxml_parser(outfile)
 
     assert out_dict is not None
     assert isinstance(out_dict, dict)
     assert out_dict != {}
 
 
-def test_outxml_validation_errors(data_regression):
+def test_outxml_validation_errors(data_regression, clean_parser_log):
     """
     Test the output parser against files for detecting validation
     """
@@ -62,58 +62,58 @@ def test_outxml_validation_errors(data_regression):
     OUTXML_FILEPATH1 = os.path.join(outxmlfilefolder, 'files/fleur/broken_out_xml/simple_validation_error.xml')
 
     with pytest.raises(ValueError, match='Output file does not validate against the schema:'):
-        out_dict = outxml_parser(OUTXML_FILEPATH1, strict=True)
+        out_dict = outxml_parser(OUTXML_FILEPATH1)
 
-    result_warnings = {'parser_warnings': []}
-    out_dict = outxml_parser(OUTXML_FILEPATH1, strict=True, ignore_validation=True, parser_info_out=result_warnings)
+    warnings = {}
+    out_dict = outxml_parser(OUTXML_FILEPATH1, ignore_validation=True, parser_info_out=warnings)
 
-    data_regression.check({'output_dict': out_dict, 'warnings': result_warnings})
+    data_regression.check({'output_dict': out_dict, 'warnings': clean_parser_log(warnings)})
 
 
-def test_outxml_empty_out(data_regression):
+def test_outxml_empty_out(data_regression, clean_parser_log):
     """
     Test the output parser against empty file
     """
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder, 'files/fleur/broken_out_xml/empty_out.xml')
 
-    result_warnings = {'parser_warnings': []}
-    out_dict = outxml_parser(OUTXML_FILEPATH, strict=True, parser_info_out=result_warnings)
+    warnings = {}
+    out_dict = outxml_parser(OUTXML_FILEPATH, parser_info_out=warnings)
 
-    data_regression.check({'output_dict': out_dict, 'warnings': result_warnings})
+    data_regression.check({'output_dict': out_dict, 'warnings': clean_parser_log(warnings)})
 
 
-def test_outxml_broken(data_regression):
+def test_outxml_broken(data_regression, clean_parser_log):
     """
     Test the output parser against a file which terminates after some iterations
     """
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder, 'files/fleur/broken_out_xml/terminated.xml')
 
-    result_warnings = {'parser_warnings': []}
-    out_dict = outxml_parser(OUTXML_FILEPATH, strict=True, parser_info_out=result_warnings)
+    warnings = {}
+    out_dict = outxml_parser(OUTXML_FILEPATH, parser_info_out=warnings)
 
     data_regression.check({
         'output_dict': out_dict,
-        'warnings': result_warnings,
+        'warnings': clean_parser_log(warnings),
     })
 
 
-def test_outxml_broken_firstiter(data_regression):
+def test_outxml_broken_firstiter(data_regression, clean_parser_log):
     """
     Test the output parser against a file which terminates in the first iteration
     """
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder, 'files/fleur/broken_out_xml/terminated_firstit.xml')
-    result_warnings = {'parser_warnings': []}
-    out_dict = outxml_parser(OUTXML_FILEPATH, strict=True, parser_info_out=result_warnings)
+    warnings = {}
+    out_dict = outxml_parser(OUTXML_FILEPATH, parser_info_out=warnings)
 
     data_regression.check({
         'output_dict': out_dict,
-        'warnings': result_warnings,
+        'warnings': clean_parser_log(warnings),
     })
 
 
-def test_outxml_garbage_values(data_regression):
+def test_outxml_garbage_values(data_regression, clean_parser_log):
     """
     Test the behaviour of the ouput parser when encountering NaN, Inf or fortran formatting errors ****
     """
@@ -122,14 +122,14 @@ def test_outxml_garbage_values(data_regression):
     def isNaN(num):
         return math.isnan(num)  #num != num
 
-    result_warnings = {'parser_warnings': []}
-    out_dict = outxml_parser(OUTXML_FILEPATH, strict=True, ignore_validation=True, parser_info_out=result_warnings)
+    warnings = {}
+    out_dict = outxml_parser(OUTXML_FILEPATH, ignore_validation=True, parser_info_out=warnings)
 
     assert isNaN(out_dict['fermi_energy'])
     assert out_dict['magnetic_moments'] == '********'
     assert out_dict['total_charge'] == float('Inf')
 
-    data_regression.check({'warnings': result_warnings})
+    data_regression.check({'warnings': clean_parser_log(warnings)})
 
 
 def test_outxml_incompatible_versions():
@@ -140,12 +140,12 @@ def test_outxml_incompatible_versions():
     #output version does not exist
     OUTXML_FILEPATH1 = os.path.join(outxmlfilefolder, 'files/fleur/broken_out_xml/non_existing_version.xml')
     with pytest.raises(FileNotFoundError, match='No FleurOutputSchema.xsd found'):
-        out_dict = outxml_parser(OUTXML_FILEPATH1, strict=True)
+        out_dict = outxml_parser(OUTXML_FILEPATH1)
 
     #version string 0.27 and programVersion='fleur 27' not supported
     OUTXML_FILEPATH1 = os.path.join(outxmlfilefolder, 'files/fleur/broken_out_xml/non_supported_version.xml')
     with pytest.raises(ValueError, match="Unknown fleur version: File-version '0.27' Program-version 'fleur 20'"):
-        out_dict = outxml_parser(OUTXML_FILEPATH1, strict=True)
+        out_dict = outxml_parser(OUTXML_FILEPATH1)
 
 
 def test_outxml_invalid_iteration():
@@ -156,11 +156,11 @@ def test_outxml_invalid_iteration():
     #output version does not exist (InputSchema is loaded first so this is the raised error)
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder_valid[0], 'SiLOXML/files/out.xml')
     with pytest.raises(ValueError, match=r"Valid values are: 'first', 'last', 'all', or int"):
-        out_dict = outxml_parser(OUTXML_FILEPATH, strict=True, iteration_to_parse=('Test', 3))
+        out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse=('Test', 3))
         pprint(out_dict)
 
     with pytest.raises(ValueError, match=r"Got '999'; but only '6' iterations are available"):
-        out_dict = outxml_parser(OUTXML_FILEPATH, strict=True, iteration_to_parse=999)
+        out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse=999)
 
 
 def test_outxml_additional_tasks_simple(data_regression):
@@ -301,94 +301,94 @@ def test_outxml_add_tasks_append(data_regression):
     })
 
 
-def test_outxml_pre_max3_1compatibility(data_regression):
+def test_outxml_pre_max3_1compatibility(data_regression, clean_parser_log):
     """
     Test if older than Max3.1 output files are processed correctly (and a warning should be shown for this case)
     """
 
     OUTXML_FILEPATH = os.path.abspath(os.path.join(outxmlfilefolder, 'files/fleur/old_versions/Max3_0_test_out.xml'))
 
-    warnings = {'parser_warnings': []}
+    warnings = {}
     with pytest.warns(UserWarning):
         out_dict = outxml_parser(OUTXML_FILEPATH, parser_info_out=warnings, iteration_to_parse='all')
     data_regression.check({
         'output_dict': out_dict,
-        'warnings': warnings,
+        'warnings': clean_parser_log(warnings),
     })
 
 
-def test_outxml_max3_1compatibility(data_regression):
+def test_outxml_max3_1compatibility(data_regression, clean_parser_log):
     """
     Test if Max3.1 output files are processed correctly
     """
 
     OUTXML_FILEPATH = os.path.abspath(os.path.join(outxmlfilefolder, 'files/fleur/old_versions/Max3_1_test_out.xml'))
 
-    warnings = {'parser_warnings': []}
+    warnings = {}
     out_dict = outxml_parser(OUTXML_FILEPATH, parser_info_out=warnings, iteration_to_parse='all')
     data_regression.check({
         'output_dict': out_dict,
-        'warnings': warnings,
+        'warnings': clean_parser_log(warnings),
     })
 
 
-def test_outxml_max4compatibility(data_regression):
+def test_outxml_max4compatibility(data_regression, clean_parser_log):
     """
     Test if Max4 output files are processed correctly
     """
 
     OUTXML_FILEPATH = os.path.abspath(os.path.join(outxmlfilefolder, 'files/fleur/old_versions/Max4_test_out.xml'))
 
-    warnings = {'parser_warnings': []}
+    warnings = {}
     out_dict = outxml_parser(OUTXML_FILEPATH, parser_info_out=warnings, iteration_to_parse='all')
     data_regression.check({
         'output_dict': out_dict,
-        'warnings': warnings,
+        'warnings': clean_parser_log(warnings),
     })
 
 
-def test_outxml_max5_0_compatibility(data_regression):
+def test_outxml_max5_0_compatibility(data_regression, clean_parser_log):
     """
     Test if Max5.0 output files are processed correctly
     """
 
     OUTXML_FILEPATH = os.path.abspath(os.path.join(outxmlfilefolder, 'files/fleur/old_versions/Max5_0_test_out.xml'))
 
-    warnings = {'parser_warnings': []}
+    warnings = {}
     out_dict = outxml_parser(OUTXML_FILEPATH, parser_info_out=warnings, iteration_to_parse='all')
     data_regression.check({
         'output_dict': out_dict,
-        'warnings': warnings,
+        'warnings': clean_parser_log(warnings),
     })
 
 
-def test_outxml_differing_versions(data_regression):
+def test_outxml_differing_versions(data_regression, clean_parser_log):
     """
     Test if files with different input/output versions are parsed correctly
     """
     OUTXML_FILEPATH = os.path.abspath(os.path.join(outxmlfilefolder, 'files/fleur/output_mixed_versions.xml'))
 
-    warnings = {'parser_warnings': []}
+    warnings = {}
     out_dict = outxml_parser(OUTXML_FILEPATH, parser_info_out=warnings)
 
     data_regression.check({
         'output_dict': out_dict,
-        'warnings': warnings,
+        'warnings': clean_parser_log(warnings),
     })
 
 
-def test_outxml_newer_version(data_regression):
+def test_outxml_newer_version(data_regression, clean_parser_log):
     """
     Test if files with not yet existent versions are parsed correctly (fallback to last available)
     """
     OUTXML_FILEPATH = os.path.abspath(os.path.join(outxmlfilefolder, 'files/fleur/output_newer_version.xml'))
 
-    warnings = {'parser_warnings': []}
+    warnings = {}
     out_dict = outxml_parser(OUTXML_FILEPATH, parser_info_out=warnings)
 
     data_regression.check({
         'output_dict': out_dict,
-        'warnings': warnings,
+        'warnings': clean_parser_log(warnings),
     })
 
 
@@ -399,7 +399,7 @@ def test_outxml_lastiter(data_regression):
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder_valid[0], 'SiLOXML/files/out.xml')
 
-    out_dict = outxml_parser(OUTXML_FILEPATH, strict=True)
+    out_dict = outxml_parser(OUTXML_FILEPATH)
     data_regression.check({
         'output_dict': out_dict,
     })
@@ -412,7 +412,7 @@ def test_outxml_firstiter(data_regression):
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder_valid[0], 'SiLOXML/files/out.xml')
 
-    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='first', strict=True)
+    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='first')
     data_regression.check({
         'output_dict': out_dict,
     })
@@ -425,7 +425,7 @@ def test_outxml_alliter(data_regression):
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder_valid[0], 'SiLOXML/files/out.xml')
 
-    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all', strict=True)
+    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all')
     data_regression.check({
         'output_dict': out_dict,
     })
@@ -438,7 +438,7 @@ def test_outxml_indexiter(data_regression):
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder_valid[0], 'SiLOXML/files/out.xml')
 
-    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse=3, strict=True)
+    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse=3)
     data_regression.check({
         'output_dict': out_dict,
     })
@@ -451,7 +451,7 @@ def test_outxml_minimal_mode(data_regression):
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder_valid[0], 'SiLOXML/files/out.xml')
 
-    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all', minimal_mode=True, strict=True)
+    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all', minimal_mode=True)
     data_regression.check({
         'output_dict': out_dict,
     })
@@ -464,7 +464,7 @@ def test_outxml_magnetic(data_regression):
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder_valid[0], 'Fe_bct_LOXML/files/out.xml')
 
-    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all', strict=True)
+    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all')
     data_regression.check({
         'output_dict': out_dict,
     })
@@ -477,7 +477,7 @@ def test_outxml_ldaurelax(data_regression):
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder_valid[0], 'GaAsMultiUForceXML/files/out.xml')
 
-    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all', strict=True)
+    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all')
     data_regression.check({
         'output_dict': out_dict,
     })
@@ -490,7 +490,7 @@ def test_outxml_force(data_regression):
 
     OUTXML_FILEPATH = os.path.join(outxmlfilefolder_valid[0], 'FePt_film_SSFT_LO/files/out.xml')
 
-    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all', strict=True)
+    out_dict = outxml_parser(OUTXML_FILEPATH, iteration_to_parse='all')
 
     data_regression.check({
         'output_dict': out_dict,

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken.yml
@@ -61,18 +61,14 @@ output_dict:
   walltime: -60787
   walltime_units: seconds
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: hist
-    dos: false
-    film: false
-    jspin: 2
-    ldau: false
-    noco: true
-    relax: false
-    soc: false
-  last_iteration_parsed: 2
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
+  - 'Found fleur out file with the versions out: 0.34; inp: 0.34'
+  - 'The following Fleur modes were found: {''jspin'': 2, ''relax'': False, ''ldau'':
+    False, ''soc'': False, ''noco'': True, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''hist''}'
+  - The last parsed iteration is 2
   parser_warnings:
   - The out.xml file is broken I try to repair it.
   - No values found for attribute date at tag endDateAndTime

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken_firstiter.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken_firstiter.yml
@@ -60,37 +60,47 @@ warnings:
   - No values found for attribute time at tag endDateAndTime
   - Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!
   - Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!
-  - No values found for attribute units at tag totalEnergy
-  - No values found for attribute value at tag totalEnergy
-  - 'Failed to evaluate singleValue from tag totalEnergy: Has no ''value'' attribute'
-  - 'Failed to evaluate singleValue from tag totalEnergy: Has no ''units'' attribute'
-  - convert_total_energy cannot convert None to eV
-  - No values found for attribute distance
-  - No values found for attribute units
-  - No values found for attribute distance
-  - No values found for attribute distance
-  - No values found for attribute value at tag sumOfEigenvalues
-  - 'Failed to evaluate singleValue from tag sumOfEigenvalues: Has no ''value'' attribute'
-  - No values found for attribute value at tag coreElectrons
-  - 'Failed to evaluate singleValue from tag coreElectrons: Has no ''value'' attribute'
-  - No values found for attribute value at tag valenceElectrons
-  - 'Failed to evaluate singleValue from tag valenceElectrons: Has no ''value'' attribute'
-  - No values found for attribute value at tag chargeDenXCDenIntegral
-  - 'Failed to evaluate singleValue from tag chargeDenXCDenIntegral: Has no ''value''
+  - '[Iteration 1] No values found for attribute units at tag totalEnergy'
+  - '[Iteration 1] No values found for attribute value at tag totalEnergy'
+  - '[Iteration 1] Failed to evaluate singleValue from tag totalEnergy: Has no ''value''
     attribute'
-  - No values found for attribute units at tag FermiEnergy
-  - No values found for attribute value at tag FermiEnergy
-  - 'Failed to evaluate singleValue from tag FermiEnergy: Has no ''value'' attribute'
-  - 'Failed to evaluate singleValue from tag FermiEnergy: Has no ''units'' attribute'
-  - No values found for attribute units at tag bandgap
-  - No values found for attribute value at tag bandgap
-  - 'Failed to evaluate singleValue from tag bandgap: Has no ''value'' attribute'
-  - 'Failed to evaluate singleValue from tag bandgap: Has no ''units'' attribute'
-  - No values found for attribute moment at tag magneticMoment
-  - No values found for attribute spinDownCharge at tag magneticMoment
-  - No values found for attribute spinUpCharge at tag magneticMoment
-  - No values found for attribute interstitial at tag spinDependentCharge
-  - No values found for attribute mtSpheres at tag spinDependentCharge
-  - No values found for attribute total at tag spinDependentCharge
-  - No values found for attribute value at tag totalCharge
-  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'
+  - '[Iteration 1] Failed to evaluate singleValue from tag totalEnergy: Has no ''units''
+    attribute'
+  - '[Iteration 1] convert_total_energy cannot convert None to eV'
+  - '[Iteration 1] No values found for attribute distance'
+  - '[Iteration 1] No values found for attribute units'
+  - '[Iteration 1] No values found for attribute distance'
+  - '[Iteration 1] No values found for attribute distance'
+  - '[Iteration 1] No values found for attribute value at tag sumOfEigenvalues'
+  - '[Iteration 1] Failed to evaluate singleValue from tag sumOfEigenvalues: Has no
+    ''value'' attribute'
+  - '[Iteration 1] No values found for attribute value at tag coreElectrons'
+  - '[Iteration 1] Failed to evaluate singleValue from tag coreElectrons: Has no ''value''
+    attribute'
+  - '[Iteration 1] No values found for attribute value at tag valenceElectrons'
+  - '[Iteration 1] Failed to evaluate singleValue from tag valenceElectrons: Has no
+    ''value'' attribute'
+  - '[Iteration 1] No values found for attribute value at tag chargeDenXCDenIntegral'
+  - '[Iteration 1] Failed to evaluate singleValue from tag chargeDenXCDenIntegral:
+    Has no ''value'' attribute'
+  - '[Iteration 1] No values found for attribute units at tag FermiEnergy'
+  - '[Iteration 1] No values found for attribute value at tag FermiEnergy'
+  - '[Iteration 1] Failed to evaluate singleValue from tag FermiEnergy: Has no ''value''
+    attribute'
+  - '[Iteration 1] Failed to evaluate singleValue from tag FermiEnergy: Has no ''units''
+    attribute'
+  - '[Iteration 1] No values found for attribute units at tag bandgap'
+  - '[Iteration 1] No values found for attribute value at tag bandgap'
+  - '[Iteration 1] Failed to evaluate singleValue from tag bandgap: Has no ''value''
+    attribute'
+  - '[Iteration 1] Failed to evaluate singleValue from tag bandgap: Has no ''units''
+    attribute'
+  - '[Iteration 1] No values found for attribute moment at tag magneticMoment'
+  - '[Iteration 1] No values found for attribute spinDownCharge at tag magneticMoment'
+  - '[Iteration 1] No values found for attribute spinUpCharge at tag magneticMoment'
+  - '[Iteration 1] No values found for attribute interstitial at tag spinDependentCharge'
+  - '[Iteration 1] No values found for attribute mtSpheres at tag spinDependentCharge'
+  - '[Iteration 1] No values found for attribute total at tag spinDependentCharge'
+  - '[Iteration 1] No values found for attribute value at tag totalCharge'
+  - '[Iteration 1] Failed to evaluate singleValue from tag totalCharge: Has no ''value''
+    attribute'

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken_firstiter.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken_firstiter.yml
@@ -46,18 +46,14 @@ output_dict:
   walltime: -60787
   walltime_units: seconds
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: hist
-    dos: false
-    film: false
-    jspin: 2
-    ldau: false
-    noco: true
-    relax: false
-    soc: false
-  last_iteration_parsed: 1
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
+  - 'Found fleur out file with the versions out: 0.34; inp: 0.34'
+  - 'The following Fleur modes were found: {''jspin'': 2, ''relax'': False, ''ldau'':
+    False, ''soc'': False, ''noco'': True, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''hist''}'
+  - The last parsed iteration is 1
   parser_warnings:
   - The out.xml file is broken I try to repair it.
   - No values found for attribute date at tag endDateAndTime
@@ -66,18 +62,30 @@ warnings:
   - Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!
   - No values found for attribute units at tag totalEnergy
   - No values found for attribute value at tag totalEnergy
+  - 'Failed to evaluate singleValue from tag totalEnergy: Has no ''value'' attribute'
+  - 'Failed to evaluate singleValue from tag totalEnergy: Has no ''units'' attribute'
+  - convert_total_energy cannot convert None to eV
   - No values found for attribute distance
   - No values found for attribute units
   - No values found for attribute distance
   - No values found for attribute distance
   - No values found for attribute value at tag sumOfEigenvalues
+  - 'Failed to evaluate singleValue from tag sumOfEigenvalues: Has no ''value'' attribute'
   - No values found for attribute value at tag coreElectrons
+  - 'Failed to evaluate singleValue from tag coreElectrons: Has no ''value'' attribute'
   - No values found for attribute value at tag valenceElectrons
+  - 'Failed to evaluate singleValue from tag valenceElectrons: Has no ''value'' attribute'
   - No values found for attribute value at tag chargeDenXCDenIntegral
+  - 'Failed to evaluate singleValue from tag chargeDenXCDenIntegral: Has no ''value''
+    attribute'
   - No values found for attribute units at tag FermiEnergy
   - No values found for attribute value at tag FermiEnergy
+  - 'Failed to evaluate singleValue from tag FermiEnergy: Has no ''value'' attribute'
+  - 'Failed to evaluate singleValue from tag FermiEnergy: Has no ''units'' attribute'
   - No values found for attribute units at tag bandgap
   - No values found for attribute value at tag bandgap
+  - 'Failed to evaluate singleValue from tag bandgap: Has no ''value'' attribute'
+  - 'Failed to evaluate singleValue from tag bandgap: Has no ''units'' attribute'
   - No values found for attribute moment at tag magneticMoment
   - No values found for attribute spinDownCharge at tag magneticMoment
   - No values found for attribute spinUpCharge at tag magneticMoment
@@ -85,3 +93,4 @@ warnings:
   - No values found for attribute mtSpheres at tag spinDependentCharge
   - No values found for attribute total at tag spinDependentCharge
   - No values found for attribute value at tag totalCharge
+  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_differing_versions.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_differing_versions.yml
@@ -70,16 +70,12 @@ output_dict:
   walltime: 5
   walltime_units: seconds
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: hist
-    dos: false
-    film: false
-    jspin: 2
-    ldau: false
-    noco: true
-    relax: false
-    soc: true
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
-  parser_warnings:
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
   - 'Creating OutputSchemaDict object for differing versions (out: 0.34; inp: 0.33)'
+  - 'Found fleur out file with the versions out: 0.34; inp: 0.33'
+  - 'The following Fleur modes were found: {''jspin'': 2, ''relax'': False, ''ldau'':
+    False, ''soc'': True, ''noco'': True, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''hist''}'
+  parser_warnings: []

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_empty_out.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_empty_out.yml
@@ -1,6 +1,8 @@
 output_dict: {}
 warnings:
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors:
+  - Skipping the parsing of the xml file. Repairing was not possible.
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
   parser_warnings:
   - The out.xml file is broken I try to repair it.
-  - Skipping the parsing of the xml file. Repairing was not possible.

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_garbage_values.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_garbage_values.yml
@@ -1,19 +1,16 @@
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: tetra
-    dos: false
-    film: false
-    jspin: 2
-    ldau: false
-    noco: false
-    relax: false
-    soc: false
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
+  - 'Found fleur out file with the versions out: 0.34; inp: 0.34'
+  - 'The following Fleur modes were found: {''jspin'': 2, ''relax'': False, ''ldau'':
+    False, ''soc'': False, ''noco'': False, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''tetra''}'
   parser_warnings:
   - "Output file does not validate against the schema: \nLine 591: Element 'FermiEnergy',\
     \ attribute 'value': 'NAN' is not a valid value of the atomic type 'xs:double'.\
     \ \nLine 624: Element 'magneticMoment', attribute 'moment': '********' is not\
     \ a valid value of the atomic type 'xs:double'. \n"
-  - 'Failed to evaluate attribute moment: Below are the warnings from convert_xml_attribute'
-  - 'Could not convert: ''********'' to float, ValueError'
+  - 'Could not convert ''********''. The following errors occurred:'
+  - '   could not convert string to float: ''********'''
+  - 'Failed to evaluate attribute moment, Got value: ********'

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_garbage_values.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_garbage_values.yml
@@ -11,6 +11,6 @@ warnings:
     \ attribute 'value': 'NAN' is not a valid value of the atomic type 'xs:double'.\
     \ \nLine 624: Element 'magneticMoment', attribute 'moment': '********' is not\
     \ a valid value of the atomic type 'xs:double'. \n"
-  - 'Could not convert ''********''. The following errors occurred:'
-  - '   could not convert string to float: ''********'''
-  - 'Failed to evaluate attribute moment, Got value: [''********'']'
+  - '[Iteration 1] Could not convert ''********''. The following errors occurred:'
+  - '[Iteration 1]    could not convert string to float: ''********'''
+  - '[Iteration 1] Failed to evaluate attribute moment, Got value: [''********'']'

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_garbage_values.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_garbage_values.yml
@@ -13,4 +13,4 @@ warnings:
     \ a valid value of the atomic type 'xs:double'. \n"
   - 'Could not convert ''********''. The following errors occurred:'
   - '   could not convert string to float: ''********'''
-  - 'Failed to evaluate attribute moment, Got value: ********'
+  - 'Failed to evaluate attribute moment, Got value: [''********'']'

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max3_1compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max3_1compatibility.yml
@@ -690,17 +690,13 @@ output_dict:
   walltime: 8
   walltime_units: seconds
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: hist
-    dos: false
-    film: false
-    jspin: 2
-    ldau: false
-    noco: true
-    relax: false
-    soc: true
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
+  - 'Found fleur out file with the versions out: 0.30; inp: 0.30'
+  - 'The following Fleur modes were found: {''jspin'': 2, ''relax'': False, ''ldau'':
+    False, ''soc'': True, ''noco'': True, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''hist''}'
   parser_warnings:
   - Ignoring '0.27' outputVersion for MaX3.1 release
   - "Output file does not validate against the schema: \nLine 16: Element 'inputData':\

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max4compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max4compatibility.yml
@@ -233,17 +233,13 @@ output_dict:
   walltime: 6
   walltime_units: seconds
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: hist
-    dos: false
-    film: false
-    jspin: 1
-    ldau: true
-    noco: false
-    relax: false
-    soc: false
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
+  - 'Found fleur out file with the versions out: 0.31; inp: 0.31'
+  - 'The following Fleur modes were found: {''jspin'': 1, ''relax'': False, ''ldau'':
+    True, ''soc'': False, ''noco'': False, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''hist''}'
   parser_warnings:
   - Ignoring '0.27' outputVersion for MaX4.0 release
   - "Output file does not validate against the schema: \nLine 17: Element 'inputData':\

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max5_0_compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max5_0_compatibility.yml
@@ -246,17 +246,13 @@ output_dict:
   walltime: 4
   walltime_units: seconds
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: hist
-    dos: false
-    film: false
-    jspin: 1
-    ldau: true
-    noco: false
-    relax: false
-    soc: false
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
+  - 'Found fleur out file with the versions out: 0.33; inp: 0.33'
+  - 'The following Fleur modes were found: {''jspin'': 1, ''relax'': False, ''ldau'':
+    True, ''soc'': False, ''noco'': False, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''hist''}'
   parser_warnings:
   - Ignoring '0.27' outputVersion for MaX5.0 release
   - "Output file does not validate against the schema: \nLine 131: Element 'kPointList',\

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_newer_version.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_newer_version.yml
@@ -61,17 +61,13 @@ output_dict:
   walltime: 2
   walltime_units: seconds
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: hist
-    dos: false
-    film: false
-    jspin: 2
-    ldau: false
-    noco: true
-    relax: false
-    soc: false
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
+  - 'Found fleur out file with the versions out: 0.34; inp: 0.34'
+  - 'The following Fleur modes were found: {''jspin'': 2, ''relax'': False, ''ldau'':
+    False, ''soc'': False, ''noco'': True, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''hist''}'
   parser_warnings:
   - No Output Schema available for version '0.36'; falling back to '0.34'
   - No Input Schema available for version '0.36'; falling back to '0.34'

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_pre_max3_1compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_pre_max3_1compatibility.yml
@@ -134,17 +134,13 @@ output_dict:
   walltime: 3
   walltime_units: seconds
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: hist
-    dos: false
-    film: false
-    jspin: 2
-    ldau: false
-    noco: true
-    relax: false
-    soc: false
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
+  - 'Found fleur out file with the versions out: 0.29; inp: 0.29'
+  - 'The following Fleur modes were found: {''jspin'': 2, ''relax'': False, ''ldau'':
+    False, ''soc'': False, ''noco'': True, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''hist''}'
   parser_warnings:
   - Found version before MaX3.1 release falling back to file version '0.29'
   - "Output file does not validate against the schema: \nLine 14: Element 'inputData':\
@@ -159,15 +155,19 @@ warnings:
   - No values found for attribute mtSpheres at tag spinDependentCharge
   - No values found for attribute total at tag spinDependentCharge
   - No values found for attribute value at tag totalCharge
+  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'
   - No values found for attribute interstitial at tag spinDependentCharge
   - No values found for attribute mtSpheres at tag spinDependentCharge
   - No values found for attribute total at tag spinDependentCharge
   - No values found for attribute value at tag totalCharge
+  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'
   - No values found for attribute interstitial at tag spinDependentCharge
   - No values found for attribute mtSpheres at tag spinDependentCharge
   - No values found for attribute total at tag spinDependentCharge
   - No values found for attribute value at tag totalCharge
+  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'
   - No values found for attribute interstitial at tag spinDependentCharge
   - No values found for attribute mtSpheres at tag spinDependentCharge
   - No values found for attribute total at tag spinDependentCharge
   - No values found for attribute value at tag totalCharge
+  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_pre_max3_1compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_pre_max3_1compatibility.yml
@@ -151,23 +151,27 @@ warnings:
     \ Expected is ( volumes ). \nLine 73: Element 'atomsInCell': The attribute 'n_hia'\
     \ is required but missing. \n"
   - No values found for attribute count
-  - No values found for attribute interstitial at tag spinDependentCharge
-  - No values found for attribute mtSpheres at tag spinDependentCharge
-  - No values found for attribute total at tag spinDependentCharge
-  - No values found for attribute value at tag totalCharge
-  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'
-  - No values found for attribute interstitial at tag spinDependentCharge
-  - No values found for attribute mtSpheres at tag spinDependentCharge
-  - No values found for attribute total at tag spinDependentCharge
-  - No values found for attribute value at tag totalCharge
-  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'
-  - No values found for attribute interstitial at tag spinDependentCharge
-  - No values found for attribute mtSpheres at tag spinDependentCharge
-  - No values found for attribute total at tag spinDependentCharge
-  - No values found for attribute value at tag totalCharge
-  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'
-  - No values found for attribute interstitial at tag spinDependentCharge
-  - No values found for attribute mtSpheres at tag spinDependentCharge
-  - No values found for attribute total at tag spinDependentCharge
-  - No values found for attribute value at tag totalCharge
-  - 'Failed to evaluate singleValue from tag totalCharge: Has no ''value'' attribute'
+  - '[Iteration 1] No values found for attribute interstitial at tag spinDependentCharge'
+  - '[Iteration 1] No values found for attribute mtSpheres at tag spinDependentCharge'
+  - '[Iteration 1] No values found for attribute total at tag spinDependentCharge'
+  - '[Iteration 1] No values found for attribute value at tag totalCharge'
+  - '[Iteration 1] Failed to evaluate singleValue from tag totalCharge: Has no ''value''
+    attribute'
+  - '[Iteration 2] No values found for attribute interstitial at tag spinDependentCharge'
+  - '[Iteration 2] No values found for attribute mtSpheres at tag spinDependentCharge'
+  - '[Iteration 2] No values found for attribute total at tag spinDependentCharge'
+  - '[Iteration 2] No values found for attribute value at tag totalCharge'
+  - '[Iteration 2] Failed to evaluate singleValue from tag totalCharge: Has no ''value''
+    attribute'
+  - '[Iteration 3] No values found for attribute interstitial at tag spinDependentCharge'
+  - '[Iteration 3] No values found for attribute mtSpheres at tag spinDependentCharge'
+  - '[Iteration 3] No values found for attribute total at tag spinDependentCharge'
+  - '[Iteration 3] No values found for attribute value at tag totalCharge'
+  - '[Iteration 3] Failed to evaluate singleValue from tag totalCharge: Has no ''value''
+    attribute'
+  - '[Iteration 4] No values found for attribute interstitial at tag spinDependentCharge'
+  - '[Iteration 4] No values found for attribute mtSpheres at tag spinDependentCharge'
+  - '[Iteration 4] No values found for attribute total at tag spinDependentCharge'
+  - '[Iteration 4] No values found for attribute value at tag totalCharge'
+  - '[Iteration 4] Failed to evaluate singleValue from tag totalCharge: Has no ''value''
+    attribute'

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_validation_errors.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_validation_errors.yml
@@ -53,17 +53,13 @@ output_dict:
   walltime: 1
   walltime_units: seconds
 warnings:
-  fleur_modes:
-    band: false
-    bz_integration: tetra
-    dos: false
-    film: false
-    jspin: 2
-    ldau: false
-    noco: false
-    relax: false
-    soc: false
-  parser_info: Masci-Tools Fleur out.xml Parser v0.4.0
+  parser_errors: []
+  parser_info:
+  - Masci-Tools Fleur out.xml Parser v0.5.0
+  - 'Found fleur out file with the versions out: 0.34; inp: 0.34'
+  - 'The following Fleur modes were found: {''jspin'': 2, ''relax'': False, ''ldau'':
+    False, ''soc'': False, ''noco'': False, ''film'': False, ''dos'': False, ''band'':
+    False, ''bz_integration'': ''tetra''}'
   parser_warnings:
   - "Output file does not validate against the schema: \nLine 346: Element 'kPointList',\
     \ attribute 'weightSc': The attribute 'weightSc' is not allowed. \nLine 346: Element\

--- a/masci_tools/tests/test_xml_setters_xpaths.py
+++ b/masci_tools/tests/test_xml_setters_xpaths.py
@@ -152,8 +152,11 @@ def test_eval_xpath_create_differing_xpaths(load_inpxml):
 
     assert len(eval_xpath(root, '/fleurInput/atomSpecies/species/ldaU')) == 0
 
-    nodes = eval_xpath_create(xmltree, schema_dict, "/fleurInput/atomSpecies/species[@name='Fe-1']/ldaU",
-                              '/fleurInput/atomSpecies/species/ldaU')
+    nodes = eval_xpath_create(xmltree,
+                              schema_dict,
+                              "/fleurInput/atomSpecies/species[@name='Fe-1']/ldaU",
+                              '/fleurInput/atomSpecies/species/ldaU',
+                              list_return=True)
 
     assert len(nodes) == 1
     assert [node.getparent().attrib['name'] for node in nodes] == ['Fe-1']
@@ -173,7 +176,8 @@ def test_eval_xpath_create_create_parents(load_inpxml):
                               schema_dict,
                               "/fleurInput/atomSpecies/species[@name='Fe-1']/ldaHIA/addArg",
                               '/fleurInput/atomSpecies/species/ldaHIA/addArg',
-                              create_parents=True)
+                              create_parents=True,
+                              list_return=True)
 
     assert len(nodes) == 1
 

--- a/masci_tools/util/fleur_calculate_expression.py
+++ b/masci_tools/util/fleur_calculate_expression.py
@@ -54,6 +54,13 @@ def calculate_expression(expression, constants, prevCommand=None, exp_return=Fal
 
     stop_loop = False
     loop_count = 0
+
+    if expression is None:
+        raise ValueError('Invalid expression: Got None for expression')
+
+    if isinstance(expression, (float, int)):
+        return expression
+
     expression = expression.replace(' ', '')
     value = None
     while not stop_loop and len(expression) != 0:

--- a/masci_tools/util/logging_util.py
+++ b/masci_tools/util/logging_util.py
@@ -24,7 +24,7 @@ class DictHandler(Handler):
     Keyword arguments can be used to modify the keys for the different levels
     """
 
-    def __init__(self, log_dict, **kwargs):
+    def __init__(self, log_dict, ignore_unknown_levels=False, **kwargs):
         from logging import _levelToName
         import copy
 
@@ -33,7 +33,12 @@ class DictHandler(Handler):
         levels = copy.copy(list(_levelToName.values()))
         levels.remove('NOTSET')
 
-        self.level_names = {name: name if name not in kwargs else kwargs[name] for name in levels}
+        self.level_names = {name: kwargs[name] for name in levels if name in kwargs}
+
+        if not ignore_unknown_levels:
+            for name in levels:
+                if name not in self.level_names:
+                    self.level_names[name] = name
 
         for name in self.level_names.values():
             self.log_dict[name] = []

--- a/masci_tools/util/logging_util.py
+++ b/masci_tools/util/logging_util.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+# Copyright (c), 2018 Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.    #
+#                All rights reserved.                                         #
+# This file is part of the Masci-tools package.                               #
+# (Material science tools)                                                    #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/judftteam/masci-tools    #
+# For further information on the license, see the LICENSE.txt file            #
+#                                                                             #
+###############################################################################
+"""
+This module defines useful utility for logging related functionality
+"""
+from logging import Handler
+
+
+class DictHandler(Handler):
+    """
+    Custom Handler for the logging module inserting logging messages
+    into a given dictionary.
+
+    Messages are grouped into list under the names of the error categories.
+    Keyword arguments can be used to modify the keys for the different levels
+    """
+
+    def __init__(self, log_dict, **kwargs):
+        from logging import _levelToName
+        import copy
+
+        self.log_dict = log_dict
+
+        levels = copy.copy(list(_levelToName.values()))
+        levels.remove('NOTSET')
+
+        self.level_names = {name: name if name not in kwargs else kwargs[name] for name in levels}
+
+        for name in self.level_names.values():
+            self.log_dict[name] = []
+
+        super().__init__()
+
+    def emit(self, record):
+        """
+        Emit a record.
+        """
+        try:
+            msg = self.format(record)
+            entry_name = self.level_names.get(record.levelname, 'NOTSET')
+            if entry_name not in self.log_dict:
+                self.log_dict[entry_name] = []
+
+            self.log_dict[entry_name].append(msg)
+        except Exception:  #pylint: disable=broad-except
+            self.handleError(record)
+
+    def __repr__(self):
+        from logging import getLevelName
+        level = getLevelName(self.level)
+        return '<%s (%s)>' % (self.__class__.__name__, level)

--- a/masci_tools/util/logging_util.py
+++ b/masci_tools/util/logging_util.py
@@ -12,7 +12,7 @@
 """
 This module defines useful utility for logging related functionality
 """
-from logging import Handler
+from logging import Handler, LoggerAdapter
 
 
 class DictHandler(Handler):
@@ -63,3 +63,13 @@ class DictHandler(Handler):
         from logging import getLevelName
         level = getLevelName(self.level)
         return '<%s (%s)>' % (self.__class__.__name__, level)
+
+
+class OutParserLogAdapter(LoggerAdapter):
+    """
+    This adapter expects the passed in dict-like object to have a
+    'iteration' key, whose value is prepended as [Iteration i] to the message
+    """
+
+    def process(self, msg, kwargs):
+        return '[Iteration %s] %s' % (self.extra['iteration'], msg), kwargs

--- a/masci_tools/util/parse_tasks.py
+++ b/masci_tools/util/parse_tasks.py
@@ -289,7 +289,7 @@ class ParseTasks(object):
             else:
                 self._iteration_tasks.append(task_name)
 
-    def perform_task(self, task_name, node, out_dict, schema_dict, constants, parser_info_out=None, use_lists=True):
+    def perform_task(self, task_name, node, out_dict, schema_dict, constants, logger=None, use_lists=True):
         """
         Evaluates the task given in the tasks_definition dict
 
@@ -299,15 +299,12 @@ class ParseTasks(object):
         :param schema_dict: dict, here all paths and attributes are stored according to the
                             outputschema
         :param constants: dict with all the defined mathematical constants
-        :param parser_info_out: dict, with warnings, info, errors, ...
+        :param logger: logger object for logging warnings, errors
         :param root_tag: str, this string will be appended in front of any xpath before it is evaluated
         :param use_lists: bool, if True lists are created for each key if not otherwise specified
 
         """
         from masci_tools.io.common_functions import camel_to_snake
-
-        if parser_info_out is None:
-            parser_info_out = {'parser_warnings': []}
 
         try:
             tasks_definition = self.tasks[task_name]
@@ -338,7 +335,7 @@ class ParseTasks(object):
             if 'subdict' in spec:
                 parsed_dict = out_dict.get(spec['subdict'], {})
 
-            parsed_value = action(node, schema_dict, parser_info_out=parser_info_out, **args)
+            parsed_value = action(node, schema_dict, logger=logger, **args)
 
             if isinstance(parsed_value, dict):
 
@@ -396,7 +393,7 @@ class ParseTasks(object):
         conversions = tasks_definition.get('_conversions', [])
         for conversion in conversions:
             action = self._conversion_functions[conversion]
-            out_dict = action(out_dict, parser_info_out=parser_info_out)
+            out_dict = action(out_dict, logger=logger)
 
         return out_dict
 

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -291,11 +291,18 @@ def evaluate_attribute(node, schema_dict, name, constants=None, logger=None, **k
                 raise ValueError(f'No values found for attribute {name}')
         else:
             logger.warning('No values found for attribute %s', name)
-        return None
+        if list_return:
+            return []
+        else:
+            return None
 
     possible_types = schema_dict['attrib_types'][name]
 
-    converted_value, suc = convert_xml_attribute(stringattribute, possible_types, constants=constants, logger=logger, list_return=list_return)
+    converted_value, suc = convert_xml_attribute(stringattribute,
+                                                 possible_types,
+                                                 constants=constants,
+                                                 logger=logger,
+                                                 list_return=list_return)
 
     if not suc:
         if logger is None:
@@ -339,7 +346,6 @@ def evaluate_text(node, schema_dict, name, constants, logger=None, **kwargs):
 
     stringtext = eval_xpath(node, f'{tag_xpath}/text()', logger=logger, list_return=True)
 
-
     for text in stringtext.copy():
         if text.strip() == '':
             stringtext.remove(text)
@@ -350,11 +356,18 @@ def evaluate_text(node, schema_dict, name, constants, logger=None, **kwargs):
                 raise ValueError(f'No text found for tag {name}')
         else:
             logger.warning('No text found for tag %s', name)
-        return None
+        if list_return:
+            return []
+        else:
+            return None
 
     possible_definitions = schema_dict['simple_elements'][name]
 
-    converted_value, suc = convert_xml_text(stringtext, possible_definitions, constants=constants, logger=logger, list_return=list_return)
+    converted_value, suc = convert_xml_text(stringtext,
+                                            possible_definitions,
+                                            constants=constants,
+                                            logger=logger,
+                                            list_return=list_return)
 
     if not suc:
         if logger is None:
@@ -442,7 +455,10 @@ def evaluate_tag(node, schema_dict, name, constants=None, logger=None, **kwargs)
                     raise ValueError(f'No values found for attribute {attrib} at tag {name}')
             else:
                 logger.warning('No values found for attribute %s at tag %s', attrib, name)
-            out_dict[attrib] = None
+            if list_return:
+                out_dict[attrib] = []
+            else:
+                out_dict[attrib] = None
             continue
 
         possible_types = schema_dict['attrib_types'][attrib]

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -268,6 +268,7 @@ def evaluate_attribute(node, schema_dict, name, constants=None, logger=None, **k
         :param exclude: list of str, here specific types of attributes can be excluded
                         valid values are: settable, settable_contains, other
         :param list_return: if True, the returned quantity is always a list even if only one element is in it
+        :param optional: bool, if True and no logger given none or an empty list is returned
 
     :returns: list or single value, converted in convert_xml_attribute
     """
@@ -329,6 +330,7 @@ def evaluate_text(node, schema_dict, name, constants, logger=None, **kwargs):
         :param contains: str, this string has to be in the final path
         :param not_contains: str, this string has to NOT be in the final path
         :param list_return: if True, the returned quantity is always a list even if only one element is in it
+        :param optional: bool, if True and no logger given none or an empty list is returned
 
     :returns: list or single value, converted in convert_xml_text
     """

--- a/masci_tools/util/xml/common_xml_util.py
+++ b/masci_tools/util/xml/common_xml_util.py
@@ -605,6 +605,7 @@ def check_complex_xpath(node, base_xpath, complex_xpath):
     if not results_base.issuperset(results_complex):
         raise ValueError(f"Complex xpath '{complex_xpath}' is not compatible with the base_xpath '{base_xpath}'")
 
+
 def convert_str_version_number(version_str):
     """
     Convert the version number as a integer for easy comparisons

--- a/masci_tools/util/xml/common_xml_util.py
+++ b/masci_tools/util/xml/common_xml_util.py
@@ -124,7 +124,7 @@ def validate_xml(xmltree, schema, error_header='File does not validate'):
         raise etree.DocumentInvalid(errmsg) from exc
 
 
-def convert_xml_attribute(stringattribute, possible_types, constants=None, logger=None):
+def convert_xml_attribute(stringattribute, possible_types, constants=None, logger=None, list_return=False):
     """
     Tries to converts a given string attribute to the types given in possible_types.
     First succeeded conversion will be returned
@@ -137,8 +137,9 @@ def convert_xml_attribute(stringattribute, possible_types, constants=None, logge
     :param logger: logger object for logging warnings
                    if given the errors are logged and the list is returned with the unconverted values
                    otherwise a error is raised, when the first conversion fails
+    :param list_return: if True, the returned quantity is always a list even if only one element is in it
 
-    :return: The converted value of the first succesful conversion
+    :return: The converted value of the first successful conversion
     """
     from masci_tools.util.fleur_calculate_expression import calculate_expression
 
@@ -202,13 +203,13 @@ def convert_xml_attribute(stringattribute, possible_types, constants=None, logge
             all_success = False
 
     ret_value = converted_list
-    if len(converted_list) == 1:
+    if len(converted_list) == 1 and not list_return:
         ret_value = converted_list[0]
 
     return ret_value, all_success
 
 
-def convert_attribute_to_xml(attributevalue, possible_types, logger=None, float_format='.10'):
+def convert_attribute_to_xml(attributevalue, possible_types, logger=None, float_format='.10', list_return=False):
     """
     Tries to converts a given attributevalue to a string for a xml file according
     to the types given in possible_types.
@@ -219,6 +220,7 @@ def convert_attribute_to_xml(attributevalue, possible_types, logger=None, float_
     :param logger: logger object for logging warnings
                    if given the errors are logged and the list is returned with the unconverted values
                    otherwise a error is raised, when the first conversion fails
+    :param list_return: if True, the returned quantity is always a list even if only one element is in it
 
     :return: The converted str of the value of the first succesful conversion
     """
@@ -277,13 +279,13 @@ def convert_attribute_to_xml(attributevalue, possible_types, logger=None, float_
             all_success = False
 
     ret_value = converted_list
-    if len(converted_list) == 1:
+    if len(converted_list) == 1 and not list_return:
         ret_value = converted_list[0]
 
     return ret_value, all_success
 
 
-def convert_xml_text(tagtext, possible_definitions, constants=None, logger=None):
+def convert_xml_text(tagtext, possible_definitions, constants=None, logger=None, list_return=False):
     """
     Tries to converts a given string text based on the definitions (length and type).
     First succeeded conversion will be returned
@@ -294,6 +296,7 @@ def convert_xml_text(tagtext, possible_definitions, constants=None, logger=None)
     :param logger: logger object for logging warnings
                    if given the errors are logged and the list is returned with the unconverted values
                    otherwise a error is raised, when the first conversion fails
+    :param list_return: if True, the returned quantity is always a list even if only one element is in it
 
     :return: The converted value of the first succesful conversion
     """
@@ -350,13 +353,13 @@ def convert_xml_text(tagtext, possible_definitions, constants=None, logger=None)
         converted_list.append(converted_text)
 
     ret_value = converted_list
-    if len(converted_list) == 1:
+    if len(converted_list) == 1 and not list_return:
         ret_value = converted_list[0]
 
     return ret_value, all_success
 
 
-def convert_text_to_xml(textvalue, possible_definitions, logger=None, float_format='16.13'):
+def convert_text_to_xml(textvalue, possible_definitions, logger=None, float_format='16.13', list_return=False):
     """
     Tries to convert a given list of values to str for a xml file based on the definitions (length and type).
     First succeeded conversion will be returned
@@ -366,6 +369,7 @@ def convert_text_to_xml(textvalue, possible_definitions, logger=None, float_form
     :param logger: logger object for logging warnings
                    if given the errors are logged and the list is returned with the unconverted values
                    otherwise a error is raised, when the first conversion fails
+    :param list_return: if True, the returned quantity is always a list even if only one element is in it
 
     :return: The converted value of the first succesful conversion
     """
@@ -422,7 +426,7 @@ def convert_text_to_xml(textvalue, possible_definitions, logger=None, float_form
         converted_list.append(' '.join(converted_text))
 
     ret_value = converted_list
-    if len(converted_list) == 1:
+    if len(converted_list) == 1 and not list_return:
         ret_value = converted_list[0]
 
     return ret_value, all_success

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -762,6 +762,7 @@ def set_inpchanges(xmltree, schema_dict, change_dict, path_spec=None):
 
     return xmltree
 
+
 @schema_dict_version_dispatch(output_schema=False)
 def set_nkpts(xmltree, schema_dict, count, gamma):
     """
@@ -777,6 +778,7 @@ def set_nkpts(xmltree, schema_dict, count, gamma):
     """
 
     raise NotImplementedError(f"'set_npkts' is not implemented for inputs of version '{schema_dict['inp_version']}'")
+
 
 @set_nkpts.register(max_version='0.31')
 def set_nkpts_max4(xmltree, schema_dict, count, gamma):

--- a/masci_tools/util/xml/xml_setters_nmmpmat.py
+++ b/masci_tools/util/xml/xml_setters_nmmpmat.py
@@ -41,7 +41,7 @@ def set_nmmpmat(xmltree, nmmplines, schema_dict, species_name, orbital, spin,\
     :returns: list with modified nmmplines
     """
     from masci_tools.util.xml.common_xml_util import eval_xpath, get_xml_attribute
-    from masci_tools.util.schema_dict_util import evaluate_attribute, eval_simple_xpath
+    from masci_tools.util.schema_dict_util import evaluate_attribute, eval_simple_xpath, attrib_exists
     from masci_tools.io.io_nmmpmat import write_nmmpmat, write_nmmpmat_from_states, write_nmmpmat_from_orbitals
 
     #All lda+U procedures have to be considered since we need to keep the order
@@ -58,8 +58,9 @@ def set_nmmpmat(xmltree, nmmplines, schema_dict, species_name, orbital, spin,\
 
     nspins = evaluate_attribute(xmltree, schema_dict, 'jspins')
     if 'l_mtnocoPot' in schema_dict['attrib_types']:
-        if evaluate_attribute(xmltree, schema_dict, 'l_mtnocoPot', contains='Setup'):
-            nspins = 3
+        if attrib_exists(xmltree, schema_dict, 'l_mtnocoPot', contains='Setup'):
+            if evaluate_attribute(xmltree, schema_dict, 'l_mtnocoPot', contains='Setup'):
+                nspins = 3
 
     if spin > nspins:
         raise ValueError(f'Invalid input: spin {spin} requested, but input has only {nspins} spins')
@@ -136,7 +137,7 @@ def rotate_nmmpmat(xmltree, nmmplines, schema_dict, species_name, orbital, phi, 
     :returns: list with modified nmmplines
     """
     from masci_tools.util.xml.common_xml_util import eval_xpath, get_xml_attribute
-    from masci_tools.util.schema_dict_util import evaluate_attribute, eval_simple_xpath
+    from masci_tools.util.schema_dict_util import evaluate_attribute, eval_simple_xpath, attrib_exists
     from masci_tools.io.io_nmmpmat import read_nmmpmat_block, rotate_nmmpmat_block, format_nmmpmat
 
     species_base_path = get_tag_xpath(schema_dict, 'species')
@@ -152,8 +153,9 @@ def rotate_nmmpmat(xmltree, nmmplines, schema_dict, species_name, orbital, phi, 
 
     nspins = evaluate_attribute(xmltree, schema_dict, 'jspins')
     if 'l_mtnocoPot' in schema_dict['attrib_types']:
-        if evaluate_attribute(xmltree, schema_dict, 'l_mtnocoPot', contains='Setup'):
-            nspins = 3
+        if attrib_exists(xmltree, schema_dict, 'l_mtnocoPot', contains='Setup'):
+            if evaluate_attribute(xmltree, schema_dict, 'l_mtnocoPot', contains='Setup'):
+                nspins = 3
 
     all_ldau = eval_simple_xpath(xmltree, schema_dict, 'ldaU', contains='species', list_return=True)
     numRows = nspins * 14 * len(all_ldau)
@@ -217,12 +219,13 @@ def validate_nmmpmat(xmltree, nmmplines, schema_dict):
     :raises ValueError: if any of the above checks are violated.
     """
     from masci_tools.util.xml.common_xml_util import get_xml_attribute
-    from masci_tools.util.schema_dict_util import evaluate_attribute, eval_simple_xpath
+    from masci_tools.util.schema_dict_util import evaluate_attribute, eval_simple_xpath, attrib_exists
 
     nspins = evaluate_attribute(xmltree, schema_dict, 'jspins')
     if 'l_mtnocoPot' in schema_dict['attrib_types']:
-        if evaluate_attribute(xmltree, schema_dict, 'l_mtnocoPot', contains='Setup'):
-            nspins = 3
+        if attrib_exists(xmltree, schema_dict, 'l_mtnocoPot', contains='Setup'):
+            if evaluate_attribute(xmltree, schema_dict, 'l_mtnocoPot', contains='Setup'):
+                nspins = 3
 
     all_ldau = eval_simple_xpath(xmltree, schema_dict, 'ldaU', contains='species', list_return=True)
     numRows = nspins * 14 * len(all_ldau)

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -182,13 +182,7 @@ def xml_set_attrib_value(xmltree,
             f'Allowed attributes are: {attribs.original_case.values()}')
     attributename = attribs.original_case[attributename]
 
-    warnings = []
-    converted_attribv, suc = convert_attribute_to_xml(attribv,
-                                                      schema_dict['attrib_types'][attributename],
-                                                      conversion_warnings=warnings)
-
-    if not suc:
-        raise ValueError(f"Failed to convert attribute values '{attribv}': \n" '\n'.join(warnings))
+    converted_attribv, suc = convert_attribute_to_xml(attribv, schema_dict['attrib_types'][attributename])
 
     return xml_set_attrib_value_no_create(xmltree, xpath, attributename, converted_attribv, occurrences=occurrences)
 
@@ -266,11 +260,8 @@ def xml_set_text(xmltree, schema_dict, xpath, base_xpath, text, occurrences=None
     _, tag_name = split_off_tag(base_xpath)
 
     possible_definitions = schema_dict['simple_elements'][tag_name]
-    warnings = []
-    converted_text, suc = convert_text_to_xml(text, possible_definitions, conversion_warnings=warnings)
 
-    if not suc:
-        raise ValueError(f"Failed to convert text values '{text}': \n" '\n'.join(warnings))
+    converted_text, suc = convert_text_to_xml(text, possible_definitions)
 
     return xml_set_text_no_create(xmltree, xpath, converted_text, occurrences=occurrences)
 

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -89,7 +89,13 @@ def xml_create_tag_schema_dict(xmltree,
     return xml_create_tag(xmltree, xpath, element, tag_order=tag_order, occurrences=occurrences)
 
 
-def eval_xpath_create(xmltree, schema_dict, xpath, base_xpath, create_parents=False, occurrences=None):
+def eval_xpath_create(xmltree,
+                      schema_dict,
+                      xpath,
+                      base_xpath,
+                      create_parents=False,
+                      occurrences=None,
+                      list_return=False):
     """
     Evaluates and xpath and creates tag if the result is empty
 
@@ -101,6 +107,7 @@ def eval_xpath_create(xmltree, schema_dict, xpath, base_xpath, create_parents=Fa
                            if they are missing
     :param occurrences: int or list of int. Which occurence of the parent nodes to create a tag if the tag is missing.
                         By default all nodes are used.
+    :param list_return: if True, the returned quantity is always a list even if only one element is in it
 
     :returns: list of nodes from the result of the xpath expression
     """
@@ -121,6 +128,9 @@ def eval_xpath_create(xmltree, schema_dict, xpath, base_xpath, create_parents=Fa
                                              create_parents=create_parents,
                                              occurrences=occurrences)
         nodes = eval_xpath(xmltree, xpath, list_return=True)
+
+    if len(nodes) == 1 and not list_return:
+        nodes = nodes[0]
 
     return nodes
 
@@ -164,7 +174,13 @@ def xml_set_attrib_value(xmltree,
     check_complex_xpath(xmltree, base_xpath, xpath)
 
     if create:
-        nodes = eval_xpath_create(xmltree, schema_dict, xpath, base_xpath, create_parents=True, occurrences=occurrences)
+        nodes = eval_xpath_create(xmltree,
+                                  schema_dict,
+                                  xpath,
+                                  base_xpath,
+                                  create_parents=True,
+                                  occurrences=occurrences,
+                                  list_return=True)
     else:
         nodes = eval_xpath(xmltree, xpath, list_return=True)
 
@@ -249,7 +265,13 @@ def xml_set_text(xmltree, schema_dict, xpath, base_xpath, text, occurrences=None
     check_complex_xpath(xmltree, base_xpath, xpath)
 
     if create:
-        nodes = eval_xpath_create(xmltree, schema_dict, xpath, base_xpath, create_parents=True, occurrences=occurrences)
+        nodes = eval_xpath_create(xmltree,
+                                  schema_dict,
+                                  xpath,
+                                  base_xpath,
+                                  create_parents=True,
+                                  occurrences=occurrences,
+                                  list_return=True)
     else:
         nodes = eval_xpath(xmltree, xpath, list_return=True)
 
@@ -353,21 +375,14 @@ def xml_add_number_to_attrib(xmltree,
     if not xpath.endswith(f'/@{attributename}'):
         xpath = '/@'.join([xpath, attributename])
 
-    stringattribute = eval_xpath(xmltree, xpath)
+    stringattribute = eval_xpath(xmltree, xpath, list_return=True)
 
     tag_xpath, attributename = split_off_attrib(xpath)
 
-    if isinstance(stringattribute, list):
-        if len(stringattribute) == 0:
-            raise ValueError(f"No attribute values found for '{attributename}'. Cannot add number")
+    if len(stringattribute) == 0:
+        raise ValueError(f"No attribute values found for '{attributename}'. Cannot add number")
 
-    attribvalues, suc = convert_xml_attribute(stringattribute, possible_types, constants=constants)
-
-    if not isinstance(attribvalues, list):
-        attribvalues = [attribvalues]
-
-    if not suc or any(value is None for value in attribvalues):
-        raise ValueError(f"Something went wrong finding values found for '{attributename}'. Cannot add number")
+    attribvalues, _ = convert_xml_attribute(stringattribute, possible_types, constants=constants, list_return=True)
 
     if occurrences is not None:
         if not is_sequence(occurrences):


### PR DESCRIPTION
Closes #38 

This PR is a possible design to solve the issue above. We make use of the `logging` module in the standard library to make extensions of XML parser functions easier and making it easier to get consistent behaviour for failures in these functions

Low-level parser functions now have two options:
1. Raise Errors for all failures
2. Take a logger argument and raise errors if the argument was not provided or is None. If the argument was given the function can still decide to raise for critical errors

This way we can keep the resilience of the Parsers by absorbing non-critical errors and still producing user readable output for all cases as before.

However, when using the parser functions in separate scripts, where they can also be incredibly useful, they now raise errors for all failures by default