### PR TITLE
Improve schema_dict_util functions for for relative xpaths

### DIFF
--- a/masci_tools/io/common_functions.py
+++ b/masci_tools/io/common_functions.py
@@ -396,16 +396,16 @@ def camel_to_snake(name):
     name = name.replace('-', '')
     return ''.join(['_' + c.lower() if c.isupper() else c for c in name]).lstrip('_')
 
+
 def convert_to_fortran(val, quote_strings=True):
     """
     :param val: the value to be read and converted to a Fortran-friendly string.
     """
     # Note that bool should come before integer, because a boolean matches also
     # isinstance(...,int)
-    import numpy
     import numbers
 
-    if isinstance(val, (bool, numpy.bool_)):
+    if isinstance(val, (bool, np.bool_)):
         if val:
             val_str = '.true.'
         else:
@@ -425,6 +425,7 @@ def convert_to_fortran(val, quote_strings=True):
 
     return val_str
 
+
 def convert_to_fortran_string(string):
     """
     converts some parameter strings to the format for the inpgen
@@ -432,6 +433,7 @@ def convert_to_fortran_string(string):
     :returns: string in right format (extra "")
     """
     return f'"{string}"'
+
 
 def is_sequence(arg):
     """

--- a/masci_tools/tests/test_common_functions.py
+++ b/masci_tools/tests/test_common_functions.py
@@ -180,3 +180,18 @@ class Test_common_functions(object):
             np.float128
         ]
         assert out == [list, int, int, int, list, int, int, int, list, int, int, int, int, float, int, float]
+
+
+TEST_PYTHON_VALUES = [True, False, 3.14, 4, 'str', 'TEST_STRING']
+TEST_QUOTE_STRINGS = [False, False, False, False, False, True]
+TEST_FORTRAN_STRING = ['.true.', '.false.', '  3.1400000000d+00', '4', 'str', "'TEST_STRING'"]
+
+
+@pytest.mark.parametrize('value,expected_result,quote', zip(TEST_PYTHON_VALUES, TEST_FORTRAN_STRING,
+                                                            TEST_QUOTE_STRINGS))
+def test_convert_to_fortran(value, expected_result, quote):
+    from masci_tools.io.common_functions import convert_to_fortran
+
+    res = convert_to_fortran(value, quote_strings=quote)
+
+    assert res == expected_result

--- a/masci_tools/tests/test_schema_dict_util.py
+++ b/masci_tools/tests/test_schema_dict_util.py
@@ -53,6 +53,42 @@ def test_get_tag_xpath_input():
         get_tag_xpath(schema_dict_34, 'ldaU')
 
 
+def test_get_relative_tag_xpath_input():
+    """
+    Test the path finding for tags for the input schema without additional options
+    And verify with different version of the schema
+    """
+    from masci_tools.util.schema_dict_util import get_relative_tag_xpath
+
+    assert get_relative_tag_xpath(schema_dict_34, 'magnetism', 'calculationSetup') == './magnetism'
+    assert get_relative_tag_xpath(schema_dict_34, 'magnetism', 'magnetism') == './'
+
+    assert get_relative_tag_xpath(schema_dict_34, 'DMI', 'forceTheorem') == './DMI'
+    with pytest.raises(ValueError, match='The tag DMI has no possible relative paths with the current specification.'):
+        get_relative_tag_xpath(schema_dict_27, 'DMI', 'forceTheorem')
+
+    with pytest.raises(ValueError,
+                       match='The tag ldaU has multiple possible relative paths with the current specification.'):
+        get_relative_tag_xpath(schema_dict_34, 'ldaU', 'fleurInput')
+
+    assert get_relative_tag_xpath(schema_dict_34, 'ldaU', 'fleurInput',
+                                  contains='species') == './atomSpecies/species/ldaU'
+    assert get_relative_tag_xpath(schema_dict_34, 'ldaU', 'species') == './ldaU'
+
+
+def test_get_relative_tag_xpath_output():
+    """
+    Test the path finding for tags for the input schema without additional options
+    And verify with different version of the schema
+    """
+    from masci_tools.util.schema_dict_util import get_relative_tag_xpath
+
+    assert get_relative_tag_xpath(outschema_dict_34, 'iteration', 'scfLoop') == './iteration'
+    assert get_relative_tag_xpath(outschema_dict_34, 'iteration', 'iteration') == './'
+
+    assert get_relative_tag_xpath(outschema_dict_34, 'densityMatrixFor', 'ldaUDensityMatrix') == './densityMatrixFor'
+
+
 def test_get_tag_xpath_output():
     """
     Test the path finding for tags for the output schema without additional options
@@ -177,6 +213,38 @@ def test_get_attrib_xpath_input():
         get_attrib_xpath(schema_dict_34, 'l_amf')
 
 
+def test_get_relative_attrib_xpath_input():
+    """
+    Test the path finding for tags for the input schema without additional options
+    And verify with different version of the schema
+    """
+    from masci_tools.util.schema_dict_util import get_relative_attrib_xpath
+
+    #First example easy (magnetism tag is unique and should not differ between the versions)
+    assert get_relative_attrib_xpath(schema_dict_34, 'jspins', 'calculationSetup') == './magnetism/@jspins'
+    assert get_relative_attrib_xpath(schema_dict_34, 'jspins', 'magnetism') == './@jspins'
+
+    #Non existent tag in old version
+    assert get_relative_attrib_xpath(schema_dict_34, 'l_mtNocoPot', 'magnetism') == './mtNocoParams/@l_mtNocoPot'
+    with pytest.raises(
+            ValueError,
+            match='The attrib l_mtNocoPot has multiple possible relative paths with the current specification.'):
+        get_relative_attrib_xpath(schema_dict_34, 'l_mtNocoPot', 'fleurInput')
+
+    with pytest.raises(ValueError,
+                       match='The attrib l_mtNocoPot has no possible relative paths with the current specification.'):
+        get_relative_attrib_xpath(schema_dict_34, 'l_mtNocoPot', 'output')
+
+    #Multiple possible paths
+    with pytest.raises(ValueError,
+                       match='The attrib l_amf has multiple possible relative paths with the current specification.'):
+        get_relative_attrib_xpath(schema_dict_34, 'l_amf', 'fleurInput')
+
+    assert get_relative_attrib_xpath(schema_dict_34, 'l_amf', 'fleurInput', contains='species',
+                                     not_contains='ldaHIA') == './atomSpecies/species/ldaU/@l_amf'
+    assert get_relative_attrib_xpath(schema_dict_34, 'l_amf', 'ldaU') == './@l_amf'
+
+
 def test_get_attrib_xpath_output():
     """
     Test the path finding for tags for the input schema without additional options
@@ -191,6 +259,20 @@ def test_get_attrib_xpath_output():
     #relative
     assert get_attrib_xpath(outschema_dict_31, 'qvectors') == './Forcetheorem_SSDISP/@qvectors'
     assert get_attrib_xpath(outschema_dict_34, 'qvectors') == './Forcetheorem_SSDISP/@qvectors'
+
+
+def test_get_relative_attrib_xpath_output():
+    """
+    Test the path finding for tags for the input schema without additional options
+    And verify with different version of the schema
+    """
+    from masci_tools.util.schema_dict_util import get_relative_attrib_xpath
+
+    assert get_relative_attrib_xpath(outschema_dict_34, 'nat', 'numericalParameters') == './atomsInCell/@nat'
+    assert get_relative_attrib_xpath(outschema_dict_34, 'nat', 'atomsInCell') == './@nat'
+
+    assert get_relative_attrib_xpath(outschema_dict_34, 'qvectors', '.') == './Forcetheorem_SSDISP/@qvectors'
+    assert get_relative_attrib_xpath(outschema_dict_34, 'qvectors', 'Forcetheorem_SSDISP') == './@qvectors'
 
 
 def test_get_attrib_xpath_contains():

--- a/masci_tools/tests/test_schema_dict_util.py
+++ b/masci_tools/tests/test_schema_dict_util.py
@@ -224,6 +224,11 @@ def test_get_relative_attrib_xpath_input():
     assert get_relative_attrib_xpath(schema_dict_34, 'jspins', 'calculationSetup') == './magnetism/@jspins'
     assert get_relative_attrib_xpath(schema_dict_34, 'jspins', 'magnetism') == './@jspins'
 
+    assert get_relative_attrib_xpath(schema_dict_34, 'jspins', 'magnetism', tag_name='magnetism') == './@jspins'
+
+    with pytest.raises(ValueError, match='No attribute jspins found at tag calculationSetup'):
+        get_relative_attrib_xpath(schema_dict_34, 'jspins', 'calculationSetup', tag_name='calculationSetup')
+
     #Non existent tag in old version
     assert get_relative_attrib_xpath(schema_dict_34, 'l_mtNocoPot', 'magnetism') == './mtNocoParams/@l_mtNocoPot'
     with pytest.raises(

--- a/masci_tools/tests/test_xml_common_functions.py
+++ b/masci_tools/tests/test_xml_common_functions.py
@@ -181,3 +181,16 @@ def test_check_complex_xpath(load_inpxml):
     check_complex_xpath(xmltree, '/fleurInput/atomSpecies/species',
                         "/fleurInput/atomSpecies/species[@name='does_not_exist']")
     check_complex_xpath(xmltree, '/fleurInput/atomSpecies/species/lo', "//species[@name='Pt-1']/lo")
+
+
+def test_abs_to_rel_xpath():
+
+    from masci_tools.util.xml.common_functions import abs_to_rel_xpath
+
+    assert abs_to_rel_xpath('/test/new_root/relative/path', 'new_root') == './relative/path'
+    assert abs_to_rel_xpath('/test/new_root/relative/path/@attrib', 'new_root') == './relative/path/@attrib'
+    assert abs_to_rel_xpath('/test/new_root/relative/path', 'path') == './'
+    assert abs_to_rel_xpath('/test/new_root/relative/path/@attrib', 'path') == './@attrib'
+
+    with pytest.raises(ValueError):
+        abs_to_rel_xpath('/test/new_root/relative/path/@attrib', 'non_existent')

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -21,6 +21,7 @@ from masci_tools.util.parse_tasks_decorators import register_parsing_function
 from masci_tools.util.lockable_containers import LockableList
 from lxml import etree
 
+
 def _find_paths(schema_dict, name, entries, contains=None, not_contains=None):
     """
     Find all paths in the schema_dict in the given entries for the given name
@@ -105,6 +106,7 @@ def get_tag_xpath(schema_dict, name, contains=None, not_contains=None):
                          f'contains: {contains}, not_contains: {not_contains} \n'
                          f'These are possible: {paths}')
 
+
 def get_relative_tag_xpath(schema_dict, name, root_tag, contains=None, not_contains=None):
     """
     Tries to find a unique relative path from the schema_dict based on the given name of the tag
@@ -150,6 +152,7 @@ def get_relative_tag_xpath(schema_dict, name, root_tag, contains=None, not_conta
                          f'contains: {contains}, not_contains: {not_contains}, root_tag {root_tag} \n'
                          f'These are possible: {rel_paths}')
 
+
 def get_attrib_xpath(schema_dict, name, contains=None, not_contains=None, exclude=None, tag_name=None):
     """
     Tries to find a unique path from the schema_dict based on the given name of the attribute
@@ -182,7 +185,6 @@ def get_attrib_xpath(schema_dict, name, contains=None, not_contains=None, exclud
                 raise ValueError(err_msg)
         return f'{tag_xpath}/@{name}'
 
-
     possible_lists = ['unique_attribs', 'unique_path_attribs', 'other_attribs']
     output = False
     if 'iteration_unique_attribs' in schema_dict:
@@ -196,7 +198,6 @@ def get_attrib_xpath(schema_dict, name, contains=None, not_contains=None, exclud
             if output:
                 possible_lists.remove(f'iteration_{list_name}_attribs')
 
-
     paths = _find_paths(schema_dict, name, possible_lists, contains=contains, not_contains=not_contains)
 
     if len(paths) == 1:
@@ -209,7 +210,14 @@ def get_attrib_xpath(schema_dict, name, contains=None, not_contains=None, exclud
                          f'contains: {contains}, not_contains: {not_contains}, exclude {exclude}\n'
                          f'These are possible: {paths}')
 
-def get_relative_attrib_xpath(schema_dict, name, root_tag, contains=None, not_contains=None, exclude=None, tag_name=None):
+
+def get_relative_attrib_xpath(schema_dict,
+                              name,
+                              root_tag,
+                              contains=None,
+                              not_contains=None,
+                              exclude=None,
+                              tag_name=None):
     """
     Tries to find a unique relative path from the schema_dict based on the given name of the attribute
     name of the root, from which the path should be relative and additional further specifications
@@ -230,7 +238,11 @@ def get_relative_attrib_xpath(schema_dict, name, root_tag, contains=None, not_co
     from masci_tools.util.xml.common_functions import abs_to_rel_xpath
 
     if tag_name is not None:
-        tag_xpath = get_relative_tag_xpath(schema_dict, tag_name, root_tag, contains=contains, not_contains=not_contains)
+        tag_xpath = get_relative_tag_xpath(schema_dict,
+                                           tag_name,
+                                           root_tag,
+                                           contains=contains,
+                                           not_contains=not_contains)
 
         err_msg = f'No attribute {name} found at tag {tag_name}'
         if tag_xpath in schema_dict['tag_info']:
@@ -240,7 +252,6 @@ def get_relative_attrib_xpath(schema_dict, name, root_tag, contains=None, not_co
             if name not in schema_dict['iteration_tag_info'][tag_xpath]['attribs']:
                 raise ValueError(err_msg)
         return f'{tag_xpath}/@{name}'
-
 
     possible_lists = ['unique_attribs', 'unique_path_attribs', 'other_attribs']
     output = False
@@ -279,7 +290,14 @@ def get_relative_attrib_xpath(schema_dict, name, root_tag, contains=None, not_co
                          f'These are possible: {rel_paths}')
 
 
-def get_tag_info(schema_dict, name, contains=None, not_contains=None, path_return=True, convert_to_builtin=False, multiple_paths=False, parent=False):
+def get_tag_info(schema_dict,
+                 name,
+                 contains=None,
+                 not_contains=None,
+                 path_return=True,
+                 convert_to_builtin=False,
+                 multiple_paths=False,
+                 parent=False):
     """
     Tries to find a unique path from the schema_dict based on the given name of the tag
     and additional further specifications and returns the tag_info entry for this tag
@@ -336,7 +354,6 @@ def get_tag_info(schema_dict, name, contains=None, not_contains=None, path_retur
 
     if not multiple_paths:
         paths = paths[0]
-
 
     if convert_to_builtin:
         tag_info = {
@@ -560,7 +577,6 @@ def evaluate_tag(node, schema_dict, name, constants=None, logger=None, **kwargs)
 
     if tag_xpath is None:
         tag_xpath = get_tag_xpath(schema_dict, name, **kwargs)
-
 
     #Which attributes are expected
     try:

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -211,11 +211,11 @@ def get_attrib_xpath(schema_dict, name, contains=None, not_contains=None, exclud
 
 def get_relative_attrib_xpath(schema_dict, name, root_tag, contains=None, not_contains=None, exclude=None, tag_name=None):
     """
-    Tries to find a unique path from the schema_dict based on the given name of the tag
-    and additional further specifications
+    Tries to find a unique relative path from the schema_dict based on the given name of the attribute
+    name of the root, from which the path should be relative and additional further specifications
 
     :param schema_dict: dict, containing all the path information and more
-    :param name: str, name of the tag
+    :param name: str, name of the attribute
     :param contains: str or list of str, this string has to be in the final path
     :param not_contains: str or list of str, this string has to NOT be in the final path
     :param exclude: list of str, here specific types of attributes can be excluded

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -244,14 +244,21 @@ def get_relative_attrib_xpath(schema_dict,
                                            contains=contains,
                                            not_contains=not_contains)
 
+        tag_info = get_tag_info(schema_dict,
+                                tag_name,
+                                path_return=False,
+                                multiple_paths=True,
+                                contains=contains,
+                                not_contains=not_contains)
+
         err_msg = f'No attribute {name} found at tag {tag_name}'
-        if tag_xpath in schema_dict['tag_info']:
-            if name not in schema_dict['tag_info'][tag_xpath]['attribs']:
-                raise ValueError(err_msg)
+        if name not in tag_info['attribs']:
+            raise ValueError(err_msg)
+
+        if tag_xpath.endswith('/'):
+            return f'{tag_xpath}@{name}'
         else:
-            if name not in schema_dict['iteration_tag_info'][tag_xpath]['attribs']:
-                raise ValueError(err_msg)
-        return f'{tag_xpath}/@{name}'
+            return f'{tag_xpath}/@{name}'
 
     possible_lists = ['unique_attribs', 'unique_path_attribs', 'other_attribs']
     output = False

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -282,10 +282,10 @@ def get_relative_attrib_xpath(schema_dict,
     if len(rel_paths) == 1:
         return rel_paths.pop()
     elif len(rel_paths) == 0:
-        raise ValueError(f'The tag {name} has no possible relative paths with the current specification.\n'
+        raise ValueError(f'The attrib {name} has no possible relative paths with the current specification.\n'
                          f'contains: {contains}, not_contains: {not_contains}, root_tag {root_tag}')
     else:
-        raise ValueError(f'The tag {name} has multiple possible relative paths with the current specification.\n'
+        raise ValueError(f'The attrib {name} has multiple possible relative paths with the current specification.\n'
                          f'contains: {contains}, not_contains: {not_contains}, root_tag {root_tag} \n'
                          f'These are possible: {rel_paths}')
 

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -21,20 +21,17 @@ from masci_tools.util.parse_tasks_decorators import register_parsing_function
 from masci_tools.util.lockable_containers import LockableList
 from lxml import etree
 
-
-def get_tag_xpath(schema_dict, name, contains=None, not_contains=None):
+def _find_paths(schema_dict, name, entries, contains=None, not_contains=None):
     """
-    Tries to find a unique path from the schema_dict based on the given name of the tag
-    and additional further specifications
+    Find all paths in the schema_dict in the given entries for the given name
+    and matching the contains/not_contains criteria
 
     :param schema_dict: dict, containing all the path information and more
     :param name: str, name of the tag
     :param contains: str or list of str, this string has to be in the final path
     :param not_contains: str or list of str, this string has to NOT be in the final path
 
-    :returns: str, xpath to the given tag
-
-    :raises ValueError: If no unique path could be found
+    :returns: list of str, found xpaths matching the criteria
     """
 
     if contains is None:
@@ -47,81 +44,111 @@ def get_tag_xpath(schema_dict, name, contains=None, not_contains=None):
     elif not isinstance(not_contains, (list, set)):
         not_contains = [not_contains]
 
-    possible_lists = ['tag_paths']
+    path_list = []
+    for entry in entries:
+        if name in schema_dict[entry]:
+            entry_paths = schema_dict[entry][name]
 
-    if 'iteration_tag_paths' in schema_dict:
-        possible_lists += ['iteration_tag_paths']
-
-    all_paths = []
-    for list_name in possible_lists:
-        if name in schema_dict[list_name]:
-            paths = schema_dict[list_name][name]
-
-            if not isinstance(paths, LockableList):
-                paths = [paths]
+            if not isinstance(entry_paths, LockableList):
+                entry_paths = [entry_paths]
             else:
-                paths = paths.get_unlocked()
+                entry_paths = entry_paths.get_unlocked()
 
             invalid_paths = set()
             for phrase in contains:
-                for xpath in paths:
+                for xpath in entry_paths:
                     if phrase not in xpath:
                         invalid_paths.add(xpath)
 
             for phrase in not_contains:
-                for xpath in paths:
+                for xpath in entry_paths:
                     if phrase in xpath:
                         invalid_paths.add(xpath)
 
             for invalid in invalid_paths:
-                paths.remove(invalid)
+                entry_paths.remove(invalid)
 
-            all_paths += paths
+            path_list += entry_paths
 
-    if len(all_paths) == 1:
-        return all_paths[0]
-    elif len(all_paths) == 0:
-        raise ValueError(f'The tag {name} has no possible paths with the current specification.\n'
-                         f'contains: {contains}, not_contains: {not_contains}')
-    else:
-        raise ValueError(f'The tag {name} has multiple possible paths with the current specification.\n'
-                         f'contains: {contains}, not_contains: {not_contains} \n'
-                         f'These are possible: {all_paths}')
+    return path_list
 
 
-def get_tag_info(schema_dict, name, contains=None, not_contains=None, path_return=True, convert_to_builtin=False):
+def get_tag_xpath(schema_dict, name, contains=None, not_contains=None):
     """
     Tries to find a unique path from the schema_dict based on the given name of the tag
-    and additional further specifications and returns the tag_info entry for this tag
+    and additional further specifications
 
     :param schema_dict: dict, containing all the path information and more
     :param name: str, name of the tag
     :param contains: str or list of str, this string has to be in the final path
     :param not_contains: str or list of str, this string has to NOT be in the final path
-    :param path_return: bool, if True the found path will be returned alongside the tag_info
-    :param convert_to_builtin: bool, if True the CaseInsensitiveFrozenSets are converetd to normal sets
-                               with the rigth case of the attributes
 
-    :returns: dict, tag_info for the found xpath
-    :returns: str, xpath to the tag if `path_return=True`
+    :returns: str, xpath for the given tag
+
+    :raises ValueError: If no unique path could be found
     """
-    import copy
-    from masci_tools.util.case_insensitive_dict import CaseInsensitiveFrozenSet
 
-    tag_xpath = get_tag_xpath(schema_dict, name, contains=contains, not_contains=not_contains)
-    tag_info = copy.deepcopy(schema_dict['tag_info'][tag_xpath])
+    possible_lists = ['tag_paths']
 
-    if convert_to_builtin:
-        tag_info = {
-            key: set(val.original_case.values()) if isinstance(val, CaseInsensitiveFrozenSet) else val
-            for key, val in tag_info.items()
-        }
+    if 'iteration_tag_paths' in schema_dict:
+        possible_lists += ['iteration_tag_paths']
 
-    if path_return:
-        return tag_info, tag_xpath
+    paths = _find_paths(schema_dict, name, possible_lists, contains=contains, not_contains=not_contains)
+
+    if len(paths) == 1:
+        return paths[0]
+    elif len(paths) == 0:
+        raise ValueError(f'The tag {name} has no possible paths with the current specification.\n'
+                         f'contains: {contains}, not_contains: {not_contains}')
     else:
-        return tag_info
+        raise ValueError(f'The tag {name} has multiple possible paths with the current specification.\n'
+                         f'contains: {contains}, not_contains: {not_contains} \n'
+                         f'These are possible: {paths}')
 
+def get_relative_tag_xpath(schema_dict, name, root_tag, contains=None, not_contains=None):
+    """
+    Tries to find a unique relative path from the schema_dict based on the given name of the tag
+    name of the root, from which the path should be relative and additional further specifications
+
+    :param schema_dict: dict, containing all the path information and more
+    :param name: str, name of the tag
+    :param root_tag: str, name of the tag from which the path should be relative
+    :param contains: str or list of str, this string has to be in the final path
+    :param not_contains: str or list of str, this string has to NOT be in the final path
+
+    :returns: str, xpath for the given tag
+
+    :raises ValueError: If no unique path could be found
+    """
+    from masci_tools.util.xml.common_functions import abs_to_rel_xpath
+
+    possible_lists = ['tag_paths']
+
+    if 'iteration_tag_paths' in schema_dict:
+        possible_lists += ['iteration_tag_paths']
+
+    #The paths have to include the root_tag
+    if contains is None:
+        contains = [root_tag]
+    else:
+        contains = set(contains)
+        contains.add(root_tag)
+
+    paths = _find_paths(schema_dict, name, possible_lists, contains=contains, not_contains=not_contains)
+
+    rel_paths = set()
+    for xpath in paths:
+        rel_paths.add(abs_to_rel_xpath(xpath, root_tag))
+
+    if len(rel_paths) == 1:
+        return rel_paths.pop()
+    elif len(rel_paths) == 0:
+        raise ValueError(f'The tag {name} has no possible relative paths with the current specification.\n'
+                         f'contains: {contains}, not_contains: {not_contains}, root_tag {root_tag}')
+    else:
+        raise ValueError(f'The tag {name} has multiple possible relative paths with the current specification.\n'
+                         f'contains: {contains}, not_contains: {not_contains}, root_tag {root_tag} \n'
+                         f'These are possible: {rel_paths}')
 
 def get_attrib_xpath(schema_dict, name, contains=None, not_contains=None, exclude=None, tag_name=None):
     """
@@ -130,6 +157,7 @@ def get_attrib_xpath(schema_dict, name, contains=None, not_contains=None, exclud
 
     :param schema_dict: dict, containing all the path information and more
     :param name: str, name of the attribute
+    :param root_tag: str, name of the tag from which the path should be relative
     :param contains: str or list of str, this string has to be in the final path
     :param not_contains: str or list of str, this string has to NOT be in the final path
     :param exclude: list of str, here specific types of attributes can be excluded
@@ -154,15 +182,6 @@ def get_attrib_xpath(schema_dict, name, contains=None, not_contains=None, exclud
                 raise ValueError(err_msg)
         return f'{tag_xpath}/@{name}'
 
-    if contains is None:
-        contains = []
-    elif not isinstance(contains, (list, set)):
-        contains = [contains]
-
-    if not_contains is None:
-        not_contains = []
-    elif not isinstance(not_contains, (list, set)):
-        not_contains = [not_contains]
 
     possible_lists = ['unique_attribs', 'unique_path_attribs', 'other_attribs']
     output = False
@@ -176,41 +195,159 @@ def get_attrib_xpath(schema_dict, name, contains=None, not_contains=None, exclud
             possible_lists.remove(f'{list_name}_attribs')
             if output:
                 possible_lists.remove(f'iteration_{list_name}_attribs')
-    all_paths = []
-    for list_name in possible_lists:
-        if name in schema_dict[list_name]:
-            paths = schema_dict[list_name][name]
 
-            if not isinstance(paths, LockableList):
-                paths = [paths]
-            else:
-                paths = paths.get_unlocked()
 
-            invalid_paths = set()
-            for phrase in contains:
-                for xpath in paths:
-                    if phrase not in xpath:
-                        invalid_paths.add(xpath)
+    paths = _find_paths(schema_dict, name, possible_lists, contains=contains, not_contains=not_contains)
 
-            for phrase in not_contains:
-                for xpath in paths:
-                    if phrase in xpath:
-                        invalid_paths.add(xpath)
-
-            for invalid in invalid_paths:
-                paths.remove(invalid)
-
-            all_paths += paths
-
-    if len(all_paths) == 1:
-        return all_paths[0]
-    elif len(all_paths) == 0:
+    if len(paths) == 1:
+        return paths[0]
+    elif len(paths) == 0:
         raise ValueError(f'The attrib {name} has no possible paths with the current specification.\n'
                          f'contains: {contains}, not_contains: {not_contains}, exclude {exclude}')
     else:
         raise ValueError(f'The attrib {name} has multiple possible paths with the current specification.\n'
                          f'contains: {contains}, not_contains: {not_contains}, exclude {exclude}\n'
-                         f'These are possible: {all_paths}')
+                         f'These are possible: {paths}')
+
+def get_relative_attrib_xpath(schema_dict, name, root_tag, contains=None, not_contains=None, exclude=None, tag_name=None):
+    """
+    Tries to find a unique path from the schema_dict based on the given name of the tag
+    and additional further specifications
+
+    :param schema_dict: dict, containing all the path information and more
+    :param name: str, name of the tag
+    :param contains: str or list of str, this string has to be in the final path
+    :param not_contains: str or list of str, this string has to NOT be in the final path
+    :param exclude: list of str, here specific types of attributes can be excluded
+                    valid values are: settable, settable_contains, other
+    :param tag_name: str, if given this name will be used to find a path to a tag with the
+                     same name in :py:func:`get_relative_tag_xpath()`
+
+    :returns: str, xpath for the given tag
+
+    :raises ValueError: If no unique path could be found
+    """
+    from masci_tools.util.xml.common_functions import abs_to_rel_xpath
+
+    if tag_name is not None:
+        tag_xpath = get_relative_tag_xpath(schema_dict, tag_name, root_tag, contains=contains, not_contains=not_contains)
+
+        err_msg = f'No attribute {name} found at tag {tag_name}'
+        if tag_xpath in schema_dict['tag_info']:
+            if name not in schema_dict['tag_info'][tag_xpath]['attribs']:
+                raise ValueError(err_msg)
+        else:
+            if name not in schema_dict['iteration_tag_info'][tag_xpath]['attribs']:
+                raise ValueError(err_msg)
+        return f'{tag_xpath}/@{name}'
+
+
+    possible_lists = ['unique_attribs', 'unique_path_attribs', 'other_attribs']
+    output = False
+    if 'iteration_unique_attribs' in schema_dict:
+        #outputschema
+        output = True
+        possible_lists += ['iteration_unique_attribs', 'iteration_unique_path_attribs', 'iteration_other_attribs']
+
+    if exclude is not None:
+        for list_name in exclude:
+            possible_lists.remove(f'{list_name}_attribs')
+            if output:
+                possible_lists.remove(f'iteration_{list_name}_attribs')
+
+    #The paths have to include the root_tag
+    if contains is None:
+        contains = [root_tag]
+    else:
+        contains = set(contains)
+        contains.add(root_tag)
+
+    paths = _find_paths(schema_dict, name, possible_lists, contains=contains, not_contains=not_contains)
+
+    rel_paths = set()
+    for xpath in paths:
+        rel_paths.add(abs_to_rel_xpath(xpath, root_tag))
+
+    if len(rel_paths) == 1:
+        return rel_paths.pop()
+    elif len(rel_paths) == 0:
+        raise ValueError(f'The tag {name} has no possible relative paths with the current specification.\n'
+                         f'contains: {contains}, not_contains: {not_contains}, root_tag {root_tag}')
+    else:
+        raise ValueError(f'The tag {name} has multiple possible relative paths with the current specification.\n'
+                         f'contains: {contains}, not_contains: {not_contains}, root_tag {root_tag} \n'
+                         f'These are possible: {rel_paths}')
+
+
+def get_tag_info(schema_dict, name, contains=None, not_contains=None, path_return=True, convert_to_builtin=False, multiple_paths=False, parent=False):
+    """
+    Tries to find a unique path from the schema_dict based on the given name of the tag
+    and additional further specifications and returns the tag_info entry for this tag
+
+    :param schema_dict: dict, containing all the path information and more
+    :param name: str, name of the tag
+    :param contains: str or list of str, this string has to be in the final path
+    :param not_contains: str or list of str, this string has to NOT be in the final path
+    :param path_return: bool, if True the found path will be returned alongside the tag_info
+    :param convert_to_builtin: bool, if True the CaseInsensitiveFrozenSets are converetd to normal sets
+                               with the rigth case of the attributes
+    :param multiple_paths: bool, if True mulitple paths are allowed to match as long as they have the same tag_info
+    :param parent: bool, if True the tag_info for the parent of the tag is returned
+
+    :returns: dict, tag_info for the found xpath
+    :returns: str, xpath to the tag if `path_return=True`
+    """
+    import copy
+    from masci_tools.util.case_insensitive_dict import CaseInsensitiveFrozenSet
+    from masci_tools.util.xml.common_functions import split_off_tag
+
+    if multiple_paths:
+        possible_lists = ['tag_paths']
+
+        if 'iteration_tag_paths' in schema_dict:
+            possible_lists += ['iteration_tag_paths']
+
+        paths = _find_paths(schema_dict, name, possible_lists, contains=contains, not_contains=not_contains)
+    else:
+        paths = [get_tag_xpath(schema_dict, name, contains=contains, not_contains=not_contains)]
+
+    tag_info = None
+    for path in paths:
+
+        if parent:
+            path, _ = split_off_tag(path)
+
+        err_msg = f'Could not fing tag_info for {path}'
+        if path in schema_dict['tag_info']:
+            entry = schema_dict['tag_info'][path]
+        elif 'iteration_tag_info' in schema_dict:
+            if path in schema_dict['iteration_tag_info']:
+                entry = schema_dict['iteration_tag_info'][path]
+            else:
+                raise ValueError(err_msg)
+        else:
+            raise ValueError(err_msg)
+
+        if tag_info is not None:
+            if entry != tag_info:
+                raise ValueError(f'Differing tag_info for the found paths {paths}')
+        else:
+            tag_info = entry
+
+    if not multiple_paths:
+        paths = paths[0]
+
+
+    if convert_to_builtin:
+        tag_info = {
+            key: set(val.original_case.values()) if isinstance(val, CaseInsensitiveFrozenSet) else val
+            for key, val in tag_info.items()
+        }
+
+    if path_return:
+        return tag_info, paths
+    else:
+        return tag_info
 
 
 def read_constants(root, schema_dict, logger=None):
@@ -278,12 +415,13 @@ def evaluate_attribute(node, schema_dict, name, constants=None, logger=None, **k
     list_return = kwargs.pop('list_return', False)
     optional = kwargs.pop('optional', False)
 
+    attrib_xpath = None
     if isinstance(node, etree._Element):
         if node.tag != schema_dict['root_tag'] and node.tag != 'iteration':
-            kwargs['contains'] = set(kwargs.get('contains', []))
-            kwargs['contains'].add(node.tag)
+            attrib_xpath = get_relative_attrib_xpath(schema_dict, name, node.tag, **kwargs)
 
-    attrib_xpath = get_attrib_xpath(schema_dict, name, **kwargs)
+    if attrib_xpath is None:
+        attrib_xpath = get_attrib_xpath(schema_dict, name, **kwargs)
 
     stringattribute = eval_xpath(node, attrib_xpath, logger=logger, list_return=True)
 
@@ -341,12 +479,13 @@ def evaluate_text(node, schema_dict, name, constants, logger=None, **kwargs):
     list_return = kwargs.pop('list_return', False)
     optional = kwargs.pop('optional', False)
 
+    tag_xpath = None
     if isinstance(node, etree._Element):
         if node.tag != schema_dict['root_tag'] and node.tag != 'iteration':
-            kwargs['contains'] = set(kwargs.get('contains', []))
-            kwargs['contains'].add(node.tag)
+            tag_xpath = get_relative_tag_xpath(schema_dict, name, node.tag, **kwargs)
 
-    tag_xpath = get_tag_xpath(schema_dict, name, **kwargs)
+    if tag_xpath is None:
+        tag_xpath = get_tag_xpath(schema_dict, name, **kwargs)
 
     stringtext = eval_xpath(node, f'{tag_xpath}/text()', logger=logger, list_return=True)
 
@@ -412,22 +551,34 @@ def evaluate_tag(node, schema_dict, name, constants=None, logger=None, **kwargs)
     ignore = kwargs.pop('ignore', None)
     list_return = kwargs.pop('list_return', False)
 
+    tag_xpath = None
     if isinstance(node, etree._Element):
         if node.tag != schema_dict['root_tag'] and node.tag != 'iteration':
             kwargs['contains'] = set(kwargs.get('contains', []))
             kwargs['contains'].add(node.tag)
+            tag_xpath = get_relative_tag_xpath(schema_dict, name, node.tag, **kwargs)
 
-    tag_xpath = get_tag_xpath(schema_dict, name, **kwargs)
+    if tag_xpath is None:
+        tag_xpath = get_tag_xpath(schema_dict, name, **kwargs)
+
 
     #Which attributes are expected
-    attribs = set()
-    if tag_xpath in schema_dict['tag_info']:
-        attribs = schema_dict['tag_info'][tag_xpath]['attribs']
-        optional = schema_dict['tag_info'][tag_xpath]['optional_attribs']
-    elif 'iteration_tag_info' in schema_dict:
-        if tag_xpath in schema_dict['iteration_tag_info']:
-            attribs = schema_dict['iteration_tag_info'][tag_xpath]['attribs']
-            optional = schema_dict['iteration_tag_info'][tag_xpath]['optional_attribs']
+    try:
+        tag_info = get_tag_info(schema_dict, name, path_return=False, multiple_paths=True, **kwargs)
+        attribs = tag_info['attribs']
+        optional = tag_info['optional_attribs']
+    except ValueError as err:
+        if logger is None:
+            raise ValueError(f'Failed to evaluate attributes from tag {name}: '
+                             'No attributes to parse either the tag does not '
+                             'exist or it has no attributes') from err
+        else:
+            logger.exception(
+                'Failed to evaluate attributes from tag %s: '
+                'No attributes to parse either the tag does not '
+                'exist or it has no attributes', name)
+        attribs = set()
+        optional = set()
 
     if only_required:
         attribs = attribs.difference(optional)
@@ -556,24 +707,33 @@ def evaluate_parent_tag(node, schema_dict, name, constants=None, logger=None, **
     only_required = kwargs.pop('only_required', False)
     ignore = kwargs.pop('ignore', None)
 
+    tag_xpath = None
     if isinstance(node, etree._Element):
         if node.tag != schema_dict['root_tag'] and node.tag != 'iteration':
             kwargs['contains'] = set(kwargs.get('contains', []))
             kwargs['contains'].add(node.tag)
+            tag_xpath = get_relative_tag_xpath(schema_dict, name, node.tag, **kwargs)
 
-    tag_xpath = get_tag_xpath(schema_dict, name, **kwargs)
-
-    parent_xpath = '/'.join(tag_xpath.split('/')[:-1])
+    if tag_xpath is None:
+        tag_xpath = get_tag_xpath(schema_dict, name, **kwargs)
 
     #Which attributes are expected
-    attribs = set()
-    if parent_xpath in schema_dict['tag_info']:
-        attribs = schema_dict['tag_info'][parent_xpath]['attribs']
-        optional = schema_dict['tag_info'][parent_xpath]['optional_attribs']
-    elif 'iteration_tag_info' in schema_dict:
-        if parent_xpath in schema_dict['iteration_tag_info']:
-            attribs = schema_dict['iteration_tag_info'][parent_xpath]['attribs']
-            optional = schema_dict['iteration_tag_info'][parent_xpath]['optional_attribs']
+    try:
+        tag_info = get_tag_info(schema_dict, name, path_return=False, multiple_paths=True, parent=True, **kwargs)
+        attribs = tag_info['attribs']
+        optional = tag_info['optional_attribs']
+    except ValueError as err:
+        if logger is None:
+            raise ValueError(f'Failed to evaluate attributes from parent tag of {name}: '
+                             'No attributes to parse either the tag does not '
+                             'exist or it has no attributes') from err
+        else:
+            logger.exception(
+                'Failed to evaluate attributes from parent tag of %s: '
+                'No attributes to parse either the tag does not '
+                'exist or it has no attributes', name)
+        attribs = set()
+        optional = set()
 
     if only_required:
         attribs = attribs.difference(optional)
@@ -655,7 +815,14 @@ def attrib_exists(node, schema_dict, name, logger=None, **kwargs):
     """
     from masci_tools.util.xml.common_functions import eval_xpath, split_off_attrib
 
-    attrib_xpath = get_attrib_xpath(schema_dict, name, **kwargs)
+    attrib_xpath = None
+    if isinstance(node, etree._Element):
+        if node.tag != schema_dict['root_tag'] and node.tag != 'iteration':
+            attrib_xpath = get_relative_attrib_xpath(schema_dict, name, node.tag, **kwargs)
+
+    if attrib_xpath is None:
+        attrib_xpath = get_attrib_xpath(schema_dict, name, **kwargs)
+
     tag_xpath, attrib_name = split_off_attrib(attrib_xpath)
 
     tags = eval_xpath(node, tag_xpath, logger=logger, list_return=True)
@@ -724,11 +891,12 @@ def eval_simple_xpath(node, schema_dict, name, logger=None, **kwargs):
 
     list_return = kwargs.pop('list_return', False)
 
+    tag_xpath = None
     if isinstance(node, etree._Element):
         if node.tag != schema_dict['root_tag'] and node.tag != 'iteration':
-            kwargs['contains'] = set(kwargs.get('contains', []))
-            kwargs['contains'].add(node.tag)
+            tag_xpath = get_relative_tag_xpath(schema_dict, name, node.tag, **kwargs)
 
-    tag_xpath = get_tag_xpath(schema_dict, name, **kwargs)
+    if tag_xpath is None:
+        tag_xpath = get_tag_xpath(schema_dict, name, **kwargs)
 
     return eval_xpath(node, tag_xpath, logger=logger, list_return=list_return)

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -145,15 +145,6 @@ def eval_xpath(node, xpath, logger=None, list_return=False, namespaces=None):
             logger.error('Wrong Type for xpath eval; Got: %s', type(node))
         raise TypeError(f'Wrong Type for xpath eval; Got: {type(node)}')
 
-    if isinstance(node, etree._Element):
-        if node.tag != xpath.split('/')[1] and xpath.split('/')[0] != '.':
-            #absolute path with a different root tag than node
-            if node.tag in xpath:
-                if '@' not in xpath:
-                    xpath = xpath + '/'
-                xpath = xpath.replace('/'.join(xpath.split(node.tag + '/')[:-1]) + node.tag, '.')
-                xpath = xpath.rstrip('/')
-
     try:
         return_value = node.xpath(xpath, namespaces=namespaces)
     except etree.XPathEvalError as err:
@@ -245,3 +236,26 @@ def check_complex_xpath(node, base_xpath, complex_xpath):
 
     if not results_base.issuperset(results_complex):
         raise ValueError(f"Complex xpath '{complex_xpath}' is not compatible with the base_xpath '{base_xpath}'")
+
+def abs_to_rel_xpath(xpath, new_root):
+    """
+    Convert a given xpath to be relative from a tag appearing in the
+    original xpath.
+
+    :param xpath: str of the xpath to convert
+    :param new_root: str of the tag from which the new xpath should be relative
+
+    :returns: str of the relative xpath
+    """
+    if new_root in xpath:
+        if '@' not in xpath:
+            xpath = xpath + '/'
+
+        xpath_to_root = '/'.join(xpath.split(new_root + '/')[:-1]) + new_root
+        xpath = xpath.replace(xpath_to_root, '.')
+        if xpath != './':
+            xpath = xpath.rstrip('/')
+    else:
+        raise ValueError(f'New root element {new_root} does not appear in xpath {xpath}')
+
+    return xpath

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -237,6 +237,7 @@ def check_complex_xpath(node, base_xpath, complex_xpath):
     if not results_base.issuperset(results_complex):
         raise ValueError(f"Complex xpath '{complex_xpath}' is not compatible with the base_xpath '{base_xpath}'")
 
+
 def abs_to_rel_xpath(xpath, new_root):
     """
     Convert a given xpath to be relative from a tag appearing in the


### PR DESCRIPTION
This PR expands the capabilities of the schema_dict_util functions, when handling nodes, that are not on the root of the XML file. Previously the tag of the node was taken as a constraint and `eval_xpath` converted the absolute xpath from the schema dictionary to a relative xpath starting from that tag.

Unfortunately this works only on one level. Consider the following examples for extracting the Hubbard U from a ldaU tag

```python
#Read in xmltree and load schema_dict before

from masci_tools.util.schema_dict_util import eval_simple_xpath, evaluate_attribute

species_elems = eval_simple_xpath(xmltree, schema_dict, 'species', list_return=True)

for species in species_elems:
     print(evaluate_attribute(species, schema_dict, 'U', contains='ldaU', constants=constants))
```

```python
#Read in xmltree and load schema_dict before

from masci_tools.util.schema_dict_util import eval_simple_xpath, evaluate_attribute

ldau_elems = eval_simple_xpath(xmltree, schema_dict, 'ldaU', contains='species', list_return=True)

for ldau in ldau_elems:
     print(evaluate_attribute(ldau, schema_dict, 'U', constants=constants))
```

The first code will work, since the species tag uniquely identifies that we are interested in the species elements

The second example will not work since the schema_dict cannot determine, which of the two paths (species or group) should be taken. But in this case this should not matter because the resulting relative xpath is exactly the same.

For this reason the schema_dict_util module has two new functions `get_relative_tag_xpath` and `get_relative_attrib_xpath`, which convert the absolute paths to start from the given node tag and only then is uniqueness enforced. These are used in all parsing functions in the module for the case of relative paths. get_tag_info now can return the tag_info, even if multiple xpaths are possible as long as the information in tag_info is the same. 