### PR TITLE
Release 0.4.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.4
+current_version = 0.4.5
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/masci_tools/__init__.py
+++ b/masci_tools/__init__.py
@@ -13,6 +13,6 @@ masci-tools
 '''
 import logging
 
-__version__ = '0.4.4'
+__version__ = '0.4.5'
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
@@ -97,7 +97,7 @@ def inpxml_parser(inpxmlfile, version=None, parser_info_out=None, strict=False, 
 
     ignore_validation = schema_dict['inp_version'] != version
 
-    xmltree = clear_xml(xmltree)
+    xmltree, _ = clear_xml(xmltree)
     root = xmltree.getroot()
 
     constants = read_constants(root, schema_dict, logger=logger)

--- a/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
@@ -200,7 +200,7 @@ def outxml_parser(outxmlfile,
     if logger is not None:
         logger.info('Found fleur out file with the versions out: %s; inp: %s', out_version, inp_version)
 
-    xmltree = clear_xml(xmltree)
+    xmltree, _ = clear_xml(xmltree)
     root = xmltree.getroot()
 
     errmsg = ''
@@ -235,7 +235,6 @@ def outxml_parser(outxmlfile,
                                                     logger=logger,
                                                     iteration_to_parse=iteration_to_parse,
                                                     **kwargs)
-
 
     out_dict['input_file_version'] = outschema_dict['inp_version']
     # get all iterations in out.xml file

--- a/masci_tools/io/parsers/fleur/fleur_schema/add_fleur_schema.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/add_fleur_schema.py
@@ -35,7 +35,7 @@ def add_fleur_schema(path, overwrite=False):
     schema_path = os.path.join(path, 'FleurInputSchema.xsd')
     if os.path.isfile(schema_path):
         xmlschema = etree.parse(schema_path)
-        xmlschema = clear_xml(xmlschema)
+        xmlschema, _ = clear_xml(xmlschema)
 
         namespaces = {'xsd': 'http://www.w3.org/2001/XMLSchema'}
         inp_version = xmlschema.xpath('/xsd:schema/@version', namespaces=namespaces)[0]
@@ -55,7 +55,7 @@ def add_fleur_schema(path, overwrite=False):
     schema_path = os.path.join(path, 'FleurOutputSchema.xsd')
     if os.path.isfile(schema_path):
         xmlschema = etree.parse(schema_path)
-        xmlschema = clear_xml(xmlschema)
+        xmlschema, _ = clear_xml(xmlschema)
 
         namespaces = {'xsd': 'http://www.w3.org/2001/XMLSchema'}
         out_version = xmlschema.xpath('/xsd:schema/@version', namespaces=namespaces)[0]

--- a/masci_tools/io/parsers/fleur/fleur_schema/inpschema_todict.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/inpschema_todict.py
@@ -46,7 +46,7 @@ def create_inpschema_dict(path):
 
     #print(f'processing: {path}/FleurInputSchema.xsd')
     xmlschema = etree.parse(path)
-    xmlschema = clear_xml(xmlschema)
+    xmlschema, _ = clear_xml(xmlschema)
 
     namespaces = {'xsd': 'http://www.w3.org/2001/XMLSchema'}
     inp_version = str(xmlschema.xpath('/xsd:schema/@version', namespaces=namespaces)[0])

--- a/masci_tools/io/parsers/fleur/fleur_schema/outschema_todict.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/outschema_todict.py
@@ -54,7 +54,7 @@ def create_outschema_dict(path, inp_path=None, inpschema_dict=None):
 
     #print(f'processing: {path}/FleurOutputSchema.xsd')
     xmlschema = etree.parse(path)
-    xmlschema = clear_xml(xmlschema)
+    xmlschema, _ = clear_xml(xmlschema)
 
     namespaces = {'xsd': 'http://www.w3.org/2001/XMLSchema'}
     out_version = str(xmlschema.xpath('/xsd:schema/@version', namespaces=namespaces)[0])
@@ -66,7 +66,7 @@ def create_outschema_dict(path, inp_path=None, inpschema_dict=None):
             inp_path = path.replace('FleurOutputSchema', 'FleurInputSchema')
         #Parse type definitions directly from inputSchema
         inpxmlschema = etree.parse(inp_path)
-        inpxmlschema = clear_xml(inpxmlschema)
+        inpxmlschema, _ = clear_xml(inpxmlschema)
         input_basic_types = get_basic_types(inpxmlschema, namespaces)
 
     schema_dict = {}

--- a/masci_tools/tests/test_xml_common_functions.py
+++ b/masci_tools/tests/test_xml_common_functions.py
@@ -128,6 +128,8 @@ def test_reverse_xinclude(load_inpxml):
                               namespaces={'xi': 'http://www.w3.org/2001/XInclude'},
                               list_return=True)
     assert len(include_tags) == 2
+    assert [tag.attrib['href'] for tag in include_tags] == ['sym.xml', 'relax.xml']
+
 
     symmetry_tags = eval_xpath(cleared_root, '//symOp', list_return=True)
     assert len(symmetry_tags) == 16

--- a/masci_tools/tests/test_xml_common_functions.py
+++ b/masci_tools/tests/test_xml_common_functions.py
@@ -130,7 +130,6 @@ def test_reverse_xinclude(load_inpxml):
     assert len(include_tags) == 2
     assert [tag.attrib['href'] for tag in include_tags] == ['sym.xml', 'relax.xml']
 
-
     symmetry_tags = eval_xpath(cleared_root, '//symOp', list_return=True)
     assert len(symmetry_tags) == 16
 

--- a/masci_tools/tests/test_xml_setters_names.py
+++ b/masci_tools/tests/test_xml_setters_names.py
@@ -170,6 +170,7 @@ def test_set_attrib_value_xcFunctional(load_inpxml):
 
     assert res == 'TEST'
 
+
 def test_set_attrib_forcetheorem_angles(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_names import set_attrib_value
@@ -179,7 +180,7 @@ def test_set_attrib_forcetheorem_angles(load_inpxml):
 
     set_attrib_value(xmltree, schema_dict, 'theta', 5.321, contains='DMI', create=True)
     assert eval_xpath(root, '/fleurInput/forceTheorem/DMI/@theta') == '5.3210000000'
-    set_attrib_value(xmltree, schema_dict, 'phi', [1,2,3.14], contains='DMI', create=True)
+    set_attrib_value(xmltree, schema_dict, 'phi', [1, 2, 3.14], contains='DMI', create=True)
     assert eval_xpath(root, '/fleurInput/forceTheorem/DMI/@phi') == '1.0000000000 2.0000000000 3.1400000000'
     set_attrib_value(xmltree, schema_dict, 'ef_shift', [10.0], contains='DMI', create=True)
     assert eval_xpath(root, '/fleurInput/forceTheorem/DMI/@ef_shift') == '10.0000000000'

--- a/masci_tools/tests/test_xml_setters_names.py
+++ b/masci_tools/tests/test_xml_setters_names.py
@@ -170,6 +170,20 @@ def test_set_attrib_value_xcFunctional(load_inpxml):
 
     assert res == 'TEST'
 
+def test_set_attrib_forcetheorem_angles(load_inpxml):
+    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.xml_setters_names import set_attrib_value
+
+    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH)
+    root = xmltree.getroot()
+
+    set_attrib_value(xmltree, schema_dict, 'theta', 5.321, contains='DMI', create=True)
+    assert eval_xpath(root, '/fleurInput/forceTheorem/DMI/@theta') == '5.3210000000'
+    set_attrib_value(xmltree, schema_dict, 'phi', [1,2,3.14], contains='DMI', create=True)
+    assert eval_xpath(root, '/fleurInput/forceTheorem/DMI/@phi') == '1.0000000000 2.0000000000 3.1400000000'
+    set_attrib_value(xmltree, schema_dict, 'ef_shift', [10.0], contains='DMI', create=True)
+    assert eval_xpath(root, '/fleurInput/forceTheorem/DMI/@ef_shift') == '10.0000000000'
+
 
 def test_set_attrib_value_specification(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -168,7 +168,7 @@ def reverse_xinclude(xmltree, schema_dict, included_tags, **kwargs):
 
     if 'relax.xml' not in included_trees:
         #The relax.xml include should always be there
-        xinclude_elem = etree.Element(INCLUDE_TAG, href=file_name, nsmap=INCLUDE_NSMAP)
+        xinclude_elem = etree.Element(INCLUDE_TAG, href='relax.xml', nsmap=INCLUDE_NSMAP)
         xinclude_elem.append(etree.Element(FALLBACK_TAG))
         root.append(xinclude_elem)
 

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -338,9 +338,7 @@ def abs_to_rel_xpath(xpath, new_root):
     :returns: str of the relative xpath
     """
     if new_root in xpath:
-        if '@' not in xpath:
-            xpath = xpath + '/'
-
+        xpath = xpath + '/'
         xpath_to_root = '/'.join(xpath.split(new_root + '/')[:-1]) + new_root
         xpath = xpath.replace(xpath_to_root, '.')
         xpath = xpath.rstrip('/')

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -109,6 +109,8 @@ def reverse_xinclude(xmltree, schema_dict, included_tags, **kwargs):
         - `relaxation`: ``relax.xml``
         - `kPointLists`: ``kpts.xml``
         - `symmetryOperations`: ``sym.xml``
+        - `atomSpecies`: ``species.xml``
+        - `atomGroups`: ``atoms.xml``
 
     Additional mappings can be given in the keyword arguments
 
@@ -130,7 +132,13 @@ def reverse_xinclude(xmltree, schema_dict, included_tags, **kwargs):
 
     excluded_tree = copy.deepcopy(xmltree)
 
-    include_file_names = {'relaxation': 'relax.xml', 'kPointLists': 'kpts.xml', 'symmetryOperations': 'sym.xml'}
+    include_file_names = {
+        'relaxation': 'relax.xml',
+        'kPointLists': 'kpts.xml',
+        'symmetryOperations': 'sym.xml',
+        'atomSpecies': 'species.xml',
+        'atomGroups': 'atoms.xml'
+    }
 
     include_file_names = {**include_file_names, **kwargs}
 

--- a/masci_tools/util/xml/converters.py
+++ b/masci_tools/util/xml/converters.py
@@ -115,8 +115,9 @@ def convert_attribute_to_xml(attributevalue, possible_types, logger=None, float_
 
     :return: The converted str of the value of the first succesful conversion
     """
+    import numpy as np
 
-    if not isinstance(attributevalue, list):
+    if not isinstance(attributevalue, (list, np.ndarray)):
         attributevalue = [attributevalue]
 
     possible_types = possible_types.copy()
@@ -264,17 +265,18 @@ def convert_text_to_xml(textvalue, possible_definitions, logger=None, float_form
 
     :return: The converted value of the first succesful conversion
     """
+    import numpy as np
 
-    if not isinstance(textvalue, list):
+    if not isinstance(textvalue, (list, np.ndarray)):
         textvalue = [textvalue]
-    elif not isinstance(textvalue[0], list):
+    elif not isinstance(textvalue[0], (list, np.ndarray)):
         textvalue = [textvalue]
 
     converted_list = []
     all_success = True
     for text in textvalue:
 
-        if not isinstance(text, list):
+        if not isinstance(text, (list, np.ndarray)):
             text = [text]
 
         text_definition = None

--- a/masci_tools/util/xml/xml_getters.py
+++ b/masci_tools/util/xml/xml_getters.py
@@ -50,7 +50,7 @@ def get_fleur_modes(xmltree, schema_dict, logger=None):
     from masci_tools.util.xml.common_functions import clear_xml
 
     if isinstance(xmltree, etree._ElementTree):
-        xmltree = clear_xml(xmltree)
+        xmltree, _ = clear_xml(xmltree)
         root = xmltree.getroot()
     else:
         root = xmltree
@@ -123,7 +123,7 @@ def get_nkpts(xmltree, schema_dict, logger=None):
     from masci_tools.util.xml.common_functions import clear_xml
 
     if isinstance(xmltree, etree._ElementTree):
-        xmltree = clear_xml(xmltree)
+        xmltree, _ = clear_xml(xmltree)
         root = xmltree.getroot()
     else:
         root = xmltree
@@ -173,7 +173,7 @@ def get_nkpts_max4(xmltree, schema_dict, logger=None):
     import warnings
 
     if isinstance(xmltree, etree._ElementTree):
-        xmltree = clear_xml(xmltree)
+        xmltree, _ = clear_xml(xmltree)
         root = xmltree.getroot()
     else:
         root = xmltree
@@ -251,7 +251,7 @@ def get_cell(xmltree, schema_dict, logger=None):
     import numpy as np
 
     if isinstance(xmltree, etree._ElementTree):
-        xmltree = clear_xml(xmltree)
+        xmltree, _ = clear_xml(xmltree)
         root = xmltree.getroot()
     else:
         root = xmltree
@@ -335,7 +335,7 @@ def get_parameter_data(xmltree, schema_dict, inpgen_ready=True, write_ids=True, 
     ########
     parameters = {}
     if isinstance(xmltree, etree._ElementTree):
-        xmltree = clear_xml(xmltree)
+        xmltree, _ = clear_xml(xmltree)
         root = xmltree.getroot()
     else:
         root = xmltree
@@ -519,7 +519,7 @@ def get_structure_data(xmltree, schema_dict, logger=None):
     from masci_tools.io.common_functions import rel_to_abs, rel_to_abs_f
 
     if isinstance(xmltree, etree._ElementTree):
-        xmltree = clear_xml(xmltree)
+        xmltree, _ = clear_xml(xmltree)
         root = xmltree.getroot()
     else:
         root = xmltree
@@ -644,7 +644,7 @@ def get_kpoints_data(xmltree, schema_dict, name=None, logger=None):
     from masci_tools.util.xml.converters import convert_xml_attribute
 
     if isinstance(xmltree, etree._ElementTree):
-        xmltree = clear_xml(xmltree)
+        xmltree, _ = clear_xml(xmltree)
         root = xmltree.getroot()
     else:
         root = xmltree
@@ -733,7 +733,7 @@ def get_kpoints_data_max4(xmltree, schema_dict, logger=None):
     from masci_tools.util.xml.converters import convert_xml_attribute
 
     if isinstance(xmltree, etree._ElementTree):
-        xmltree = clear_xml(xmltree)
+        xmltree, _ = clear_xml(xmltree)
         root = xmltree.getroot()
     else:
         root = xmltree
@@ -802,7 +802,7 @@ def get_relaxation_information(xmltree, schema_dict, logger=None):
     from masci_tools.util.xml.common_functions import clear_xml
 
     if isinstance(xmltree, etree._ElementTree):
-        xmltree = clear_xml(xmltree)
+        xmltree, _ = clear_xml(xmltree)
         root = xmltree.getroot()
     else:
         root = xmltree

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -84,7 +84,7 @@ def xml_delete_tag(xmltree, xpath):
     return xmltree
 
 
-def xml_create_tag(xmltree, xpath, element, place_index=None, tag_order=None, occurrences=None, correct_order=True):
+def xml_create_tag(xmltree, xpath, element, place_index=None, tag_order=None, occurrences=None, correct_order=True, several=True):
     """
     This method evaluates an xpath expression and creates a tag in a xmltree under the
     returned nodes.
@@ -103,6 +103,7 @@ def xml_create_tag(xmltree, xpath, element, place_index=None, tag_order=None, oc
     :param correct_order: bool, if True (default) and a tag_order is given, that does not correspond to the given order
                           in the xmltree (only order wrong no unknown tags) it will be corrected and a warning is given
                           This is necessary for some edge cases of the xml schemas of fleur
+    :param several: bool, if True multiple tags od the given name are allowed
 
     :raises ValueError: If the insertion failed in any way (tag_order does not match, failed to insert, ...)
 
@@ -156,6 +157,9 @@ def xml_create_tag(xmltree, xpath, element, place_index=None, tag_order=None, oc
             extra_tags = set(existing_order).difference(set(tag_order))
             if extra_tags:
                 raise ValueError(f'Did not find existing elements in the tag_order list: {extra_tags}')
+
+            if element_name in existing_order and not several:
+                raise ValueError(f'The given tag {element_name} is not allowed to appear multiple times')
 
             #Is the existing order in line with the given tag_order
             if sorted(existing_order, key=tag_order.index) != existing_order:
@@ -256,7 +260,7 @@ def xml_set_attrib_value_no_create(xmltree, xpath, attributename, attribv, occur
 
     if is_sequence(attribv):
         if len(attribv) != len(nodes):
-            raise ValueError(f'Wrong length for attribute values. Expected {len(nodes)} items. Got: {attribv}')
+            raise ValueError(f'Wrong length for attribute values. Expected {len(nodes)} items. Got: {len(attribv)}')
     else:
         attribv = [attribv] * len(nodes)
 

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -84,7 +84,14 @@ def xml_delete_tag(xmltree, xpath):
     return xmltree
 
 
-def xml_create_tag(xmltree, xpath, element, place_index=None, tag_order=None, occurrences=None, correct_order=True, several=True):
+def xml_create_tag(xmltree,
+                   xpath,
+                   element,
+                   place_index=None,
+                   tag_order=None,
+                   occurrences=None,
+                   correct_order=True,
+                   several=True):
     """
     This method evaluates an xpath expression and creates a tag in a xmltree under the
     returned nodes.

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -202,6 +202,14 @@ def xml_set_attrib_value(xmltree,
 
     converted_attribv, suc = convert_attribute_to_xml(attribv, schema_dict['attrib_types'][attributename])
 
+    if '/fleurInput/forceTheorem/' in base_xpath and attributename in ('theta', 'phi', 'ef_shift'):
+        #Special case for theta and phi attributes on forceTheorem tags
+        #In Max5/5.1 They are entered as FleurDouble but can be a list. Since
+        #the attribute setting so far does not support this we convert the values explicitely
+        #here
+        if isinstance(converted_attribv, list):
+            converted_attribv = ' '.join(converted_attribv)
+
     return xml_set_attrib_value_no_create(xmltree, xpath, attributename, converted_attribv, occurrences=occurrences)
 
 

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -70,6 +70,8 @@ def xml_create_tag_schema_dict(xmltree,
     else:
         tag_order = tag_info['order']
 
+    several_tags = element_name in tag_info['several']
+
     parent_nodes = eval_xpath(xmltree, xpath, list_return=True)
 
     if len(parent_nodes) == 0:
@@ -86,7 +88,7 @@ def xml_create_tag_schema_dict(xmltree,
             raise ValueError(f"Could not create tag '{element_name}' because atleast one subtag is missing. "
                              'Use create=True to create the subtags')
 
-    return xml_create_tag(xmltree, xpath, element, tag_order=tag_order, occurrences=occurrences)
+    return xml_create_tag(xmltree, xpath, element, tag_order=tag_order, occurrences=occurrences, several=several_tags)
 
 
 def eval_xpath_create(xmltree,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [tool.poetry]
 name = "masci_tools"
-version = "0.4.4"
+version = "0.4.5"
 description = "Tools for Materials science. Vis contains wrapers of matplotlib functionality to visualalize common material science data. Plus wrapers of visualisation for aiida-fleur workflow nodes"
 readme = "README.md"
 authors = ["Jens Bröder <j.broeder@fz-juelich.de>",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf8') as f:
 if __name__ == '__main__':
     setup(
         name='masci_tools',
-        version='0.4.4',
+        version='0.4.5',
         description='Tools for Materials science. Vis contains wrappers of matplotlib functionality to visualize common material science data. Plus wrappers of visualisation for aiida-fleur workflow nodes',
         # add long_description from readme.md:
         long_description = long_description, # add contents of README.md


### PR DESCRIPTION
This Release contains:
- various bugfixes for xml modifying functions
- A special case for `theta`, `phi` and `ef_shift` attributes of `forceTheorem` tags, since they are not correctly typed in the Inputschema
- Introduced function to split a xmltree back up into the included subtrees and the main tree with `xi: include` tags
- `clear_xml` now returns a set of the tags, that were included