### PR TITLE
Release 0.4.6

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.5
+current_version = 0.4.6
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?

--- a/masci_tools/__init__.py
+++ b/masci_tools/__init__.py
@@ -13,6 +13,6 @@ masci-tools
 '''
 import logging
 
-__version__ = '0.4.5'
+__version__ = '0.4.6'
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_add_tasks_append.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_add_tasks_append.yml
@@ -21,6 +21,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_add_tasks_overwrite.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_add_tasks_overwrite.yml
@@ -20,6 +20,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_additional_tasks_allattribs.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_additional_tasks_allattribs.yml
@@ -28,6 +28,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_additional_tasks_simple.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_additional_tasks_simple.yml
@@ -22,6 +22,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_alliter.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_alliter.yml
@@ -69,6 +69,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken.yml
@@ -23,6 +23,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false
@@ -82,11 +83,14 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 2, ''noco'': True, ''soc'':
-    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'': ''hist''}'
+    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''hist''}'
   - The last parsed iteration is 2
   parser_warnings:
   - The out.xml file is broken I try to repair it.
+  - No values found for attribute potential
+  - No values found for attribute chargeDensity
   - No values found for attribute date at tag endDateAndTime
   - No values found for attribute time at tag endDateAndTime
   - Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken_firstiter.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_broken_firstiter.yml
@@ -21,6 +21,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false
@@ -67,11 +68,14 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 2, ''noco'': True, ''soc'':
-    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'': ''hist''}'
+    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''hist''}'
   - The last parsed iteration is 1
   parser_warnings:
   - The out.xml file is broken I try to repair it.
+  - No values found for attribute potential
+  - No values found for attribute chargeDensity
   - No values found for attribute date at tag endDateAndTime
   - No values found for attribute time at tag endDateAndTime
   - Endtime was unparsed, inp.xml prob not complete, do not believe the walltime!

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_differing_versions.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_differing_versions.yml
@@ -23,6 +23,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false
@@ -92,6 +93,9 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 2, ''noco'': True, ''soc'':
-    True, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'': ''hist''}'
-  parser_warnings: []
+    True, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''hist''}'
+  parser_warnings:
+  - No values found for attribute potential
+  - No values found for attribute chargeDensity

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_firstiter.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_firstiter.yml
@@ -21,6 +21,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_force.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_force.yml
@@ -8,6 +8,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: true
     force_theorem: true

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_garbage_values.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_garbage_values.yml
@@ -7,13 +7,16 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 2, ''noco'': False, ''soc'':
-    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'': ''tetra''}'
+    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''tetra''}'
   parser_warnings:
   - "Output file does not validate against the schema: \nLine 591: Element 'FermiEnergy',\
     \ attribute 'value': 'NAN' is not a valid value of the atomic type 'xs:double'.\
     \ \nLine 624: Element 'magneticMoment', attribute 'moment': '********' is not\
     \ a valid value of the atomic type 'xs:double'. \n"
+  - No values found for attribute potential
+  - No values found for attribute chargeDensity
   - '[Iteration 1] Could not convert ''********''. The following errors occurred:'
   - '[Iteration 1]    could not convert string to float: ''********'''
   - '[Iteration 1] Failed to evaluate attribute moment, Got value: [''********'']'

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_indexiter.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_indexiter.yml
@@ -21,6 +21,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_lastiter.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_lastiter.yml
@@ -21,6 +21,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_ldaurelax.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_ldaurelax.yml
@@ -54,6 +54,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_magnetic.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_magnetic.yml
@@ -57,6 +57,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max3_1compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max3_1compatibility.yml
@@ -201,6 +201,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false
@@ -711,8 +712,9 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 2, ''noco'': True, ''soc'':
-    True, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'': ''hist''}'
+    True, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''hist''}'
   parser_warnings:
   - Ignoring '0.27' outputVersion for MaX3.1 release
   - "Output file does not validate against the schema: \nLine 16: Element 'inputData':\

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max4compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max4compatibility.yml
@@ -117,6 +117,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false
@@ -254,8 +255,9 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 1, ''noco'': False, ''soc'':
-    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': True, ''dos'': False, ''band'': False, ''bz_integration'': ''hist''}'
+    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': True, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''hist''}'
   parser_warnings:
   - Ignoring '0.27' outputVersion for MaX4.0 release
   - "Output file does not validate against the schema: \nLine 17: Element 'inputData':\

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max5_0_compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max5_0_compatibility.yml
@@ -117,6 +117,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false
@@ -267,8 +268,9 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 1, ''noco'': False, ''soc'':
-    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': True, ''dos'': False, ''band'': False, ''bz_integration'': ''hist''}'
+    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': True, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''hist''}'
   parser_warnings:
   - Ignoring '0.27' outputVersion for MaX5.0 release
   - "Output file does not validate against the schema: \nLine 131: Element 'kPointList',\
@@ -276,3 +278,5 @@ warnings:
     \ 'kPointList': The attribute 'weightScale' is required but missing. \nLine 135:\
     \ Element 'spinDependentCharge': This element is not expected. \n"
   - No values found for attribute l_f
+  - No values found for attribute potential
+  - No values found for attribute chargeDensity

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_minimal_mode.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_minimal_mode.yml
@@ -32,6 +32,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_newer_version.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_newer_version.yml
@@ -23,6 +23,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false
@@ -82,8 +83,9 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 2, ''noco'': True, ''soc'':
-    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'': ''hist''}'
+    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''hist''}'
   parser_warnings:
   - No Output Schema available for version '0.36'; falling back to '0.34'
   - No Input Schema available for version '0.36'; falling back to '0.34'
@@ -92,3 +94,5 @@ warnings:
     \ an element of the set {'0.34'}. \nLine 16: Element 'fleurInput', attribute 'fleurInputVersion':\
     \ [facet 'enumeration'] The value '0.36' is not an element of the set {'0.34'}.\
     \ \n"
+  - No values found for attribute potential
+  - No values found for attribute chargeDensity

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_pre_max3_1compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_pre_max3_1compatibility.yml
@@ -57,6 +57,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: hist
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false
@@ -155,8 +156,9 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 2, ''noco'': True, ''soc'':
-    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'': ''hist''}'
+    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''hist''}'
   parser_warnings:
   - Found version before MaX3.1 release falling back to file version '0.29'
   - "Output file does not validate against the schema: \nLine 14: Element 'inputData':\

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_validation_errors.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_validation_errors.yml
@@ -21,6 +21,7 @@ output_dict:
   fleur_modes:
     band: false
     bz_integration: tetra
+    cf_coeff: false
     dos: false
     film: false
     force_theorem: false
@@ -74,9 +75,12 @@ warnings:
     0.017453292519943295, ''Ang'': 1.889726124772898, ''nm'': 18.89726124772898, ''pm'':
     0.01889726124772898, ''Bohr'': 1.0}'
   - 'The following Fleur modes were found: {''jspin'': 2, ''noco'': False, ''soc'':
-    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''film'': False,
-    ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'': ''tetra''}'
+    False, ''relax'': False, ''gw'': False, ''force_theorem'': False, ''cf_coeff'':
+    False, ''film'': False, ''ldau'': False, ''dos'': False, ''band'': False, ''bz_integration'':
+    ''tetra''}'
   parser_warnings:
   - "Output file does not validate against the schema: \nLine 346: Element 'kPointList',\
     \ attribute 'weightSc': The attribute 'weightSc' is not allowed. \nLine 346: Element\
     \ 'kPointList': The attribute 'weightScale' is required but missing. \n"
+  - No values found for attribute potential
+  - No values found for attribute chargeDensity

--- a/masci_tools/tests/test_xml_getters/test_fleur_modes_bulk.yml
+++ b/masci_tools/tests/test_xml_getters/test_fleur_modes_bulk.yml
@@ -1,5 +1,6 @@
 band: false
 bz_integration: hist
+cf_coeff: false
 dos: false
 film: false
 force_theorem: false

--- a/masci_tools/tests/test_xml_getters/test_fleur_modes_film.yml
+++ b/masci_tools/tests/test_xml_getters/test_fleur_modes_film.yml
@@ -1,5 +1,6 @@
 band: false
 bz_integration: hist
+cf_coeff: false
 dos: false
 film: true
 force_theorem: true

--- a/masci_tools/tests/test_xml_getters/test_fleur_modes_max4.yml
+++ b/masci_tools/tests/test_xml_getters/test_fleur_modes_max4.yml
@@ -1,5 +1,6 @@
 band: false
 bz_integration: hist
+cf_coeff: false
 dos: false
 film: true
 force_theorem: false

--- a/masci_tools/util/xml/xml_getters.py
+++ b/masci_tools/util/xml/xml_getters.py
@@ -86,6 +86,23 @@ def get_fleur_modes(xmltree, schema_dict, logger=None):
     else:
         fleur_modes['force_theorem'] = False
 
+    if schema_dict.inp_version >= (0, 33):
+        cf_coeff = any(
+            evaluate_attribute(root,
+                               schema_dict,
+                               'potential',
+                               contains='cFCoeffs',
+                               logger=logger,
+                               list_return=True,
+                               optional=True))
+        cf_coeff = cf_coeff or any(
+            evaluate_attribute(
+                root, schema_dict, 'chargeDensity', contains='cFCoeffs', logger=logger, list_return=True,
+                optional=True))
+        fleur_modes['cf_coeff'] = cf_coeff
+    else:
+        fleur_modes['cf_coeff'] = False
+
     fleur_modes['film'] = tag_exists(root, schema_dict, 'filmPos', logger=logger)
     fleur_modes['ldau'] = tag_exists(root, schema_dict, 'ldaU', contains='species', logger=logger)
     fleur_modes['dos'] = evaluate_attribute(root, schema_dict, 'dos', constants=constants, logger=logger)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [tool.poetry]
 name = "masci_tools"
-version = "0.4.5"
+version = "0.4.6"
 description = "Tools for Materials science. Vis contains wrapers of matplotlib functionality to visualalize common material science data. Plus wrapers of visualisation for aiida-fleur workflow nodes"
 readme = "README.md"
 authors = ["Jens Bröder <j.broeder@fz-juelich.de>",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf8') as f:
 if __name__ == '__main__':
     setup(
         name='masci_tools',
-        version='0.4.5',
+        version='0.4.6',
         description='Tools for Materials science. Vis contains wrappers of matplotlib functionality to visualize common material science data. Plus wrappers of visualisation for aiida-fleur workflow nodes',
         # add long_description from readme.md:
         long_description = long_description, # add contents of README.md


### PR DESCRIPTION
This release contains a bugfix for the `clear_xml` function, where comments could end up in the set of included tags. This leads to failures in aiida-fleur