### PR TITLE
Schema dict patch functions

### DIFF
--- a/masci_tools/io/parsers/fleur/fleur_schema/outschema_todict.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/outschema_todict.py
@@ -22,7 +22,7 @@ import copy
 from collections import UserList
 
 
-def create_outschema_dict(path, inp_path=None, inpschema_dict=None):
+def create_outschema_dict(path, inpschema_dict):
     """
     Creates dictionary with information about the FleurOutputSchema.xsd.
     The functions, whose results are added to the schema_dict and the corresponding keys
@@ -59,15 +59,7 @@ def create_outschema_dict(path, inp_path=None, inpschema_dict=None):
     namespaces = {'xsd': 'http://www.w3.org/2001/XMLSchema'}
     out_version = str(xmlschema.xpath('/xsd:schema/@version', namespaces=namespaces)[0])
 
-    if inpschema_dict is not None:
-        input_basic_types = inpschema_dict.get('_basic_types').get_unlocked()
-    else:
-        if inp_path is None:
-            inp_path = path.replace('FleurOutputSchema', 'FleurInputSchema')
-        #Parse type definitions directly from inputSchema
-        inpxmlschema = etree.parse(inp_path)
-        inpxmlschema, _ = clear_xml(inpxmlschema)
-        input_basic_types = get_basic_types(inpxmlschema, namespaces)
+    input_basic_types = inpschema_dict.get('_basic_types').get_unlocked()
 
     schema_dict = {}
     schema_dict['out_version'] = out_version

--- a/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_newer_version.yml
+++ b/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_newer_version.yml
@@ -250,8 +250,12 @@ input_dict:
   fleurInputVersion: '0.36'
   forceTheorem:
     spinSpiralDispersion:
-    - 0.0 0.0 0.0
-    - 0.2 0.0 0.0
+    - - 0.0
+      - 0.0
+      - 0.0
+    - - 0.2
+      - 0.0
+      - 0.0
   output:
     band: false
     chargeDensitySlicing:

--- a/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_todict_Fe_film_SSFT_LO_.yml
+++ b/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_todict_Fe_film_SSFT_LO_.yml
@@ -249,8 +249,12 @@ comment: A Fleur input generator calculation with aiida
 fleurInputVersion: '0.34'
 forceTheorem:
   spinSpiralDispersion:
-  - 0.0 0.0 0.0
-  - 0.2 0.0 0.0
+  - - 0.0
+    - 0.0
+    - 0.0
+  - - 0.2
+    - 0.0
+    - 0.0
 output:
   band: false
   chargeDensitySlicing:

--- a/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_todict_warnings.yml
+++ b/masci_tools/tests/test_fleur_inpxml_parser/test_inpxml_todict_warnings.yml
@@ -250,8 +250,12 @@ input_dict:
   fleurInputVersion: '0.33'
   forceTheorem:
     spinSpiralDispersion:
-    - 0.0 0.0 0.0
-    - 0.2 0.0 0.0
+    - - 0.0
+      - 0.0
+      - 0.0
+    - - 0.2
+      - 0.0
+      - 0.0
   output:
     band: false
     chargeDensitySlicing:

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max3_1compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max3_1compatibility.yml
@@ -212,9 +212,9 @@ output_dict:
     plot: false
     relax: false
     soc: true
-  gmax: '10.20000000'
+  gmax: 10.2
   input_file_version: '0.30'
-  kmax: '3.40000000'
+  kmax: 3.4
   magnetic_moments:
   - - 1.9133653688
     - 1.9134157142

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max4compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_max4compatibility.yml
@@ -128,9 +128,9 @@ output_dict:
     plot: false
     relax: false
     soc: false
-  gmax: '10.80000000'
+  gmax: 10.8
   input_file_version: '0.31'
-  kmax: '3.60000000'
+  kmax: 3.6
   ldau_info:
     As-2/33:
       d:

--- a/masci_tools/tests/test_fleur_outxml_parser/test_outxml_pre_max3_1compatibility.yml
+++ b/masci_tools/tests/test_fleur_outxml_parser/test_outxml_pre_max3_1compatibility.yml
@@ -68,9 +68,9 @@ output_dict:
     plot: false
     relax: false
     soc: false
-  gmax: '10.17596029'
+  gmax: 10.17596029
   input_file_version: '0.29'
-  kmax: '3.40000000'
+  kmax: 3.4
   magnetic_moments:
   - - 1.9158091539
     - 1.9159592226

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_27_.yml
@@ -599,7 +599,7 @@ simple_elements:
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   c:
   - length: 1
     type:
@@ -615,7 +615,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   kpoint:
   - length: 3
     type:
@@ -635,31 +635,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_27_.yml
@@ -98,19 +98,19 @@ _basic_types:
     length: 1
 attrib_types:
   alpha:
-  - float
+  - float_expression
   atomicnumber:
   - int
   autocomp:
   - switch
   b_cons_x:
-  - float
+  - float_expression
   b_cons_y:
-  - float
+  - float_expression
   band:
   - switch
   beta:
-  - float
+  - float_expression
   bmt:
   - switch
   calculate:
@@ -138,9 +138,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - float
+  - float_expression
   dvac:
-  - float
+  - float_expression
   ederiv:
   - int
   eig66:
@@ -148,23 +148,23 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
+  - float_expression
   elup:
-  - float
+  - float_expression
   eonly:
   - switch
   epsdisp:
-  - float
+  - float_expression
   epsforce:
-  - float
+  - float_expression
   ev:
   - switch
   f:
   - int
   fermismearingenergy:
-  - float
+  - float_expression
   fermismearingtemp:
-  - float
+  - float_expression
   filename:
   - string
   fleurinputversion:
@@ -178,9 +178,9 @@ attrib_types:
   gamma:
   - switch
   gmax:
-  - float
+  - float_expression
   gmaxxc:
-  - float
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -214,13 +214,13 @@ attrib_types:
   itmax:
   - int
   j:
-  - float
+  - float_expression
   jspins:
   - int
   kcrel:
   - int
   kmax:
-  - float
+  - float_expression
   l:
   - int
   l_amf:
@@ -258,41 +258,41 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - float
+  - float_expression
   locx2:
-  - float
+  - float_expression
   locy1:
-  - float
+  - float_expression
   locy2:
-  - float
+  - float_expression
   logincrement:
-  - float
+  - float_expression
   lpr:
   - int
   lwb:
   - switch
   m:
-  - float
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - float
+  - float_expression
   maxeigenval:
-  - float
+  - float_expression
   maxenergy:
-  - float
+  - float_expression
   maxiterbroyd:
   - int
   maxtimetostartiter:
-  - float
+  - float_expression
   mindistance:
-  - float
+  - float_expression
   mineigenval:
-  - float
+  - float_expression
   minenergy:
-  - float
+  - float_expression
   mix_b:
   - float
   mm:
@@ -335,7 +335,7 @@ attrib_types:
   pallst:
   - switch
   phi:
-  - float
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -355,7 +355,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - float
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -365,17 +365,17 @@ attrib_types:
   s:
   - int
   scale:
-  - float
+  - float_expression
   score:
   - switch
   secvar:
   - switch
   sig_b_1:
-  - float
+  - float_expression
   sig_b_2:
-  - float
+  - float_expression
   sigma:
-  - float
+  - float_expression
   slice:
   - switch
   soc66:
@@ -387,11 +387,11 @@ attrib_types:
   spgrp:
   - string
   spindown:
-  - float
+  - float_expression
   spinf:
-  - float
+  - float_expression
   spinup:
-  - float
+  - float_expression
   sso_opt:
   - string
   star:
@@ -401,24 +401,25 @@ attrib_types:
   swsp:
   - switch
   theta:
-  - float
+  - float_expression
   thetad:
   - float
   thetaj:
-  - float
+  - float_expression
   tworkf:
-  - float
+  - float_expression
   type:
   - string
   u:
-  - float
+  - float_expression
   vacdos:
   - switch
   vacuum:
   - int
   valenceelectrons:
-  - float
+  - float_expression
   value:
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -427,7 +428,7 @@ attrib_types:
   vm:
   - int
   weight:
-  - float
+  - float_expression
   weightscale:
   - float
   xa:
@@ -437,7 +438,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - float
+  - float_expression
 inp_version: '0.27'
 omitt_contained_tags:
 - constants

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_28_.yml
@@ -118,7 +118,7 @@ _basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   atomicnumber:
   - int
   atomlist:
@@ -128,15 +128,15 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   bmt:
   - switch
   bscomf:
@@ -178,9 +178,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -192,9 +192,9 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
@@ -206,9 +206,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ewaldlambda:
@@ -218,9 +218,9 @@ attrib_types:
   f:
   - int
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fleurinputversion:
@@ -236,9 +236,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -272,13 +272,13 @@ attrib_types:
   itmax:
   - int
   j:
-  - string
+  - float_expression
   jspins:
   - int
   kcrel:
   - int
   kmax:
-  - string
+  - float_expression
   l:
   - int
   l_amf:
@@ -328,31 +328,31 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logincrement:
-  - string
+  - float_expression
   lpr:
   - int
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -360,15 +360,15 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -421,7 +421,7 @@ attrib_types:
   pallst:
   - switch
   phi:
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -443,7 +443,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -453,7 +453,7 @@ attrib_types:
   s:
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -463,11 +463,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -483,12 +483,11 @@ attrib_types:
   spgrp:
   - string
   spindown:
-  - string
+  - float_expression
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   sso_opt:
   - string
   star:
@@ -504,19 +503,19 @@ attrib_types:
   swsp:
   - switch
   theta:
-  - string
+  - float_expression
   thetad:
   - string
   thetaj:
-  - string
+  - float_expression
   tolerance:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
-  - string
+  - float_expression
   unfoldband:
   - switch
   vacdos:
@@ -524,8 +523,9 @@ attrib_types:
   vacuum:
   - int
   valenceelectrons:
-  - string
+  - float_expression
   value:
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -538,7 +538,7 @@ attrib_types:
   wannier:
   - switch
   weight:
-  - string
+  - float_expression
   weightscale:
   - string
   xa:
@@ -548,7 +548,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.28'
 omitt_contained_tags:
 - constants

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_28_.yml
@@ -1,7 +1,7 @@
 _basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -57,7 +57,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -78,7 +78,7 @@ _basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -727,19 +727,19 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -755,7 +755,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -769,9 +769,9 @@ simple_elements:
     type:
     - float
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -783,38 +783,38 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   valenceconfig:
   - length: unbounded
     type:

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_29_.yml
@@ -130,7 +130,7 @@ _basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   atomicnumber:
@@ -142,19 +142,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -199,9 +199,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -213,15 +213,15 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -229,9 +229,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ewaldlambda:
@@ -242,21 +242,21 @@ attrib_types:
   f:
   - int
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   fleurinputversion:
   - string
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - int
   form66:
@@ -270,9 +270,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -308,13 +308,13 @@ attrib_types:
   itmax:
   - int
   j:
-  - string
+  - float_expression
   jspins:
   - int
   kcrel:
   - int
   kmax:
-  - string
+  - float_expression
   l:
   - int
   l_amf:
@@ -368,31 +368,31 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logincrement:
-  - string
+  - float_expression
   lpr:
   - int
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -400,15 +400,15 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -467,7 +467,7 @@ attrib_types:
   pallst:
   - switch
   phi:
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -491,7 +491,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -501,7 +501,7 @@ attrib_types:
   s:
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -511,11 +511,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -531,12 +531,11 @@ attrib_types:
   spgrp:
   - string
   spindown:
-  - string
+  - float_expression
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   sso_opt:
   - string
   star:
@@ -556,17 +555,17 @@ attrib_types:
   swsp:
   - switch
   theta:
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   tolerance:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
-  - string
+  - float_expression
   unfoldband:
   - switch
   vacdos:
@@ -574,11 +573,12 @@ attrib_types:
   vacuum:
   - int
   valenceelectrons:
-  - string
+  - float_expression
   value:
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -590,7 +590,7 @@ attrib_types:
   wannier:
   - switch
   weight:
-  - string
+  - float_expression
   weightscale:
   - string
   zrfs:
@@ -598,7 +598,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.29'
 omitt_contained_tags:
 - constants

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_29_.yml
@@ -1,7 +1,7 @@
 _basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -65,7 +65,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -90,7 +90,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -822,19 +822,19 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -854,7 +854,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -868,13 +868,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -886,31 +886,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -921,7 +921,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   valenceconfig:
   - length: unbounded
     type:

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_30_.yml
@@ -1,7 +1,7 @@
 _basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -69,7 +69,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -94,7 +94,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -838,19 +838,19 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -870,7 +870,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -884,13 +884,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -902,31 +902,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -937,7 +937,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   valenceconfig:
   - length: unbounded
     type:

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_30_.yml
@@ -134,7 +134,7 @@ _basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   atomicnumber:
@@ -146,19 +146,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -203,9 +203,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -217,15 +217,15 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -233,9 +233,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -252,21 +252,21 @@ attrib_types:
   f:
   - int
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   fleurinputversion:
   - string
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -280,9 +280,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -318,13 +318,13 @@ attrib_types:
   itmax:
   - int
   j:
-  - string
+  - float_expression
   jspins:
   - int
   kcrel:
   - int
   kmax:
-  - string
+  - float_expression
   l:
   - int
   l_amf:
@@ -378,31 +378,31 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logincrement:
-  - string
+  - float_expression
   lpr:
   - int
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -410,15 +410,15 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -477,7 +477,7 @@ attrib_types:
   pallst:
   - switch
   phi:
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -489,7 +489,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   qfix:
@@ -501,7 +501,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -511,7 +511,7 @@ attrib_types:
   s:
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -521,11 +521,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -541,12 +541,11 @@ attrib_types:
   spgrp:
   - string
   spindown:
-  - string
+  - float_expression
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   sso_opt:
   - string
   star:
@@ -566,17 +565,17 @@ attrib_types:
   swsp:
   - switch
   theta:
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   tolerance:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
-  - string
+  - float_expression
   unfoldband:
   - switch
   vacdos:
@@ -584,11 +583,12 @@ attrib_types:
   vacuum:
   - int
   valenceelectrons:
-  - string
+  - float_expression
   value:
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -600,7 +600,7 @@ attrib_types:
   wannier:
   - switch
   weight:
-  - string
+  - float_expression
   weightscale:
   - string
   zrfs:
@@ -608,7 +608,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.30'
 omitt_contained_tags:
 - constants

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_31_.yml
@@ -1,7 +1,7 @@
 _basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -69,7 +69,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -94,7 +94,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -838,19 +838,19 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -870,7 +870,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -884,13 +884,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -902,31 +902,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -937,7 +937,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   valenceconfig:
   - length: unbounded
     type:

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_31_.yml
@@ -134,7 +134,7 @@ _basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   atomicnumber:
@@ -146,19 +146,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -203,9 +203,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -217,15 +217,15 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -233,9 +233,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -252,21 +252,21 @@ attrib_types:
   f:
   - int
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   fleurinputversion:
   - string
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -280,9 +280,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -318,13 +318,13 @@ attrib_types:
   itmax:
   - int
   j:
-  - string
+  - float_expression
   jspins:
   - int
   kcrel:
   - int
   kmax:
-  - string
+  - float_expression
   l:
   - int
   l_amf:
@@ -378,31 +378,31 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logincrement:
-  - string
+  - float_expression
   lpr:
   - int
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -410,15 +410,15 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -477,7 +477,7 @@ attrib_types:
   pallst:
   - switch
   phi:
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -489,7 +489,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   qfix:
@@ -501,7 +501,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -511,7 +511,7 @@ attrib_types:
   s:
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -521,11 +521,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -541,12 +541,11 @@ attrib_types:
   spgrp:
   - string
   spindown:
-  - string
+  - float_expression
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   sso_opt:
   - string
   star:
@@ -566,17 +565,17 @@ attrib_types:
   swsp:
   - switch
   theta:
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   tolerance:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
-  - string
+  - float_expression
   unfoldband:
   - switch
   vacdos:
@@ -584,11 +583,12 @@ attrib_types:
   vacuum:
   - int
   valenceelectrons:
-  - string
+  - float_expression
   value:
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -600,7 +600,7 @@ attrib_types:
   wannier:
   - switch
   weight:
-  - string
+  - float_expression
   weightscale:
   - string
   zrfs:
@@ -608,7 +608,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.31'
 omitt_contained_tags:
 - constants

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_32_.yml
@@ -1,7 +1,7 @@
 _basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -77,11 +77,11 @@ _basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -116,7 +116,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -1094,19 +1094,19 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -1134,7 +1134,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -1142,7 +1142,7 @@ simple_elements:
   kpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   layer:
   - length: 1
     type:
@@ -1156,13 +1156,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -1174,31 +1174,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_32_.yml
@@ -166,8 +166,7 @@ attrib_types:
   all_atoms:
   - switch
   alpha:
-  - float
-  - string
+  - float_expression
   alpha_ex:
   - float
   analytical_cont:
@@ -181,13 +180,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   banddos:
@@ -195,8 +194,7 @@ attrib_types:
   bands:
   - int
   beta:
-  - float
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -240,9 +238,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   eb:
   - float
   ederiv:
@@ -256,17 +254,15 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
-  - string
+  - float_expression
   elup:
-  - float
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -274,9 +270,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   et:
   - float
   etot_correlation:
@@ -296,13 +292,13 @@ attrib_types:
   - switch
   - int
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   file:
   - string
   fixed_moment:
-  - string
+  - float_expression
   fleurinputversion:
   - string
   flipspinphi:
@@ -312,9 +308,9 @@ attrib_types:
   flipspintheta:
   - string
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -330,9 +326,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   grid:
   - string
   gridpoints:
@@ -376,7 +372,7 @@ attrib_types:
   itmax:
   - int
   j:
-  - string
+  - float_expression
   jdos:
   - switch
   jspins:
@@ -389,7 +385,7 @@ attrib_types:
   - float
   - string
   kmax:
-  - string
+  - float_expression
   l:
   - int
   l_adjenpara:
@@ -467,33 +463,33 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logincrement:
-  - string
+  - float_expression
   lpr:
   - int
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   mag_scale:
-  - string
+  - float_expression
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -501,17 +497,17 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   mincalcdistance:
   - float
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minmatdistance:
   - float
   minoccdistance:
@@ -521,9 +517,9 @@ attrib_types:
   minspinup:
   - int
   mix_b:
-  - string
+  - float_expression
   mix_relaxweightoffd:
-  - string
+  - float_expression
   mixparam:
   - float
   mm:
@@ -599,7 +595,7 @@ attrib_types:
   pallst:
   - switch
   phi:
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -611,7 +607,7 @@ attrib_types:
   potential:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   qfix:
@@ -623,7 +619,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -636,7 +632,7 @@ attrib_types:
   - switch
   - int
   scale:
-  - string
+  - float_expression
   secvar:
   - switch
   select:
@@ -644,12 +640,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - float
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -663,12 +658,11 @@ attrib_types:
   species:
   - string
   spindown:
-  - string
+  - float_expression
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   sso_opt:
   - string
   star:
@@ -688,21 +682,21 @@ attrib_types:
   swsp:
   - switch
   theta:
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   tolerance:
   - float
   twod:
   - switch
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   typemt:
   - int
   u:
-  - string
+  - float_expression
   unfoldband:
   - switch
   vacdos:
@@ -710,11 +704,12 @@ attrib_types:
   vacuum:
   - int
   valenceelectrons:
-  - string
+  - float_expression
   value:
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -732,19 +727,19 @@ attrib_types:
   vm:
   - int
   vol:
-  - string
+  - float_expression
   wannier:
   - switch
   warp_factor:
-  - string
+  - float_expression
   weight:
-  - string
+  - float_expression
   zero:
   - string
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.32'
 omitt_contained_tags:
 - constants

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_33_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_33_.yml
@@ -1168,13 +1168,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_34_.yml
+++ b/masci_tools/tests/test_schema_dict/test_inpschema_dict_0_34_.yml
@@ -1186,13 +1186,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_27_.yml
@@ -212,7 +212,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - float
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -222,13 +222,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - float
+  - float_expression
   b_cons_y:
-  - float
+  - float_expression
   band:
   - switch
   beta:
-  - float
+  - float_expression
   bmt:
   - switch
   branch:
@@ -271,9 +271,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - float
+  - float_expression
   dvac:
-  - float
+  - float_expression
   ederiv:
   - int
   eig66:
@@ -283,17 +283,17 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
+  - float_expression
   elup:
-  - float
+  - float_expression
   energy:
   - float
   eonly:
   - switch
   epsdisp:
-  - float
+  - float_expression
   epsforce:
-  - float
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -308,9 +308,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - float
+  - float_expression
   fermismearingtemp:
-  - float
+  - float_expression
   filename:
   - string
   flag:
@@ -328,9 +328,9 @@ attrib_types:
   gamma:
   - switch
   gmax:
-  - float
+  - float_expression
   gmaxxc:
-  - float
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -375,6 +375,7 @@ attrib_types:
   - int
   j:
   - float
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -392,7 +393,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - float
+  - float_expression
   kpoint:
   - int
   l:
@@ -438,17 +439,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - float
+  - float_expression
   locx2:
-  - float
+  - float_expression
   locy1:
-  - float
+  - float_expression
   locy2:
-  - float
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - float
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -456,31 +457,31 @@ attrib_types:
   lwb:
   - switch
   m:
-  - float
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - float
+  - float_expression
   maxeigenval:
-  - float
+  - float_expression
   maxenergy:
-  - float
+  - float_expression
   maxiterbroyd:
   - int
   maxtimetostartiter:
-  - float
+  - float_expression
   memorypernode:
   - string
   message:
   - string
   mindistance:
-  - float
+  - float_expression
   mineigenval:
-  - float
+  - float_expression
   minenergy:
-  - float
+  - float_expression
   mix_b:
   - float
   mm:
@@ -565,6 +566,7 @@ attrib_types:
   - switch
   phi:
   - float
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -591,7 +593,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - float
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -602,17 +604,17 @@ attrib_types:
   - float
   - int
   scale:
-  - float
+  - float_expression
   score:
   - switch
   secvar:
   - switch
   sig_b_1:
-  - float
+  - float_expression
   sig_b_2:
-  - float
+  - float_expression
   sigma:
-  - float
+  - float_expression
   slice:
   - switch
   soc66:
@@ -626,13 +628,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - float
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
+  - float_expression
   spinup:
-  - float
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -647,20 +649,22 @@ attrib_types:
   - switch
   theta:
   - float
+  - float_expression
   thetad:
   - float
   thetaj:
-  - float
+  - float_expression
   time:
   - string
   total:
   - float
   tworkf:
-  - float
+  - float_expression
   type:
   - string
   u:
   - float
+  - float_expression
   uindex:
   - int
   unitcell:
@@ -678,9 +682,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - float
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -696,6 +701,7 @@ attrib_types:
   - float
   weight:
   - float
+  - float_expression
   weightscale:
   - float
   x:
@@ -715,7 +721,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - float
+  - float_expression
 inp_version: '0.27'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_27_.yml
@@ -2353,7 +2353,7 @@ simple_elements:
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2381,7 +2381,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   kpoint:
   - length: 3
     type:
@@ -2401,31 +2401,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_28_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -69,7 +69,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -90,7 +90,7 @@ _basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -135,7 +135,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -191,7 +191,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -212,7 +212,7 @@ _input_basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2496,15 +2496,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2512,7 +2512,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2536,7 +2536,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2550,9 +2550,9 @@ simple_elements:
     type:
     - float
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2564,38 +2564,38 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_28_.yml
@@ -252,7 +252,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -264,15 +264,15 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   bmt:
   - switch
   branch:
@@ -329,9 +329,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -345,9 +345,9 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
@@ -361,9 +361,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -382,9 +382,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   flag:
@@ -404,9 +404,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -451,7 +451,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -469,7 +469,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -527,17 +527,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -545,17 +545,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -563,7 +563,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -571,11 +571,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -670,7 +670,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -699,7 +699,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -710,7 +710,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -720,11 +720,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -742,14 +742,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -770,11 +769,11 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetad:
   - string
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -782,12 +781,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -807,9 +806,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -829,7 +829,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -850,7 +850,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.28'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_29_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -77,7 +77,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -102,7 +102,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -147,7 +147,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -211,7 +211,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -236,7 +236,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2588,15 +2588,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2604,7 +2604,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2632,7 +2632,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2646,13 +2646,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2664,31 +2664,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -2699,7 +2699,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_29_.yml
@@ -276,7 +276,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -290,19 +290,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -362,9 +362,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -378,16 +378,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -395,9 +395,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -417,13 +417,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -433,9 +433,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - int
   form66:
@@ -449,9 +449,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -498,7 +498,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -516,7 +516,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -578,17 +578,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -596,17 +596,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -614,7 +614,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -622,11 +622,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -727,7 +727,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -758,7 +758,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -769,7 +769,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -779,11 +779,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -801,14 +801,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -833,9 +832,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -843,12 +842,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -868,12 +867,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -892,7 +892,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -911,7 +911,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.29'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_30_.yml
@@ -284,7 +284,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -298,19 +298,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -370,9 +370,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -386,16 +386,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -403,9 +403,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -431,13 +431,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -447,9 +447,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -463,9 +463,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -512,7 +512,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -530,7 +530,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -592,17 +592,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -610,17 +610,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -628,7 +628,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -636,11 +636,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -741,7 +741,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -753,7 +753,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -772,7 +772,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -783,7 +783,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -793,11 +793,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -815,14 +815,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -847,9 +846,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -857,12 +856,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -882,12 +881,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -906,7 +906,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -925,7 +925,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.30'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_30_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -81,7 +81,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -106,7 +106,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -151,7 +151,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -219,7 +219,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -244,7 +244,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2608,15 +2608,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2624,7 +2624,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2652,7 +2652,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2666,13 +2666,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2684,31 +2684,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -2719,7 +2719,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_31_.yml
@@ -284,7 +284,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -298,19 +298,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -370,9 +370,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -386,16 +386,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -403,9 +403,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -431,13 +431,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -447,9 +447,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -463,9 +463,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -512,7 +512,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -530,7 +530,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -592,17 +592,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -610,17 +610,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -628,7 +628,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -636,11 +636,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -741,7 +741,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -753,7 +753,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -772,7 +772,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -783,7 +783,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -793,11 +793,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -815,14 +815,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -847,9 +846,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -857,12 +856,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -882,12 +881,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -906,7 +906,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -925,7 +925,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.31'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_31_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -81,7 +81,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -106,7 +106,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -151,7 +151,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -219,7 +219,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -244,7 +244,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2608,15 +2608,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2624,7 +2624,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2652,7 +2652,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2666,13 +2666,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2684,31 +2684,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -2719,7 +2719,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_32_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -89,11 +89,11 @@ _basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -128,7 +128,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -181,7 +181,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -257,11 +257,11 @@ _input_basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -296,7 +296,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -2873,15 +2873,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2889,7 +2889,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2925,7 +2925,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2933,7 +2933,7 @@ simple_elements:
   kpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   layer:
   - length: 1
     type:
@@ -2947,13 +2947,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2965,31 +2965,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_32_.yml
@@ -346,8 +346,7 @@ attrib_types:
   all_atoms:
   - switch
   alpha:
-  - float
-  - string
+  - float_expression
   alpha_ex:
   - float
   analytical_cont:
@@ -363,13 +362,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   banddos:
@@ -377,8 +376,7 @@ attrib_types:
   bands:
   - int
   beta:
-  - float
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -437,9 +435,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   eb:
   - float
   ederiv:
@@ -455,18 +453,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
-  - string
+  - float_expression
   elup:
-  - float
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -474,9 +470,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   et:
   - float
   etot_correlation:
@@ -505,13 +501,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   file:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -525,9 +521,9 @@ attrib_types:
   flipspintheta:
   - string
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -543,9 +539,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   grid:
   - string
   gridpoints:
@@ -600,7 +596,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jdos:
@@ -625,7 +621,7 @@ attrib_types:
   - float
   - string
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -711,17 +707,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -729,19 +725,19 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   mag_scale:
-  - string
+  - float_expression
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -749,7 +745,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -759,11 +755,11 @@ attrib_types:
   mincalcdistance:
   - float
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minmatdistance:
   - float
   minoccdistance:
@@ -773,9 +769,9 @@ attrib_types:
   minspinup:
   - int
   mix_b:
-  - string
+  - float_expression
   mix_relaxweightoffd:
-  - string
+  - float_expression
   mixparam:
   - float
   mm:
@@ -893,7 +889,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -905,7 +901,7 @@ attrib_types:
   potential:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -924,7 +920,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -938,7 +934,7 @@ attrib_types:
   - int
   - switch
   scale:
-  - string
+  - float_expression
   secvar:
   - switch
   select:
@@ -946,12 +942,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - float
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -967,14 +962,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -999,9 +993,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -1011,14 +1005,14 @@ attrib_types:
   twod:
   - switch
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   typemt:
   - int
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -1038,12 +1032,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -1063,7 +1058,7 @@ attrib_types:
   vm:
   - int
   vol:
-  - string
+  - float_expression
   vzinf:
   - float
   vzir:
@@ -1071,10 +1066,10 @@ attrib_types:
   wannier:
   - switch
   warp_factor:
-  - string
+  - float_expression
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   x:
@@ -1092,7 +1087,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.32'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_33_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_33_.yml
@@ -2971,13 +2971,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_34_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_29_0_34_.yml
@@ -2987,13 +2987,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_27_.yml
@@ -212,7 +212,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - float
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -222,13 +222,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - float
+  - float_expression
   b_cons_y:
-  - float
+  - float_expression
   band:
   - switch
   beta:
-  - float
+  - float_expression
   bmt:
   - switch
   branch:
@@ -271,9 +271,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - float
+  - float_expression
   dvac:
-  - float
+  - float_expression
   ederiv:
   - int
   eig66:
@@ -283,17 +283,17 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
+  - float_expression
   elup:
-  - float
+  - float_expression
   energy:
   - float
   eonly:
   - switch
   epsdisp:
-  - float
+  - float_expression
   epsforce:
-  - float
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -308,9 +308,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - float
+  - float_expression
   fermismearingtemp:
-  - float
+  - float_expression
   filename:
   - string
   flag:
@@ -328,9 +328,9 @@ attrib_types:
   gamma:
   - switch
   gmax:
-  - float
+  - float_expression
   gmaxxc:
-  - float
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -375,6 +375,7 @@ attrib_types:
   - int
   j:
   - float
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -392,7 +393,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - float
+  - float_expression
   kpoint:
   - int
   l:
@@ -438,17 +439,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - float
+  - float_expression
   locx2:
-  - float
+  - float_expression
   locy1:
-  - float
+  - float_expression
   locy2:
-  - float
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - float
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -456,31 +457,31 @@ attrib_types:
   lwb:
   - switch
   m:
-  - float
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - float
+  - float_expression
   maxeigenval:
-  - float
+  - float_expression
   maxenergy:
-  - float
+  - float_expression
   maxiterbroyd:
   - int
   maxtimetostartiter:
-  - float
+  - float_expression
   memorypernode:
   - string
   message:
   - string
   mindistance:
-  - float
+  - float_expression
   mineigenval:
-  - float
+  - float_expression
   minenergy:
-  - float
+  - float_expression
   mix_b:
   - float
   mm:
@@ -565,6 +566,7 @@ attrib_types:
   - switch
   phi:
   - float
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -591,7 +593,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - float
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -602,17 +604,17 @@ attrib_types:
   - float
   - int
   scale:
-  - float
+  - float_expression
   score:
   - switch
   secvar:
   - switch
   sig_b_1:
-  - float
+  - float_expression
   sig_b_2:
-  - float
+  - float_expression
   sigma:
-  - float
+  - float_expression
   slice:
   - switch
   soc66:
@@ -626,13 +628,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - float
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
+  - float_expression
   spinup:
-  - float
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -647,20 +649,22 @@ attrib_types:
   - switch
   theta:
   - float
+  - float_expression
   thetad:
   - float
   thetaj:
-  - float
+  - float_expression
   time:
   - string
   total:
   - float
   tworkf:
-  - float
+  - float_expression
   type:
   - string
   u:
   - float
+  - float_expression
   uindex:
   - int
   unitcell:
@@ -678,9 +682,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - float
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -696,6 +701,7 @@ attrib_types:
   - float
   weight:
   - float
+  - float_expression
   weightscale:
   - float
   x:
@@ -715,7 +721,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - float
+  - float_expression
 inp_version: '0.27'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_27_.yml
@@ -2353,7 +2353,7 @@ simple_elements:
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2381,7 +2381,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   kpoint:
   - length: 3
     type:
@@ -2401,31 +2401,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_28_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -69,7 +69,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -90,7 +90,7 @@ _basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -135,7 +135,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -191,7 +191,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -212,7 +212,7 @@ _input_basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2496,15 +2496,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2512,7 +2512,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2536,7 +2536,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2550,9 +2550,9 @@ simple_elements:
     type:
     - float
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2564,38 +2564,38 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_28_.yml
@@ -252,7 +252,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -264,15 +264,15 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   bmt:
   - switch
   branch:
@@ -329,9 +329,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -345,9 +345,9 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
@@ -361,9 +361,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -382,9 +382,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   flag:
@@ -404,9 +404,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -451,7 +451,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -469,7 +469,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -527,17 +527,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -545,17 +545,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -563,7 +563,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -571,11 +571,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -670,7 +670,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -699,7 +699,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -710,7 +710,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -720,11 +720,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -742,14 +742,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -770,11 +769,11 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetad:
   - string
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -782,12 +781,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -807,9 +806,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -829,7 +829,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -850,7 +850,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.28'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_29_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -77,7 +77,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -102,7 +102,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -147,7 +147,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -211,7 +211,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -236,7 +236,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2588,15 +2588,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2604,7 +2604,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2632,7 +2632,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2646,13 +2646,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2664,31 +2664,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -2699,7 +2699,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_29_.yml
@@ -276,7 +276,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -290,19 +290,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -362,9 +362,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -378,16 +378,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -395,9 +395,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -417,13 +417,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -433,9 +433,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - int
   form66:
@@ -449,9 +449,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -498,7 +498,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -516,7 +516,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -578,17 +578,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -596,17 +596,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -614,7 +614,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -622,11 +622,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -727,7 +727,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -758,7 +758,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -769,7 +769,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -779,11 +779,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -801,14 +801,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -833,9 +832,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -843,12 +842,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -868,12 +867,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -892,7 +892,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -911,7 +911,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.29'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_30_.yml
@@ -284,7 +284,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -298,19 +298,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -370,9 +370,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -386,16 +386,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -403,9 +403,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -431,13 +431,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -447,9 +447,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -463,9 +463,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -512,7 +512,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -530,7 +530,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -592,17 +592,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -610,17 +610,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -628,7 +628,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -636,11 +636,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -741,7 +741,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -753,7 +753,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -772,7 +772,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -783,7 +783,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -793,11 +793,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -815,14 +815,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -847,9 +846,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -857,12 +856,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -882,12 +881,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -906,7 +906,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -925,7 +925,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.30'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_30_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -81,7 +81,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -106,7 +106,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -151,7 +151,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -219,7 +219,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -244,7 +244,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2608,15 +2608,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2624,7 +2624,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2652,7 +2652,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2666,13 +2666,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2684,31 +2684,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -2719,7 +2719,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_31_.yml
@@ -284,7 +284,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -298,19 +298,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -370,9 +370,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -386,16 +386,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -403,9 +403,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -431,13 +431,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -447,9 +447,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -463,9 +463,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -512,7 +512,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -530,7 +530,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -592,17 +592,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -610,17 +610,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -628,7 +628,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -636,11 +636,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -741,7 +741,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -753,7 +753,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -772,7 +772,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -783,7 +783,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -793,11 +793,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -815,14 +815,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -847,9 +846,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -857,12 +856,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -882,12 +881,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -906,7 +906,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -925,7 +925,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.31'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_31_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -81,7 +81,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -106,7 +106,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -151,7 +151,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -219,7 +219,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -244,7 +244,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2608,15 +2608,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2624,7 +2624,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2652,7 +2652,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2666,13 +2666,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2684,31 +2684,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -2719,7 +2719,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_32_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -89,11 +89,11 @@ _basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -128,7 +128,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -181,7 +181,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -257,11 +257,11 @@ _input_basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -296,7 +296,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -2873,15 +2873,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2889,7 +2889,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2925,7 +2925,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2933,7 +2933,7 @@ simple_elements:
   kpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   layer:
   - length: 1
     type:
@@ -2947,13 +2947,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2965,31 +2965,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_32_.yml
@@ -346,8 +346,7 @@ attrib_types:
   all_atoms:
   - switch
   alpha:
-  - float
-  - string
+  - float_expression
   alpha_ex:
   - float
   analytical_cont:
@@ -363,13 +362,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   banddos:
@@ -377,8 +376,7 @@ attrib_types:
   bands:
   - int
   beta:
-  - float
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -437,9 +435,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   eb:
   - float
   ederiv:
@@ -455,18 +453,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
-  - string
+  - float_expression
   elup:
-  - float
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -474,9 +470,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   et:
   - float
   etot_correlation:
@@ -505,13 +501,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   file:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -525,9 +521,9 @@ attrib_types:
   flipspintheta:
   - string
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -543,9 +539,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   grid:
   - string
   gridpoints:
@@ -600,7 +596,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jdos:
@@ -625,7 +621,7 @@ attrib_types:
   - float
   - string
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -711,17 +707,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -729,19 +725,19 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   mag_scale:
-  - string
+  - float_expression
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -749,7 +745,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -759,11 +755,11 @@ attrib_types:
   mincalcdistance:
   - float
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minmatdistance:
   - float
   minoccdistance:
@@ -773,9 +769,9 @@ attrib_types:
   minspinup:
   - int
   mix_b:
-  - string
+  - float_expression
   mix_relaxweightoffd:
-  - string
+  - float_expression
   mixparam:
   - float
   mm:
@@ -893,7 +889,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -905,7 +901,7 @@ attrib_types:
   potential:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -924,7 +920,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -938,7 +934,7 @@ attrib_types:
   - int
   - switch
   scale:
-  - string
+  - float_expression
   secvar:
   - switch
   select:
@@ -946,12 +942,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - float
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -967,14 +962,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -999,9 +993,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -1011,14 +1005,14 @@ attrib_types:
   twod:
   - switch
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   typemt:
   - int
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -1038,12 +1032,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -1063,7 +1058,7 @@ attrib_types:
   vm:
   - int
   vol:
-  - string
+  - float_expression
   vzinf:
   - float
   vzir:
@@ -1071,10 +1066,10 @@ attrib_types:
   wannier:
   - switch
   warp_factor:
-  - string
+  - float_expression
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   x:
@@ -1092,7 +1087,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.32'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_33_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_33_.yml
@@ -2971,13 +2971,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_34_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_30_0_34_.yml
@@ -2987,13 +2987,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_27_.yml
@@ -212,7 +212,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - float
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -222,13 +222,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - float
+  - float_expression
   b_cons_y:
-  - float
+  - float_expression
   band:
   - switch
   beta:
-  - float
+  - float_expression
   bmt:
   - switch
   branch:
@@ -271,9 +271,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - float
+  - float_expression
   dvac:
-  - float
+  - float_expression
   ederiv:
   - int
   eig66:
@@ -283,17 +283,17 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
+  - float_expression
   elup:
-  - float
+  - float_expression
   energy:
   - float
   eonly:
   - switch
   epsdisp:
-  - float
+  - float_expression
   epsforce:
-  - float
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -308,9 +308,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - float
+  - float_expression
   fermismearingtemp:
-  - float
+  - float_expression
   filename:
   - string
   flag:
@@ -328,9 +328,9 @@ attrib_types:
   gamma:
   - switch
   gmax:
-  - float
+  - float_expression
   gmaxxc:
-  - float
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -375,6 +375,7 @@ attrib_types:
   - int
   j:
   - float
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -392,7 +393,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - float
+  - float_expression
   kpoint:
   - int
   l:
@@ -438,17 +439,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - float
+  - float_expression
   locx2:
-  - float
+  - float_expression
   locy1:
-  - float
+  - float_expression
   locy2:
-  - float
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - float
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -456,31 +457,31 @@ attrib_types:
   lwb:
   - switch
   m:
-  - float
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - float
+  - float_expression
   maxeigenval:
-  - float
+  - float_expression
   maxenergy:
-  - float
+  - float_expression
   maxiterbroyd:
   - int
   maxtimetostartiter:
-  - float
+  - float_expression
   memorypernode:
   - string
   message:
   - string
   mindistance:
-  - float
+  - float_expression
   mineigenval:
-  - float
+  - float_expression
   minenergy:
-  - float
+  - float_expression
   mix_b:
   - float
   mm:
@@ -565,6 +566,7 @@ attrib_types:
   - switch
   phi:
   - float
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -591,7 +593,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - float
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -602,17 +604,17 @@ attrib_types:
   - float
   - int
   scale:
-  - float
+  - float_expression
   score:
   - switch
   secvar:
   - switch
   sig_b_1:
-  - float
+  - float_expression
   sig_b_2:
-  - float
+  - float_expression
   sigma:
-  - float
+  - float_expression
   slice:
   - switch
   soc66:
@@ -626,13 +628,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - float
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
+  - float_expression
   spinup:
-  - float
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -647,20 +649,22 @@ attrib_types:
   - switch
   theta:
   - float
+  - float_expression
   thetad:
   - float
   thetaj:
-  - float
+  - float_expression
   time:
   - string
   total:
   - float
   tworkf:
-  - float
+  - float_expression
   type:
   - string
   u:
   - float
+  - float_expression
   uindex:
   - int
   unitcell:
@@ -678,9 +682,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - float
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -696,6 +701,7 @@ attrib_types:
   - float
   weight:
   - float
+  - float_expression
   weightscale:
   - float
   x:
@@ -715,7 +721,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - float
+  - float_expression
 inp_version: '0.27'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_27_.yml
@@ -2353,7 +2353,7 @@ simple_elements:
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2381,7 +2381,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   kpoint:
   - length: 3
     type:
@@ -2401,31 +2401,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_28_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -69,7 +69,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -90,7 +90,7 @@ _basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -135,7 +135,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -191,7 +191,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -212,7 +212,7 @@ _input_basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2496,15 +2496,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2512,7 +2512,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2536,7 +2536,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2550,9 +2550,9 @@ simple_elements:
     type:
     - float
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2564,38 +2564,38 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_28_.yml
@@ -252,7 +252,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -264,15 +264,15 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   bmt:
   - switch
   branch:
@@ -329,9 +329,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -345,9 +345,9 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
@@ -361,9 +361,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -382,9 +382,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   flag:
@@ -404,9 +404,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -451,7 +451,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -469,7 +469,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -527,17 +527,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -545,17 +545,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -563,7 +563,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -571,11 +571,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -670,7 +670,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -699,7 +699,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -710,7 +710,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -720,11 +720,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -742,14 +742,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -770,11 +769,11 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetad:
   - string
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -782,12 +781,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -807,9 +806,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -829,7 +829,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -850,7 +850,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.28'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_29_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -77,7 +77,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -102,7 +102,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -147,7 +147,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -211,7 +211,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -236,7 +236,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2588,15 +2588,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2604,7 +2604,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2632,7 +2632,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2646,13 +2646,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2664,31 +2664,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -2699,7 +2699,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_29_.yml
@@ -276,7 +276,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -290,19 +290,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -362,9 +362,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -378,16 +378,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -395,9 +395,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -417,13 +417,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -433,9 +433,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - int
   form66:
@@ -449,9 +449,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -498,7 +498,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -516,7 +516,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -578,17 +578,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -596,17 +596,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -614,7 +614,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -622,11 +622,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -727,7 +727,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -758,7 +758,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -769,7 +769,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -779,11 +779,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -801,14 +801,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -833,9 +832,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -843,12 +842,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -868,12 +867,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -892,7 +892,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -911,7 +911,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.29'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_30_.yml
@@ -284,7 +284,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -298,19 +298,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -370,9 +370,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -386,16 +386,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -403,9 +403,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -431,13 +431,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -447,9 +447,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -463,9 +463,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -512,7 +512,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -530,7 +530,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -592,17 +592,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -610,17 +610,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -628,7 +628,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -636,11 +636,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -741,7 +741,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -753,7 +753,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -772,7 +772,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -783,7 +783,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -793,11 +793,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -815,14 +815,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -847,9 +846,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -857,12 +856,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -882,12 +881,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -906,7 +906,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -925,7 +925,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.30'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_30_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -81,7 +81,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -106,7 +106,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -151,7 +151,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -219,7 +219,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -244,7 +244,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2608,15 +2608,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2624,7 +2624,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2652,7 +2652,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2666,13 +2666,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2684,31 +2684,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -2719,7 +2719,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_31_.yml
@@ -284,7 +284,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -298,19 +298,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -370,9 +370,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -386,16 +386,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -403,9 +403,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -431,13 +431,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -447,9 +447,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -463,9 +463,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -512,7 +512,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -530,7 +530,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -592,17 +592,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -610,17 +610,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -628,7 +628,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -636,11 +636,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -741,7 +741,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -753,7 +753,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -772,7 +772,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -783,7 +783,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -793,11 +793,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -815,14 +815,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -847,9 +846,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -857,12 +856,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -882,12 +881,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -906,7 +906,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -925,7 +925,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.31'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_31_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -81,7 +81,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -106,7 +106,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -151,7 +151,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -219,7 +219,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -244,7 +244,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2608,15 +2608,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2624,7 +2624,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2652,7 +2652,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2666,13 +2666,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2684,31 +2684,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -2719,7 +2719,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_32_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -89,11 +89,11 @@ _basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -128,7 +128,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -181,7 +181,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -257,11 +257,11 @@ _input_basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -296,7 +296,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -2873,15 +2873,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2889,7 +2889,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2925,7 +2925,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2933,7 +2933,7 @@ simple_elements:
   kpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   layer:
   - length: 1
     type:
@@ -2947,13 +2947,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2965,31 +2965,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_32_.yml
@@ -346,8 +346,7 @@ attrib_types:
   all_atoms:
   - switch
   alpha:
-  - float
-  - string
+  - float_expression
   alpha_ex:
   - float
   analytical_cont:
@@ -363,13 +362,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   banddos:
@@ -377,8 +376,7 @@ attrib_types:
   bands:
   - int
   beta:
-  - float
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -437,9 +435,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   eb:
   - float
   ederiv:
@@ -455,18 +453,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
-  - string
+  - float_expression
   elup:
-  - float
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -474,9 +470,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   et:
   - float
   etot_correlation:
@@ -505,13 +501,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   file:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -525,9 +521,9 @@ attrib_types:
   flipspintheta:
   - string
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -543,9 +539,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   grid:
   - string
   gridpoints:
@@ -600,7 +596,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jdos:
@@ -625,7 +621,7 @@ attrib_types:
   - float
   - string
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -711,17 +707,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -729,19 +725,19 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   mag_scale:
-  - string
+  - float_expression
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -749,7 +745,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -759,11 +755,11 @@ attrib_types:
   mincalcdistance:
   - float
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minmatdistance:
   - float
   minoccdistance:
@@ -773,9 +769,9 @@ attrib_types:
   minspinup:
   - int
   mix_b:
-  - string
+  - float_expression
   mix_relaxweightoffd:
-  - string
+  - float_expression
   mixparam:
   - float
   mm:
@@ -893,7 +889,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -905,7 +901,7 @@ attrib_types:
   potential:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -924,7 +920,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -938,7 +934,7 @@ attrib_types:
   - int
   - switch
   scale:
-  - string
+  - float_expression
   secvar:
   - switch
   select:
@@ -946,12 +942,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - float
-  - string
+  - float_expression
   slice:
   - switch
   soc66:
@@ -967,14 +962,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -999,9 +993,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -1011,14 +1005,14 @@ attrib_types:
   twod:
   - switch
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   typemt:
   - int
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -1038,12 +1032,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -1063,7 +1058,7 @@ attrib_types:
   vm:
   - int
   vol:
-  - string
+  - float_expression
   vzinf:
   - float
   vzir:
@@ -1071,10 +1066,10 @@ attrib_types:
   wannier:
   - switch
   warp_factor:
-  - string
+  - float_expression
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   x:
@@ -1092,7 +1087,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.32'
 input_tag: inputData
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_33_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_33_.yml
@@ -2971,13 +2971,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_34_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_31_0_34_.yml
@@ -2987,13 +2987,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_27_.yml
@@ -2670,7 +2670,7 @@ simple_elements:
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2698,7 +2698,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   kpoint:
   - length: 3
     type:
@@ -2718,31 +2718,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_27_.yml
@@ -216,7 +216,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - float
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -226,13 +226,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - float
+  - float_expression
   b_cons_y:
-  - float
+  - float_expression
   band:
   - switch
   beta:
-  - float
+  - float_expression
   bmt:
   - switch
   branch:
@@ -277,9 +277,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - float
+  - float_expression
   dvac:
-  - float
+  - float_expression
   ederiv:
   - int
   eig66:
@@ -289,17 +289,17 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
+  - float_expression
   elup:
-  - float
+  - float_expression
   energy:
   - float
   eonly:
   - switch
   epsdisp:
-  - float
+  - float_expression
   epsforce:
-  - float
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -314,9 +314,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - float
+  - float_expression
   fermismearingtemp:
-  - float
+  - float_expression
   filename:
   - string
   flag:
@@ -334,9 +334,9 @@ attrib_types:
   gamma:
   - switch
   gmax:
-  - float
+  - float_expression
   gmaxxc:
-  - float
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -383,6 +383,7 @@ attrib_types:
   - int
   j:
   - float
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -400,7 +401,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - float
+  - float_expression
   kpoint:
   - int
   l:
@@ -446,17 +447,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - float
+  - float_expression
   locx2:
-  - float
+  - float_expression
   locy1:
-  - float
+  - float_expression
   locy2:
-  - float
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - float
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -464,31 +465,31 @@ attrib_types:
   lwb:
   - switch
   m:
-  - float
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - float
+  - float_expression
   maxeigenval:
-  - float
+  - float_expression
   maxenergy:
-  - float
+  - float_expression
   maxiterbroyd:
   - int
   maxtimetostartiter:
-  - float
+  - float_expression
   memorypernode:
   - string
   message:
   - string
   mindistance:
-  - float
+  - float_expression
   mineigenval:
-  - float
+  - float_expression
   minenergy:
-  - float
+  - float_expression
   mix_b:
   - float
   mm:
@@ -573,6 +574,7 @@ attrib_types:
   - switch
   phi:
   - float
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -599,7 +601,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - float
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -610,17 +612,17 @@ attrib_types:
   - float
   - int
   scale:
-  - float
+  - float_expression
   score:
   - switch
   secvar:
   - switch
   sig_b_1:
-  - float
+  - float_expression
   sig_b_2:
-  - float
+  - float_expression
   sigma:
-  - float
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -640,13 +642,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - float
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
+  - float_expression
   spinup:
-  - float
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -661,20 +663,22 @@ attrib_types:
   - switch
   theta:
   - float
+  - float_expression
   thetad:
   - float
   thetaj:
-  - float
+  - float_expression
   time:
   - string
   total:
   - float
   tworkf:
-  - float
+  - float_expression
   type:
   - string
   u:
   - float
+  - float_expression
   uindex:
   - int
   unitcell:
@@ -692,9 +696,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - float
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -710,6 +715,7 @@ attrib_types:
   - float
   weight:
   - float
+  - float_expression
   weightscale:
   - float
   x:
@@ -729,7 +735,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - float
+  - float_expression
 inp_version: '0.27'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_28_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -73,7 +73,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -94,7 +94,7 @@ _basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -139,7 +139,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -195,7 +195,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -216,7 +216,7 @@ _input_basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2813,15 +2813,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2829,7 +2829,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2853,7 +2853,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2867,9 +2867,9 @@ simple_elements:
     type:
     - float
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2881,38 +2881,38 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_28_.yml
@@ -256,7 +256,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -268,15 +268,15 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   bmt:
   - switch
   branch:
@@ -335,9 +335,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -351,9 +351,9 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
@@ -367,9 +367,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -388,9 +388,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   flag:
@@ -410,9 +410,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -459,7 +459,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -477,7 +477,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -535,17 +535,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -553,17 +553,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -571,7 +571,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -579,11 +579,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -678,7 +678,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -707,7 +707,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -718,7 +718,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -728,11 +728,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -756,14 +756,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -784,11 +783,11 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetad:
   - string
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -796,12 +795,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -821,9 +820,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -843,7 +843,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -864,7 +864,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.28'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_29_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -81,7 +81,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -106,7 +106,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -151,7 +151,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -215,7 +215,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -240,7 +240,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2905,15 +2905,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2921,7 +2921,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2949,7 +2949,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2963,13 +2963,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2981,31 +2981,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -3016,7 +3016,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_29_.yml
@@ -280,7 +280,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -294,19 +294,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -368,9 +368,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -384,16 +384,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -401,9 +401,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -423,13 +423,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -439,9 +439,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - int
   form66:
@@ -455,9 +455,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -506,7 +506,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -524,7 +524,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -586,17 +586,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -604,17 +604,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -622,7 +622,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -630,11 +630,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -735,7 +735,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -766,7 +766,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -777,7 +777,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -787,11 +787,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -815,14 +815,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -847,9 +846,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -857,12 +856,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -882,12 +881,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -906,7 +906,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -925,7 +925,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.29'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_30_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -85,7 +85,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -110,7 +110,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -155,7 +155,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -223,7 +223,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -248,7 +248,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2925,15 +2925,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2941,7 +2941,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2969,7 +2969,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2983,13 +2983,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -3001,31 +3001,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -3036,7 +3036,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_30_.yml
@@ -288,7 +288,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -302,19 +302,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -376,9 +376,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -392,16 +392,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -409,9 +409,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -437,13 +437,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -453,9 +453,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -469,9 +469,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -520,7 +520,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -538,7 +538,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -600,17 +600,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -618,17 +618,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -636,7 +636,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -644,11 +644,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -749,7 +749,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -761,7 +761,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -780,7 +780,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -791,7 +791,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -801,11 +801,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -829,14 +829,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -861,9 +860,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -871,12 +870,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -896,12 +895,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -920,7 +920,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -939,7 +939,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.30'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_31_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -85,7 +85,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -110,7 +110,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -155,7 +155,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -223,7 +223,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -248,7 +248,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2925,15 +2925,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2941,7 +2941,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2969,7 +2969,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2983,13 +2983,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -3001,31 +3001,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -3036,7 +3036,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_31_.yml
@@ -288,7 +288,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -302,19 +302,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -376,9 +376,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -392,16 +392,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -409,9 +409,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -437,13 +437,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -453,9 +453,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -469,9 +469,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -520,7 +520,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -538,7 +538,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -600,17 +600,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -618,17 +618,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -636,7 +636,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -644,11 +644,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -749,7 +749,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -761,7 +761,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -780,7 +780,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -791,7 +791,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -801,11 +801,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -829,14 +829,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -861,9 +860,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -871,12 +870,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -896,12 +895,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -920,7 +920,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -939,7 +939,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.31'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_32_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -93,11 +93,11 @@ _basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -132,7 +132,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -185,7 +185,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -261,11 +261,11 @@ _input_basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -300,7 +300,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -3190,15 +3190,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -3206,7 +3206,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -3242,7 +3242,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -3250,7 +3250,7 @@ simple_elements:
   kpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   layer:
   - length: 1
     type:
@@ -3264,13 +3264,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -3282,31 +3282,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_32_.yml
@@ -350,8 +350,7 @@ attrib_types:
   all_atoms:
   - switch
   alpha:
-  - float
-  - string
+  - float_expression
   alpha_ex:
   - float
   analytical_cont:
@@ -367,13 +366,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   banddos:
@@ -381,8 +380,7 @@ attrib_types:
   bands:
   - int
   beta:
-  - float
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -443,9 +441,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   eb:
   - float
   ederiv:
@@ -461,18 +459,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
-  - string
+  - float_expression
   elup:
-  - float
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -480,9 +476,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   et:
   - float
   etot_correlation:
@@ -511,13 +507,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   file:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -531,9 +527,9 @@ attrib_types:
   flipspintheta:
   - string
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -549,9 +545,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   grid:
   - string
   gridpoints:
@@ -608,7 +604,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jdos:
@@ -633,7 +629,7 @@ attrib_types:
   - float
   - string
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -719,17 +715,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -737,19 +733,19 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   mag_scale:
-  - string
+  - float_expression
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -757,7 +753,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -767,11 +763,11 @@ attrib_types:
   mincalcdistance:
   - float
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minmatdistance:
   - float
   minoccdistance:
@@ -781,9 +777,9 @@ attrib_types:
   minspinup:
   - int
   mix_b:
-  - string
+  - float_expression
   mix_relaxweightoffd:
-  - string
+  - float_expression
   mixparam:
   - float
   mm:
@@ -901,7 +897,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -913,7 +909,7 @@ attrib_types:
   potential:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -932,7 +928,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -946,7 +942,7 @@ attrib_types:
   - int
   - switch
   scale:
-  - string
+  - float_expression
   secvar:
   - switch
   select:
@@ -954,12 +950,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - float
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -981,14 +976,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -1013,9 +1007,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -1025,14 +1019,14 @@ attrib_types:
   twod:
   - switch
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   typemt:
   - int
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -1052,12 +1046,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -1077,7 +1072,7 @@ attrib_types:
   vm:
   - int
   vol:
-  - string
+  - float_expression
   vzinf:
   - float
   vzir:
@@ -1085,10 +1080,10 @@ attrib_types:
   wannier:
   - switch
   warp_factor:
-  - string
+  - float_expression
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   x:
@@ -1106,7 +1101,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.32'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_33_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_33_.yml
@@ -3288,13 +3288,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_34_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_33_0_34_.yml
@@ -3304,13 +3304,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_27_.yml
@@ -220,7 +220,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - float
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -230,13 +230,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - float
+  - float_expression
   b_cons_y:
-  - float
+  - float_expression
   band:
   - switch
   beta:
-  - float
+  - float_expression
   bmt:
   - switch
   branch:
@@ -283,9 +283,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - float
+  - float_expression
   dvac:
-  - float
+  - float_expression
   ederiv:
   - int
   ef:
@@ -299,17 +299,17 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
+  - float_expression
   elup:
-  - float
+  - float_expression
   energy:
   - float
   eonly:
   - switch
   epsdisp:
-  - float
+  - float_expression
   epsforce:
-  - float
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -324,9 +324,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - float
+  - float_expression
   fermismearingtemp:
-  - float
+  - float_expression
   filename:
   - string
   flag:
@@ -344,9 +344,9 @@ attrib_types:
   gamma:
   - switch
   gmax:
-  - float
+  - float_expression
   gmaxxc:
-  - float
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -393,6 +393,7 @@ attrib_types:
   - int
   j:
   - float
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -410,7 +411,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - float
+  - float_expression
   kpoint:
   - int
   l:
@@ -456,17 +457,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - float
+  - float_expression
   locx2:
-  - float
+  - float_expression
   locy1:
-  - float
+  - float_expression
   locy2:
-  - float
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - float
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -474,31 +475,31 @@ attrib_types:
   lwb:
   - switch
   m:
-  - float
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - float
+  - float_expression
   maxeigenval:
-  - float
+  - float_expression
   maxenergy:
-  - float
+  - float_expression
   maxiterbroyd:
   - int
   maxtimetostartiter:
-  - float
+  - float_expression
   memorypernode:
   - string
   message:
   - string
   mindistance:
-  - float
+  - float_expression
   mineigenval:
-  - float
+  - float_expression
   minenergy:
-  - float
+  - float_expression
   mix_b:
   - float
   mm:
@@ -583,6 +584,7 @@ attrib_types:
   - switch
   phi:
   - float
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -609,7 +611,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - float
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -620,17 +622,17 @@ attrib_types:
   - float
   - int
   scale:
-  - float
+  - float_expression
   score:
   - switch
   secvar:
   - switch
   sig_b_1:
-  - float
+  - float_expression
   sig_b_2:
-  - float
+  - float_expression
   sigma:
-  - float
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -650,13 +652,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - float
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
+  - float_expression
   spinup:
-  - float
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -671,20 +673,22 @@ attrib_types:
   - switch
   theta:
   - float
+  - float_expression
   thetad:
   - float
   thetaj:
-  - float
+  - float_expression
   time:
   - string
   total:
   - float
   tworkf:
-  - float
+  - float_expression
   type:
   - string
   u:
   - float
+  - float_expression
   uindex:
   - int
   unitcell:
@@ -702,9 +706,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - float
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -720,6 +725,7 @@ attrib_types:
   - float
   weight:
   - float
+  - float_expression
   weightscale:
   - float
   x:
@@ -739,7 +745,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - float
+  - float_expression
 inp_version: '0.27'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_27_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_27_.yml
@@ -2701,7 +2701,7 @@ simple_elements:
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2729,7 +2729,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   kpoint:
   - length: 3
     type:
@@ -2749,31 +2749,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_28_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -77,7 +77,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -98,7 +98,7 @@ _basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -143,7 +143,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -199,7 +199,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -220,7 +220,7 @@ _input_basic_types:
     length: 3
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2844,15 +2844,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2860,7 +2860,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2884,7 +2884,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2898,9 +2898,9 @@ simple_elements:
     type:
     - float
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -2912,38 +2912,38 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_28_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_28_.yml
@@ -260,7 +260,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   angles:
   - int
   atomicnumber:
@@ -272,15 +272,15 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   bmt:
   - switch
   branch:
@@ -341,9 +341,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -361,9 +361,9 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
@@ -377,9 +377,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -398,9 +398,9 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   flag:
@@ -420,9 +420,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -469,7 +469,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -487,7 +487,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -545,17 +545,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -563,17 +563,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -581,7 +581,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -589,11 +589,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -688,7 +688,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -717,7 +717,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -728,7 +728,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -738,11 +738,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -766,14 +766,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -794,11 +793,11 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetad:
   - string
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -806,12 +805,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -831,9 +830,10 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vcaaddcharge:
   - float
@@ -853,7 +853,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -874,7 +874,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.28'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_29_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -85,7 +85,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -110,7 +110,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -155,7 +155,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -219,7 +219,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -244,7 +244,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2936,15 +2936,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2952,7 +2952,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -2980,7 +2980,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -2994,13 +2994,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -3012,31 +3012,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -3047,7 +3047,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_29_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_29_.yml
@@ -284,7 +284,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -298,19 +298,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -374,9 +374,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -394,16 +394,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -411,9 +411,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   ev:
   - switch
   ev-sum:
@@ -433,13 +433,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -449,9 +449,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - int
   form66:
@@ -465,9 +465,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -516,7 +516,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -534,7 +534,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -596,17 +596,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -614,17 +614,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -632,7 +632,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -640,11 +640,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -745,7 +745,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -776,7 +776,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -787,7 +787,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -797,11 +797,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -825,14 +825,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -857,9 +856,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -867,12 +866,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -892,12 +891,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -916,7 +916,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -935,7 +935,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.29'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_30_.yml
@@ -292,7 +292,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -306,19 +306,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -382,9 +382,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -402,16 +402,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -419,9 +419,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -447,13 +447,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -463,9 +463,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -479,9 +479,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -530,7 +530,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -548,7 +548,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -610,17 +610,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -628,17 +628,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -646,7 +646,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -654,11 +654,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -759,7 +759,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -771,7 +771,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -790,7 +790,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -801,7 +801,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -811,11 +811,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -839,14 +839,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -871,9 +870,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -881,12 +880,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -906,12 +905,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -930,7 +930,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -949,7 +949,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.30'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_30_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_30_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -89,7 +89,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -114,7 +114,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -159,7 +159,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -227,7 +227,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -252,7 +252,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2956,15 +2956,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2972,7 +2972,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -3000,7 +3000,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -3014,13 +3014,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -3032,31 +3032,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -3067,7 +3067,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_31_.yml
@@ -292,7 +292,7 @@ _input_basic_types:
     length: 1
 attrib_types:
   alpha:
-  - string
+  - float_expression
   alpha_ex:
   - float
   angles:
@@ -306,19 +306,19 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   bands:
   - int
   beta:
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -382,9 +382,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   ederiv:
   - int
   edgetype:
@@ -402,16 +402,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - string
+  - float_expression
   elup:
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -419,9 +419,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   etot_correlation:
   - int
   - string
@@ -447,13 +447,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   filename:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -463,9 +463,9 @@ attrib_types:
   flipspin:
   - switch
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -479,9 +479,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   gridpoints:
   - int
   gw:
@@ -530,7 +530,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jmtd:
@@ -548,7 +548,7 @@ attrib_types:
   kinenergy:
   - float
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -610,17 +610,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -628,17 +628,17 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -646,7 +646,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -654,11 +654,11 @@ attrib_types:
   message:
   - string
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minspindown:
   - int
   minspinup:
@@ -759,7 +759,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -771,7 +771,7 @@ attrib_types:
   pot8:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -790,7 +790,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -801,7 +801,7 @@ attrib_types:
   - float
   - int
   scale:
-  - string
+  - float_expression
   score:
   - switch
   secvar:
@@ -811,11 +811,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -839,14 +839,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -871,9 +870,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -881,12 +880,12 @@ attrib_types:
   total:
   - float
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -906,12 +905,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -930,7 +930,7 @@ attrib_types:
   - switch
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   - string
@@ -949,7 +949,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.31'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_31_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_31_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -89,7 +89,7 @@ _basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -114,7 +114,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -159,7 +159,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -227,7 +227,7 @@ _input_basic_types:
     length: 1
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   MixingEnum:
     base_types:
@@ -252,7 +252,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpgrpEnum:
     base_types:
@@ -2956,15 +2956,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -2972,7 +2972,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -3000,7 +3000,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -3014,13 +3014,13 @@ simple_elements:
     type:
     - float
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -3032,31 +3032,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
@@ -3067,7 +3067,7 @@ simple_elements:
   specialpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   targetcomputerarchitectures:
   - length: 1
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_32_.yml
@@ -5,7 +5,7 @@ _basic_types:
     length: unbounded
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -97,11 +97,11 @@ _basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -136,7 +136,7 @@ _basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -189,7 +189,7 @@ _basic_types:
 _input_basic_types:
   AtomPosType:
     base_types:
-    - string
+    - float_expression
     length: 3
   BZIntegrationModeEnum:
     base_types:
@@ -265,11 +265,11 @@ _input_basic_types:
     length: 1
   KPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   LatticeParameterType:
     base_types:
-    - string
+    - float_expression
     length: 1
   ManualCutoffType:
     base_types:
@@ -304,7 +304,7 @@ _input_basic_types:
     length: 1
   SpecialPointType:
     base_types:
-    - string
+    - float_expression
     length: 3
   SpinNumberType:
     base_types:
@@ -3221,15 +3221,15 @@ simple_elements:
   a1:
   - length: 1
     type:
-    - string
+    - float_expression
   a2:
   - length: 1
     type:
-    - string
+    - float_expression
   abspos:
   - length: 3
     type:
-    - string
+    - float_expression
   additionalcompilerflags:
   - length: unbounded
     type:
@@ -3237,7 +3237,7 @@ simple_elements:
   c:
   - length: 1
     type:
-    - string
+    - float_expression
   comment:
   - length: 1
     type:
@@ -3273,7 +3273,7 @@ simple_elements:
   filmpos:
   - length: 3
     type:
-    - string
+    - float_expression
   joblist:
   - length: unbounded
     type:
@@ -3281,7 +3281,7 @@ simple_elements:
   kpoint:
   - length: 3
     type:
-    - string
+    - float_expression
   layer:
   - length: 1
     type:
@@ -3295,13 +3295,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:
@@ -3313,31 +3313,31 @@ simple_elements:
   relpos:
   - length: 3
     type:
-    - string
+    - float_expression
   row-1:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-2:
   - length: 2
     type:
-    - string
+    - float_expression
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float
   row-3:
   - length: 3
     type:
-    - string
+    - float_expression
   - length: 4
     type:
     - float

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_32_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_32_.yml
@@ -354,8 +354,7 @@ attrib_types:
   all_atoms:
   - switch
   alpha:
-  - float
-  - string
+  - float_expression
   alpha_ex:
   - float
   analytical_cont:
@@ -371,13 +370,13 @@ attrib_types:
   autocomp:
   - switch
   b_cons_x:
-  - string
+  - float_expression
   b_cons_y:
-  - string
+  - float_expression
   b_field:
-  - string
+  - float_expression
   b_field_mt:
-  - string
+  - float_expression
   band:
   - switch
   banddos:
@@ -385,8 +384,7 @@ attrib_types:
   bands:
   - int
   beta:
-  - float
-  - string
+  - float_expression
   beta_ex:
   - float
   bmt:
@@ -449,9 +447,9 @@ attrib_types:
   dos:
   - switch
   dtilda:
-  - string
+  - float_expression
   dvac:
-  - string
+  - float_expression
   eb:
   - float
   ederiv:
@@ -471,18 +469,16 @@ attrib_types:
   element:
   - string
   ellow:
-  - float
-  - string
+  - float_expression
   elup:
-  - float
-  - string
+  - float_expression
   emax:
   - float
   emin:
   - float
   energy:
   - float
-  - string
+  - float_expression
   energylo:
   - float
   energyup:
@@ -490,9 +486,9 @@ attrib_types:
   eonly:
   - switch
   epsdisp:
-  - string
+  - float_expression
   epsforce:
-  - string
+  - float_expression
   et:
   - float
   etot_correlation:
@@ -521,13 +517,13 @@ attrib_types:
   f_z:
   - float
   fermismearingenergy:
-  - string
+  - float_expression
   fermismearingtemp:
-  - string
+  - float_expression
   file:
   - string
   fixed_moment:
-  - string
+  - float_expression
   flag:
   - string
   fleurinputversion:
@@ -541,9 +537,9 @@ attrib_types:
   flipspintheta:
   - string
   force_converged:
-  - string
+  - float_expression
   forcealpha:
-  - string
+  - float_expression
   forcemix:
   - string
   form66:
@@ -559,9 +555,9 @@ attrib_types:
   gcutm:
   - float
   gmax:
-  - string
+  - float_expression
   gmaxxc:
-  - string
+  - float_expression
   grid:
   - string
   gridpoints:
@@ -618,7 +614,7 @@ attrib_types:
   - int
   j:
   - float
-  - string
+  - float_expression
   jatom:
   - int
   jdos:
@@ -643,7 +639,7 @@ attrib_types:
   - float
   - string
   kmax:
-  - string
+  - float_expression
   kpoint:
   - int
   l:
@@ -729,17 +725,17 @@ attrib_types:
   lnonsphr:
   - int
   locx1:
-  - string
+  - float_expression
   locx2:
-  - string
+  - float_expression
   locy1:
-  - string
+  - float_expression
   locy2:
-  - string
+  - float_expression
   logderivmt:
   - float
   logincrement:
-  - string
+  - float_expression
   lostelectrons:
   - float
   lpr:
@@ -747,19 +743,19 @@ attrib_types:
   lwb:
   - switch
   m:
-  - string
+  - float_expression
   m_cyl:
   - int
   mag_scale:
-  - string
+  - float_expression
   magfield:
   - float
   magmom:
-  - string
+  - float_expression
   maxeigenval:
-  - string
+  - float_expression
   maxenergy:
-  - string
+  - float_expression
   maxiterbroyd:
   - int
   maxspindown:
@@ -767,7 +763,7 @@ attrib_types:
   maxspinup:
   - int
   maxtimetostartiter:
-  - string
+  - float_expression
   mcd:
   - switch
   memorypernode:
@@ -777,11 +773,11 @@ attrib_types:
   mincalcdistance:
   - float
   mindistance:
-  - string
+  - float_expression
   mineigenval:
-  - string
+  - float_expression
   minenergy:
-  - string
+  - float_expression
   minmatdistance:
   - float
   minoccdistance:
@@ -791,9 +787,9 @@ attrib_types:
   minspinup:
   - int
   mix_b:
-  - string
+  - float_expression
   mix_relaxweightoffd:
-  - string
+  - float_expression
   mixparam:
   - float
   mm:
@@ -911,7 +907,7 @@ attrib_types:
   - switch
   phi:
   - float
-  - string
+  - float_expression
   plot_charge:
   - switch
   plot_rho:
@@ -923,7 +919,7 @@ attrib_types:
   potential:
   - switch
   precondparam:
-  - string
+  - float_expression
   purpose:
   - string
   q:
@@ -942,7 +938,7 @@ attrib_types:
   qz:
   - int
   radius:
-  - string
+  - float_expression
   relativisticcorrections:
   - switch
   relaxxyz:
@@ -956,7 +952,7 @@ attrib_types:
   - int
   - switch
   scale:
-  - string
+  - float_expression
   secvar:
   - switch
   select:
@@ -964,12 +960,11 @@ attrib_types:
   sgwf:
   - switch
   sig_b_1:
-  - string
+  - float_expression
   sig_b_2:
-  - string
+  - float_expression
   sigma:
-  - float
-  - string
+  - float_expression
   sigma_x:
   - float
   sigma_y:
@@ -991,14 +986,13 @@ attrib_types:
   spin:
   - int
   spindown:
-  - string
+  - float_expression
   spindowncharge:
   - float
   spinf:
-  - float
-  - string
+  - float_expression
   spinup:
-  - string
+  - float_expression
   spinupcharge:
   - float
   sso_opt:
@@ -1023,9 +1017,9 @@ attrib_types:
   - switch
   theta:
   - float
-  - string
+  - float_expression
   thetaj:
-  - string
+  - float_expression
   time:
   - string
   tolerance:
@@ -1035,14 +1029,14 @@ attrib_types:
   twod:
   - switch
   tworkf:
-  - string
+  - float_expression
   type:
   - string
   typemt:
   - int
   u:
   - float
-  - string
+  - float_expression
   uindex:
   - int
   unfoldband:
@@ -1062,12 +1056,13 @@ attrib_types:
   vacuum2:
   - float
   valenceelectrons:
-  - string
+  - float_expression
   value:
   - float
+  - float_expression
   - string
   vca_charge:
-  - string
+  - float_expression
   vcaaddcharge:
   - float
   vchk:
@@ -1087,7 +1082,7 @@ attrib_types:
   vm:
   - int
   vol:
-  - string
+  - float_expression
   vzinf:
   - float
   vzir:
@@ -1095,10 +1090,10 @@ attrib_types:
   wannier:
   - switch
   warp_factor:
-  - string
+  - float_expression
   weight:
   - float
-  - string
+  - float_expression
   weightscale:
   - float
   x:
@@ -1116,7 +1111,7 @@ attrib_types:
   zrfs1:
   - switch
   zsigma:
-  - string
+  - float_expression
 inp_version: '0.32'
 input_tag: fleurInput
 iteration_other_attribs:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_33_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_33_.yml
@@ -3319,13 +3319,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_34_.yml
+++ b/masci_tools/tests/test_schema_dict/test_outschema_dict_0_34_0_34_.yml
@@ -3335,13 +3335,13 @@ simple_elements:
     type:
     - switch
   posforce:
-  - length: 1
+  - length: 6
     type:
-    - string
+    - float_expression
   q:
-  - length: 1
+  - length: 3
     type:
-    - string
+    - float_expression
   qsc:
   - length: 3
     type:

--- a/masci_tools/util/xml/xml_getters.py
+++ b/masci_tools/util/xml/xml_getters.py
@@ -281,7 +281,6 @@ def get_cell(xmltree, schema_dict, logger=None):
     from masci_tools.util.schema_dict_util import read_constants, eval_simple_xpath
     from masci_tools.util.schema_dict_util import evaluate_text, tag_exists
     from masci_tools.util.xml.common_functions import clear_xml
-    from masci_tools.util.xml.converters import convert_xml_attribute
     from masci_tools.util.constants import BOHR_A
     import numpy as np
 
@@ -325,12 +324,6 @@ def get_cell(xmltree, schema_dict, logger=None):
                              optional=True)
 
         if all(x is not None and x != [] for x in [row1, row2, row3]):
-            #Explicit Conversion to float for versions Max4 and before
-            if schema_dict.inp_version < (0, 33):
-                row1, suc = convert_xml_attribute(row1, ['float_expression'], constants=constants, logger=logger)
-                row2, suc = convert_xml_attribute(row2, ['float_expression'], constants=constants, logger=logger)
-                row3, suc = convert_xml_attribute(row3, ['float_expression'], constants=constants, logger=logger)
-
             cell = np.array([row1, row2, row3]) * BOHR_A
 
     if cell is None:
@@ -361,7 +354,7 @@ def get_parameter_data(xmltree, schema_dict, inpgen_ready=True, write_ids=True, 
     from masci_tools.util.schema_dict_util import read_constants, eval_simple_xpath
     from masci_tools.util.schema_dict_util import evaluate_attribute, evaluate_text
     from masci_tools.util.xml.common_functions import clear_xml
-    from masci_tools.util.xml.converters import convert_fleur_lo, convert_xml_attribute
+    from masci_tools.util.xml.converters import convert_fleur_lo
     from masci_tools.io.common_functions import filter_out_empty_dict_entries
 
     # TODO: convert econfig
@@ -401,18 +394,6 @@ def get_parameter_data(xmltree, schema_dict, inpgen_ready=True, write_ids=True, 
     comp_dict['gmax'] = evaluate_attribute(root, schema_dict, 'gmax', constants=constants, logger=logger)
     comp_dict['gmaxxc'] = evaluate_attribute(root, schema_dict, 'gmaxxc', constants=constants, logger=logger)
     comp_dict['kmax'] = evaluate_attribute(root, schema_dict, 'kmax', constants=constants, logger=logger)
-
-    if schema_dict.inp_version <= (0, 31):
-        comp_dict['gmax'], _ = convert_xml_attribute(comp_dict['gmax'], ['float', 'float_expression'],
-                                                     constants=constants,
-                                                     logger=logger)
-        comp_dict['gmaxxc'], _ = convert_xml_attribute(comp_dict['gmaxxc'], ['float', 'float_expression'],
-                                                       constants=constants,
-                                                       logger=logger)
-        comp_dict['kmax'], _ = convert_xml_attribute(comp_dict['kmax'], ['float', 'float_expression'],
-                                                     constants=constants,
-                                                     logger=logger)
-
     parameters['comp'] = filter_out_empty_dict_entries(comp_dict)
 
     # &atoms
@@ -453,18 +434,6 @@ def get_parameter_data(xmltree, schema_dict, inpgen_ready=True, write_ids=True, 
 
         if len(atom_lo) != 0:
             atom_dict['lo'] = convert_fleur_lo(atom_lo)
-
-        if schema_dict.inp_version <= (0, 31):
-            atom_dict['bmu'], _ = convert_xml_attribute(atom_dict['bmu'], ['float', 'float_expression'],
-                                                        constants=constants,
-                                                        logger=logger)
-            atom_dict['dx'], _ = convert_xml_attribute(atom_dict['dx'], ['float', 'float_expression'],
-                                                       constants=constants,
-                                                       logger=logger)
-            atom_dict['rmt'], _ = convert_xml_attribute(atom_dict['rmt'], ['float', 'float_expression'],
-                                                        constants=constants,
-                                                        logger=logger)
-
         parameters[atoms_name] = filter_out_empty_dict_entries(atom_dict)
 
     # &soc
@@ -484,10 +453,6 @@ def get_parameter_data(xmltree, schema_dict, inpgen_ready=True, write_ids=True, 
                              logger=logger,
                              optional=True)
     if soc is not None and soc:
-        if schema_dict.inp_version <= (0, 31):
-            theta, _ = convert_xml_attribute(theta, ['float', 'float_expression'], constants=constants, logger=logger)
-            phi, _ = convert_xml_attribute(phi, ['float', 'float_expression'], constants=constants, logger=logger)
-
         parameters['soc'] = {'theta': theta, 'phi': phi}
 
     # &kpt
@@ -550,7 +515,6 @@ def get_structure_data(xmltree, schema_dict, logger=None):
     from masci_tools.util.schema_dict_util import read_constants, eval_simple_xpath
     from masci_tools.util.schema_dict_util import evaluate_text, evaluate_attribute
     from masci_tools.util.xml.common_functions import clear_xml
-    from masci_tools.util.xml.converters import convert_xml_attribute
     from masci_tools.io.common_functions import rel_to_abs, rel_to_abs_f
 
     if isinstance(xmltree, etree._ElementTree):
@@ -616,20 +580,6 @@ def get_structure_data(xmltree, schema_dict, logger=None):
                                        logger=logger,
                                        optional=True)
 
-        if schema_dict.inp_version < (0, 33):
-            for indx, pos in enumerate(absolute_positions):
-                absolute_positions[indx], suc = convert_xml_attribute(pos, ['float', 'float_expression'],
-                                                                      constants=constants,
-                                                                      logger=logger)
-            for indx, pos in enumerate(relative_positions):
-                relative_positions[indx], suc = convert_xml_attribute(pos, ['float', 'float_expression'],
-                                                                      constants=constants,
-                                                                      logger=logger)
-            for indx, pos in enumerate(film_positions):
-                film_positions[indx], suc = convert_xml_attribute(pos, ['float', 'float_expression'],
-                                                                  constants=constants,
-                                                                  logger=logger)
-
         atom_positions = absolute_positions
 
         for rel_pos in relative_positions:
@@ -678,7 +628,6 @@ def get_kpoints_data(xmltree, schema_dict, name=None, index=None, logger=None):
     from masci_tools.util.schema_dict_util import read_constants, eval_simple_xpath
     from masci_tools.util.schema_dict_util import evaluate_text, evaluate_attribute
     from masci_tools.util.xml.common_functions import clear_xml
-    from masci_tools.util.xml.converters import convert_xml_attribute
 
     if name is not None and index is not None:
         raise ValueError('Only provide one of index or name to select kpoint lists')
@@ -725,16 +674,6 @@ def get_kpoints_data(xmltree, schema_dict, name=None, index=None, logger=None):
                                      list_return=True,
                                      logger=logger)
 
-        if schema_dict.inp_version == (0, 32):
-            for indx, kpoint in enumerate(kpoints):
-                kpoints[indx], suc = convert_xml_attribute(kpoint, ['float', 'float_expression'],
-                                                           constants=constants,
-                                                           logger=logger)
-            weights, suc = convert_xml_attribute(weights, ['float', 'float_expression'],
-                                                 constants=constants,
-                                                 list_return=True,
-                                                 logger=logger)
-
         if not isinstance(kpoints[0], list):
             kpoints = [kpoints]
             weights = [weights]
@@ -776,7 +715,6 @@ def get_kpoints_data_max4(xmltree, schema_dict, logger=None):
     from masci_tools.util.schema_dict_util import read_constants, eval_simple_xpath
     from masci_tools.util.schema_dict_util import evaluate_text, evaluate_attribute
     from masci_tools.util.xml.common_functions import clear_xml
-    from masci_tools.util.xml.converters import convert_xml_attribute
 
     if isinstance(xmltree, etree._ElementTree):
         xmltree, _ = clear_xml(xmltree)
@@ -815,15 +753,6 @@ def get_kpoints_data_max4(xmltree, schema_dict, logger=None):
                                  list_return=True,
                                  logger=logger)
 
-    for indx, kpoint in enumerate(kpoints):
-        kpoints[indx], suc = convert_xml_attribute(kpoint, ['float', 'float_expression'],
-                                                   constants=constants,
-                                                   logger=logger)
-    weights, suc = convert_xml_attribute(weights, ['float', 'float_expression'],
-                                         constants=constants,
-                                         list_return=True,
-                                         logger=logger)
-
     return kpoints, weights, cell, pbc
 
 
@@ -844,7 +773,6 @@ def get_relaxation_information(xmltree, schema_dict, logger=None):
     """
     from masci_tools.util.schema_dict_util import tag_exists, read_constants, evaluate_text, eval_simple_xpath
     from masci_tools.util.schema_dict_util import evaluate_attribute
-    from masci_tools.util.xml.converters import convert_xml_attribute, convert_xml_text
     from masci_tools.util.xml.common_functions import clear_xml
 
     if isinstance(xmltree, etree._ElementTree):
@@ -867,26 +795,17 @@ def get_relaxation_information(xmltree, schema_dict, logger=None):
                                               constants=constants,
                                               logger=logger)
 
-    energies = evaluate_attribute(relax_tag,
-                                  schema_dict,
-                                  'energy',
-                                  list_return=True,
-                                  constants=constants,
-                                  logger=logger)
-    out_dict['energies'], _ = convert_xml_attribute(energies, ['float', 'float_expression'],
-                                                    list_return=True,
-                                                    logger=logger)
+    out_dict['energies'] = evaluate_attribute(relax_tag,
+                                              schema_dict,
+                                              'energy',
+                                              list_return=True,
+                                              constants=constants,
+                                              logger=logger)
 
     out_dict['posforces'] = []
     relax_iters = eval_simple_xpath(relax_tag, schema_dict, 'step', list_return=True, logger=logger)
     for step in relax_iters:
         posforces = evaluate_text(step, schema_dict, 'posforce', list_return=True, constants=constants, logger=logger)
-        posforces, _ = convert_xml_text(posforces, [{
-            'length': 6,
-            'type': ['float', 'float_expression']
-        }],
-                                        list_return=True,
-                                        logger=logger)
         out_dict['posforces'].append(posforces)
 
     return out_dict


### PR DESCRIPTION
Closes #47 

Here we add the first examples of functions that are inserted after the automatic collection of information from the schema files and before the creation of the schema_dict objects, which can not be mutated.

The aim of these functions is to correct ambiguous definitions in the schema files, without modifying the schema files themselves, since they should be frozen to correspond to the exact file that was present at the fleur realease with the given input version.

For now the only example of this is that previously attributes that were allowed to contain mathematical expressions were marked as string and were not picked up by the `masci-tools` functions to be passed into its calculator because of this