### PR TITLE
XPathBuilder

### DIFF
--- a/docs/source/module_guide/tools.rst
+++ b/docs/source/module_guide/tools.rst
@@ -20,6 +20,9 @@ Common XML utility
 .. automodule:: masci_tools.util.xml.converters
    :members:
 
+.. automodule:: masci_tools.util.xml.xpathbuilder
+   :members:
+
 XML Setter functions
 ---------------------
 

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -359,6 +359,8 @@ class FleurXMLModifier:
         :param species_name: string, name of the specie you want to change
                              Can be name of the species, 'all' or 'all-<string>' (sets species with the string in the species name)
         :param attributedict: a python dict specifying what you want to change.
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         :param create: bool, if species does not exist create it and all subtags?
 
         **attributedict** is a python dictionary containing dictionaries that specify attributes
@@ -412,6 +414,11 @@ class FleurXMLModifier:
         :param new_species_name: name of the species to switch to
         :param position: position of an atom group to be changed. If equals to 'all', all species will be changed
         :param species: atom groups, corresponding to the given species will be changed
+        :param clone: if True and the new species name does not exist and it corresponds to changing
+                  from one species the species will be cloned with :py:func:`clone_species()`
+        :param changes: changes to do if the species is cloned
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details`
         """
         self._validate_signature('switch_species', *args, **kwargs)
         self._tasks.append(ModifierTask('switch_species', args, kwargs))
@@ -423,6 +430,9 @@ class FleurXMLModifier:
 
         :param atom_label: string, a label of the atom which group will be changed. 'all' to change all the groups
         :param new_species_name: name of the species to switch to
+        :param clone: if True and the new species name does not exist and it corresponds to changing
+                  from one species the species will be cloned with :py:func:`clone_species()`
+        :param changes: changes to do if the species is cloned
         """
         self._validate_signature('switch_species_label', *args, **kwargs)
         self._tasks.append(ModifierTask('switch_species_label', args, kwargs))
@@ -454,6 +464,8 @@ class FleurXMLModifier:
         :param position: position of an atom group to be changed. If equals to 'all', all species will be changed
         :param species: atom groups, corresponding to the given species will be changed
         :param create: bool, if species does not exist create it and all subtags?
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
         **attributedict** is a python dictionary containing dictionaries that specify attributes
         to be set inside the certain specie. For example, if one wants to set a beta noco parameter it
@@ -495,6 +507,9 @@ class FleurXMLModifier:
                                the parent tags are created recursively
         :param occurrences: int or list of int. Which occurence of the parent nodes to create a tag.
                             By default all nodes are used.
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -512,6 +527,9 @@ class FleurXMLModifier:
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param occurrences: int or list of int. Which occurence of the parent nodes to delete a tag.
                             By default all nodes are used.
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -529,6 +547,9 @@ class FleurXMLModifier:
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param occurrences: int or list of int. Which occurence of the parent nodes to delete a attribute.
                             By default all nodes are used.
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -550,6 +571,9 @@ class FleurXMLModifier:
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param occurrences: int or list of int. Which occurence of the parent nodes to replace a tag.
                             By default all nodes are used.
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -569,6 +593,9 @@ class FleurXMLModifier:
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param create: bool optional (default False), if True and the path, where the complex tag is
                        set does not exist it is created
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -589,6 +616,9 @@ class FleurXMLModifier:
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param create_parents: bool optional (default False), if True and the path, where the simple tags are
                                set does not exist it is created
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -607,6 +637,9 @@ class FleurXMLModifier:
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param occurrences: int or list of int. Which occurence of the node to set. By default all are set.
         :param create: bool optional (default False), if True the tag is created if is missing
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -625,6 +658,9 @@ class FleurXMLModifier:
         :param text: value or list of values to set
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param create: bool optional (default False), if True the tag is created if is missing
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -644,6 +680,9 @@ class FleurXMLModifier:
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param occurrences: int or list of int. Which occurence of the node to set. By default all are set.
         :param create: bool optional (default False), if True the tag is created if is missing
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -665,6 +704,9 @@ class FleurXMLModifier:
         :param attribv: value or list of values to set
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param create: bool optional (default False), if True the tag is created if is missing
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -689,6 +731,9 @@ class FleurXMLModifier:
                      `rel` multiplies the old value with `add_number`
                      `abs` adds the old value and `add_number`
         :param occurrences: int or list of int. Which occurence of the node to set. By default all are set.
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -712,6 +757,9 @@ class FleurXMLModifier:
         :param mode: str (either `rel` or `abs`).
                      `rel` multiplies the old value with `add_number`
                      `abs` adds the old value and `add_number`
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -815,6 +863,8 @@ class FleurXMLModifier:
         :param denmat: matrix, specify the density matrix explicitely
         :param phi: float, optional angle (radian), by which to rotate the density matrix before writing it
         :param theta: float, optional angle (radian), by which to rotate the density matrix before writing it
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         """
         self._validate_signature('set_nmmpmat', *args, **kwargs)
         self._tasks.append(ModifierTask('set_nmmpmat', args, kwargs))
@@ -828,6 +878,8 @@ class FleurXMLModifier:
         :param orbital: integer, orbital quantum number of the LDA+U procedure to be modified
         :param phi: float, angle (radian), by which to rotate the density matrix
         :param theta: float, angle (radian), by which to rotate the density matrix
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         """
         self._validate_signature('rotate_nmmpmat', *args, **kwargs)
         self._tasks.append(ModifierTask('rotate_nmmpmat', args, kwargs))

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -265,12 +265,13 @@ def evaluate_attribute(node: Union[etree._Element, etree._ElementTree],
     attrib_xpath = _select_attrib_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
 
     if complex_xpath is None:
-        complex_xpath = attrib_xpath
-        if filters is not None:
-            complex_xpath = XPathBuilder(complex_xpath, strict=True, filters=filters)
+        complex_xpath = XPathBuilder(attrib_xpath, filters=filters)
     elif filters is not None:
-        raise ValueError('Only provide one of the arguments filters or complex_xpath')
-
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
     check_complex_xpath(node, attrib_xpath, complex_xpath)
 
     stringattribute: List[str] = eval_xpath(node, complex_xpath, logger=logger, list_return=True)  #type:ignore
@@ -340,11 +341,13 @@ def evaluate_text(node: Union[etree._Element, etree._ElementTree],
 
     tag_xpath = _select_tag_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
     if complex_xpath is None:
-        complex_xpath = tag_xpath
-        if filters is not None:
-            complex_xpath = XPathBuilder(complex_xpath, strict=True, filters=filters)
+        complex_xpath = XPathBuilder(tag_xpath, filters=filters)
     elif filters is not None:
-        raise ValueError('Only provide one of the arguments filters or complex_xpath')
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
 
     check_complex_xpath(node, tag_xpath, complex_xpath)
 
@@ -428,11 +431,13 @@ def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
 
     tag_xpath = _select_tag_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
     if complex_xpath is None:
-        complex_xpath = tag_xpath
-        if filters is not None:
-            complex_xpath = XPathBuilder(complex_xpath, strict=True, filters=filters)
+        complex_xpath = XPathBuilder(tag_xpath, filters=filters)
     elif filters is not None:
-        raise ValueError('Only provide one of the arguments filters or complex_xpath')
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
 
     check_complex_xpath(node, tag_xpath, complex_xpath)
 
@@ -679,11 +684,13 @@ def evaluate_parent_tag(node: Union[etree._Element, etree._ElementTree],
 
     tag_xpath = _select_tag_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
     if complex_xpath is None:
-        complex_xpath = tag_xpath
-        if filters is not None:
-            complex_xpath = XPathBuilder(complex_xpath, strict=True, filters=filters)
+        complex_xpath = XPathBuilder(tag_xpath, filters=filters)
     elif filters is not None:
-        raise ValueError('Only provide one of the arguments filters or complex_xpath')
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
 
     check_complex_xpath(node, tag_xpath, complex_xpath)
 
@@ -892,10 +899,9 @@ def eval_simple_xpath(node: Union[etree._Element, etree._ElementTree],
 
     list_return = kwargs.pop('list_return', False)
     tag_xpath = _select_tag_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
-    if filters is not None:
-        tag_xpath = XPathBuilder(tag_xpath, strict=True, filters=filters)  #type:ignore
+    tag_xpath_builder = XPathBuilder(tag_xpath, strict=True, filters=filters)
 
-    return eval_xpath(node, tag_xpath, logger=logger, list_return=list_return)
+    return eval_xpath(node, tag_xpath_builder, logger=logger, list_return=list_return)
 
 
 def _select_tag_xpath(node: Union[etree._Element, etree._ElementTree],

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -21,6 +21,7 @@ from masci_tools.io.parsers.fleur_schema import NoPathFound
 from masci_tools.util.parse_tasks_decorators import register_parsing_function
 from masci_tools.io.parsers import fleur_schema
 from masci_tools.util.xml.common_functions import check_complex_xpath
+from masci_tools.util.xml.xpathbuilder import XPathBuilder, FilterType
 from lxml import etree
 from logging import Logger
 import warnings
@@ -227,6 +228,7 @@ def evaluate_attribute(node: Union[etree._Element, etree._ElementTree],
                        constants: Dict[str, float] = None,
                        logger: Logger = None,
                        complex_xpath: 'etree._xpath' = None,
+                       filters: FilterType = None,
                        iteration_path: bool = False,
                        **kwargs: Any) -> Any:
     """
@@ -263,6 +265,10 @@ def evaluate_attribute(node: Union[etree._Element, etree._ElementTree],
 
     if complex_xpath is None:
         complex_xpath = attrib_xpath
+        if filters is not None:
+            complex_xpath = XPathBuilder(complex_xpath,strict=True, filters=filters)
+    elif filters is not None:
+        raise ValueError('Only provide one of the arguments filters or complex_xpath')
 
     check_complex_xpath(node, attrib_xpath, complex_xpath)
 
@@ -302,6 +308,7 @@ def evaluate_text(node: Union[etree._Element, etree._ElementTree],
                   logger: Logger = None,
                   complex_xpath: 'etree._xpath' = None,
                   iteration_path: bool = False,
+                  filters: FilterType = None,
                   **kwargs: Any) -> Any:
     """
     Evaluates the text of the tag based on the given name
@@ -333,6 +340,10 @@ def evaluate_text(node: Union[etree._Element, etree._ElementTree],
     tag_xpath = _select_tag_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
     if complex_xpath is None:
         complex_xpath = tag_xpath
+        if filters is not None:
+            complex_xpath = XPathBuilder(complex_xpath, strict=True, filters=filters)
+    elif filters is not None:
+        raise ValueError('Only provide one of the arguments filters or complex_xpath')
 
     check_complex_xpath(node, tag_xpath, complex_xpath)
 
@@ -379,6 +390,7 @@ def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
                  text: bool = True,
                  complex_xpath: 'etree._xpath' = None,
                  iteration_path: bool = False,
+                 filters: FilterType = None,
                  **kwargs: Any) -> Any:
     """
     Evaluates all attributes of the tag based on the given name
@@ -416,6 +428,10 @@ def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
     tag_xpath = _select_tag_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
     if complex_xpath is None:
         complex_xpath = tag_xpath
+        if filters is not None:
+            complex_xpath = XPathBuilder(complex_xpath, strict=True, filters=filters)
+    elif filters is not None:
+        raise ValueError('Only provide one of the arguments filters or complex_xpath')
 
     check_complex_xpath(node, tag_xpath, complex_xpath)
 
@@ -627,6 +643,7 @@ def evaluate_parent_tag(node: Union[etree._Element, etree._ElementTree],
                         logger: Logger = None,
                         complex_xpath: 'etree._xpath' = None,
                         iteration_path: bool = False,
+                        filters: FilterType = None,
                         **kwargs: Any) -> Any:
     """
     Evaluates all attributes of the parent tag based on the given name
@@ -662,6 +679,10 @@ def evaluate_parent_tag(node: Union[etree._Element, etree._ElementTree],
     tag_xpath = _select_tag_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
     if complex_xpath is None:
         complex_xpath = tag_xpath
+        if filters is not None:
+            complex_xpath = XPathBuilder(complex_xpath, strict=True, filters=filters)
+    elif filters is not None:
+        raise ValueError('Only provide one of the arguments filters or complex_xpath')
 
     check_complex_xpath(node, tag_xpath, complex_xpath)
 
@@ -846,6 +867,7 @@ def eval_simple_xpath(node: Union[etree._Element, etree._ElementTree],
                       name: str,
                       logger: Logger = None,
                       iteration_path: bool = False,
+                      filters: FilterType = None,
                       **kwargs: Any) -> 'etree._XPathObject':
     """
     Evaluates a simple xpath expression of the tag in the xmltree based on the given name
@@ -869,6 +891,9 @@ def eval_simple_xpath(node: Union[etree._Element, etree._ElementTree],
 
     list_return = kwargs.pop('list_return', False)
     tag_xpath = _select_tag_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
+    if filters is not None:
+        tag_xpath = XPathBuilder(tag_xpath, strict=True, filters=filters)
+    
     return eval_xpath(node, tag_xpath, logger=logger, list_return=list_return)
 
 

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -244,6 +244,8 @@ def evaluate_attribute(node: Union[etree._Element, etree._ElementTree],
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param iteration_path: bool if True and the SchemaDict is of an output schema an absolute path into
                            the iteration element is constructed
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     Kwargs:
         :param tag_name: str, name of the tag where the attribute should be parsed
@@ -324,6 +326,8 @@ def evaluate_text(node: Union[etree._Element, etree._ElementTree],
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param iteration_path: bool if True and the SchemaDict is of an output schema an absolute path into
                            the iteration element is constructed
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     Kwargs:
         :param contains: str, this string has to be in the final path
@@ -410,6 +414,8 @@ def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param iteration_path: bool if True and the SchemaDict is of an output schema an absolute path into
                            the iteration element is constructed
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     Kwargs:
         :param contains: str, this string has to be in the final path
@@ -613,6 +619,8 @@ def evaluate_single_value_tag(node: Union[etree._Element, etree._ElementTree],
         :param strict_missing_error: if True, and no logger is given an error is raised if any attribute is not found
         :param iteration_path: bool if True and the SchemaDict is of an output schema an absolute path into
                                the iteration element is constructed
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     :returns: value and unit, both converted in convert_xml_attribute
     """
@@ -663,6 +671,8 @@ def evaluate_parent_tag(node: Union[etree._Element, etree._ElementTree],
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param iteration_path: bool if True and the SchemaDict is of an output schema an absolute path into
                            the iteration element is constructed
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     Kwargs:
         :param contains: str, this string has to be in the final path
@@ -784,6 +794,7 @@ def attrib_exists(node: Union[etree._Element, etree._ElementTree],
                   name: str,
                   logger: Logger = None,
                   iteration_path: bool = False,
+                  filters: FilterType = None,
                   **kwargs: Any) -> bool:
     """
     Evaluates whether the attribute exists in the xmltree based on the given name
@@ -795,6 +806,8 @@ def attrib_exists(node: Union[etree._Element, etree._ElementTree],
     :param logger: logger object for logging warnings, errors, if not provided all errors will be raised
     :param iteration_path: bool if True and the SchemaDict is of an output schema an absolute path into
                            the iteration element is constructed
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     Kwargs:
         :param tag_name: str, name of the tag where the attribute should be parsed
@@ -809,9 +822,9 @@ def attrib_exists(node: Union[etree._Element, etree._ElementTree],
 
     attrib_xpath = _select_attrib_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
     tag_xpath, attrib_name = split_off_attrib(attrib_xpath)
+    tag_xpath_builder = XPathBuilder(tag_xpath, filters=filters)
 
-    tags: List[etree._Element] = eval_xpath(node, tag_xpath, logger=logger, list_return=True)  #type:ignore
-
+    tags: List[etree._Element] = eval_xpath(node, tag_xpath_builder, logger=logger, list_return=True)  #type:ignore
     return any(attrib_name in tag.attrib for tag in tags)
 
 
@@ -835,6 +848,8 @@ def tag_exists(node: Union[etree._Element, etree._ElementTree],
         :param not_contains: str, this string has to NOT be in the final path
         :param iteration_path: bool if True and the SchemaDict is of an output schema an absolute path into
                            the iteration element is constructed
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     :returns: bool, True if any nodes with the path exist
     """
@@ -861,6 +876,8 @@ def get_number_of_nodes(node: Union[etree._Element, etree._ElementTree],
         :param not_contains: str, this string has to NOT be in the final path
         :param iteration_path: bool if True and the SchemaDict is of an output schema an absolute path into
                            the iteration element is constructed
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     :returns: bool, True if any nodes with the path exist
     """
@@ -887,6 +904,8 @@ def eval_simple_xpath(node: Union[etree._Element, etree._ElementTree],
     :param logger: logger object for logging warnings, errors, if not provided all errors will be raised
     :param iteration_path: bool if True and the SchemaDict is of an output schema an absolute path into
                            the iteration element is constructed
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     Kwargs:
         :param contains: str, this string has to be in the final path

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -22,6 +22,7 @@ from masci_tools.util.parse_tasks_decorators import register_parsing_function
 from masci_tools.io.parsers import fleur_schema
 from masci_tools.util.xml.common_functions import check_complex_xpath
 from masci_tools.util.xml.xpathbuilder import XPathBuilder, FilterType
+from masci_tools.util.typing import XPathLike
 from lxml import etree
 from logging import Logger
 import warnings
@@ -227,7 +228,7 @@ def evaluate_attribute(node: Union[etree._Element, etree._ElementTree],
                        name: str,
                        constants: Dict[str, float] = None,
                        logger: Logger = None,
-                       complex_xpath: 'etree._xpath' = None,
+                       complex_xpath: XPathLike = None,
                        filters: FilterType = None,
                        iteration_path: bool = False,
                        **kwargs: Any) -> Any:
@@ -266,7 +267,7 @@ def evaluate_attribute(node: Union[etree._Element, etree._ElementTree],
     if complex_xpath is None:
         complex_xpath = attrib_xpath
         if filters is not None:
-            complex_xpath = XPathBuilder(complex_xpath,strict=True, filters=filters)
+            complex_xpath = XPathBuilder(complex_xpath, strict=True, filters=filters)
     elif filters is not None:
         raise ValueError('Only provide one of the arguments filters or complex_xpath')
 
@@ -306,7 +307,7 @@ def evaluate_text(node: Union[etree._Element, etree._ElementTree],
                   name: str,
                   constants: Dict[str, float] = None,
                   logger: Logger = None,
-                  complex_xpath: 'etree._xpath' = None,
+                  complex_xpath: XPathLike = None,
                   iteration_path: bool = False,
                   filters: FilterType = None,
                   **kwargs: Any) -> Any:
@@ -388,7 +389,7 @@ def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
                  logger: Logger = None,
                  subtags: bool = False,
                  text: bool = True,
-                 complex_xpath: 'etree._xpath' = None,
+                 complex_xpath: XPathLike = None,
                  iteration_path: bool = False,
                  filters: FilterType = None,
                  **kwargs: Any) -> Any:
@@ -585,7 +586,7 @@ def evaluate_single_value_tag(node: Union[etree._Element, etree._ElementTree],
                               name: str,
                               constants: Dict[str, float] = None,
                               logger: Logger = None,
-                              complex_xpath: 'etree._xpath' = None,
+                              complex_xpath: XPathLike = None,
                               **kwargs: Any) -> Any:
     """
     Evaluates the value and unit attribute of the tag based on the given name
@@ -641,7 +642,7 @@ def evaluate_parent_tag(node: Union[etree._Element, etree._ElementTree],
                         name: str,
                         constants: Dict[str, float] = None,
                         logger: Logger = None,
-                        complex_xpath: 'etree._xpath' = None,
+                        complex_xpath: XPathLike = None,
                         iteration_path: bool = False,
                         filters: FilterType = None,
                         **kwargs: Any) -> Any:
@@ -892,8 +893,8 @@ def eval_simple_xpath(node: Union[etree._Element, etree._ElementTree],
     list_return = kwargs.pop('list_return', False)
     tag_xpath = _select_tag_xpath(node, schema_dict, name, iteration_path=iteration_path, **kwargs)
     if filters is not None:
-        tag_xpath = XPathBuilder(tag_xpath, strict=True, filters=filters)
-    
+        tag_xpath = XPathBuilder(tag_xpath, strict=True, filters=filters)  #type:ignore
+
     return eval_xpath(node, tag_xpath, logger=logger, list_return=list_return)
 
 

--- a/masci_tools/util/typing.py
+++ b/masci_tools/util/typing.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+"""
+This module defines some aliases used in typing
+"""
+from typing import Union
+from lxml import etree
+
+#Type for xml setters/getters for xpath objects that can be used in `eval_xpath`
+from masci_tools.util.xml.xpathbuilder import XPathBuilder
+
+XPathLike = Union['etree._xpath', XPathBuilder]

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -294,8 +294,10 @@ def eval_xpath(node: Union[etree._Element, etree._ElementTree, 'etree._XPathEval
         if logger is not None:
             logger.exception(
                 'There was a XpathEvalError on the xpath: %s \n'
-                'Either it does not exist, or something is wrong with the expression.', xpath)
+                'The following variables were passed: %s \n'
+                'Either it does not exist, or something is wrong with the expression.', xpath, variables)
         raise ValueError(f'There was a XpathEvalError on the xpath: {str(xpath)} \n'
+                         f'The following variables were passed: {variables} \n'
                          'Either it does not exist, or something is wrong with the expression.') from err
     if isinstance(return_value, list):
         if len(return_value) == 1 and not list_return:

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -339,6 +339,7 @@ TXPathLike = TypeVar('TXPathLike', bound=XPathLike)
 Type for xpath expressions
 """
 
+
 def split_off_tag(xpath: TXPathLike) -> Tuple[TXPathLike, str]:
     """
     Splits off the last part of the given xpath

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -335,7 +335,9 @@ def get_xml_attribute(node: etree._Element, attributename: str, logger: Logger =
 
 
 TXPathLike = TypeVar('TXPathLike', bound=XPathLike)
-
+"""
+Type for xpath expressions
+"""
 
 def split_off_tag(xpath: TXPathLike) -> Tuple[TXPathLike, str]:
     """

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -393,7 +393,7 @@ def add_tag(xpath: TXPathLike, tag: str) -> TXPathLike:
     elif isinstance(xpath, etree.XPath):
         xpath = cast(TXPathLike, etree.XPath(f'{str(xpath.path)}/{tag}'))  #type:ignore [attr-defined]
     else:
-        xpath = cast(TXPathLike, f"{str(xpath.rstrip('/'))}/{tag}")
+        xpath = cast(TXPathLike, f"{str(xpath).rstrip('/')}/{tag}")
     return xpath
 
 

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -35,8 +35,6 @@ def clear_xml(tree: etree._ElementTree) -> Tuple[etree._ElementTree, Set[str]]:
 
     :returns: cleared_tree, an xmltree without comments and with replaced xinclude tags
     """
-    import copy
-
     cleared_tree = copy.deepcopy(tree)
 
     #Remove comments outside the root element (Since they have no parents this would lead to a crash)
@@ -136,7 +134,6 @@ def reverse_xinclude(
 
     :raises ValueError: if the tag can not be found in teh given xmltree
     """
-    import copy
 
     INCLUDE_NSMAP = {'xi': 'http://www.w3.org/2001/XInclude'}
     INCLUDE_TAG = etree.QName(INCLUDE_NSMAP['xi'], 'include')

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -393,7 +393,7 @@ def add_tag(xpath: TXPathLike, tag: str) -> TXPathLike:
     elif isinstance(xpath, etree.XPath):
         xpath = cast(TXPathLike, etree.XPath(f'{str(xpath.path)}/{tag}'))  #type:ignore [attr-defined]
     else:
-        xpath = cast(TXPathLike, f'{str(xpath)}/{tag}')
+        xpath = cast(TXPathLike, f"{str(xpath.rstrip('/'))}/{tag}")
     return xpath
 
 

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -21,6 +21,8 @@ from logging import Logger
 if TYPE_CHECKING:
     from masci_tools.io.parsers import fleur_schema
 
+from .xpathbuilder import XPathBuilder
+
 
 def clear_xml(tree: etree._ElementTree) -> Tuple[etree._ElementTree, Set[str]]:
     """
@@ -255,6 +257,9 @@ def eval_xpath(node: Union[etree._Element, etree._ElementTree, 'etree._XPathEval
 
     :returns: text, attribute or a node list
     """
+    if isinstance(xpath, XPathBuilder):
+        xpath = xpath.path
+        variables = {**variables, **xpath.path_variables}
 
     if not isinstance(node, (etree._Element, etree._ElementTree, etree._XPathEvaluatorBase)):  #pylint: disable=protected-access
         if logger is not None:

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -17,13 +17,14 @@ in :py:mod:`~masci_tools.util.xml.xml_setters_xpaths` since we need the schema d
 to do these operations robustly
 """
 from typing import Iterable, Union, List, Any, cast
+from masci_tools.util.typing import XPathLike
 from lxml import etree
 from masci_tools.util.xml.common_functions import eval_xpath
 import warnings
 
 
 def xml_replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
-                    xpath: 'etree._xpath',
+                    xpath: XPathLike,
                     newelement: etree._Element,
                     occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -71,7 +72,7 @@ def xml_replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
 
 
 def xml_delete_att(xmltree: Union[etree._Element, etree._ElementTree],
-                   xpath: 'etree._xpath',
+                   xpath: XPathLike,
                    attrib: str,
                    occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -112,7 +113,7 @@ def xml_delete_att(xmltree: Union[etree._Element, etree._ElementTree],
 
 
 def xml_delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
-                   xpath: 'etree._xpath',
+                   xpath: XPathLike,
                    occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
     """
     Deletes a xml tag in an xmletree.
@@ -190,7 +191,7 @@ def _reorder_tags(node: etree._Element, tag_order: List[str]) -> etree._Element:
 
 
 def xml_create_tag(xmltree: Union[etree._Element, etree._ElementTree],
-                   xpath: 'etree._xpath',
+                   xpath: XPathLike,
                    element: Union[str, etree._Element],
                    place_index: int = None,
                    tag_order: List[str] = None,
@@ -323,7 +324,7 @@ def xml_create_tag(xmltree: Union[etree._Element, etree._ElementTree],
 
 def xml_set_attrib_value_no_create(
         xmltree: Union[etree._Element, etree._ElementTree],
-        xpath: 'etree._xpath',
+        xpath: XPathLike,
         attributename: str,
         attribv: Any,
         occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
@@ -377,7 +378,7 @@ def xml_set_attrib_value_no_create(
 
 
 def xml_set_text_no_create(xmltree: Union[etree._Element, etree._ElementTree],
-                           xpath: 'etree._xpath',
+                           xpath: XPathLike,
                            text: Any,
                            occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
     """

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -17,10 +17,11 @@ in :py:mod:`~masci_tools.util.xml.xml_setters_xpaths` since we need the schema d
 to do these operations robustly
 """
 from typing import Iterable, Union, List, Any, cast
-from masci_tools.util.typing import XPathLike
 from lxml import etree
-from masci_tools.util.xml.common_functions import eval_xpath
 import warnings
+
+from masci_tools.util.typing import XPathLike
+from masci_tools.util.xml.common_functions import eval_xpath
 
 
 def xml_replace_tag(xmltree: Union[etree._Element, etree._ElementTree],

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -33,6 +33,7 @@ def create_tag(xmltree: Union[etree._Element, etree._ElementTree],
                schema_dict: 'fleur_schema.SchemaDict',
                tag: Union[str, etree._Element],
                complex_xpath: XPathLike = None,
+               filters: FilterType = None,
                create_parents: bool = False,
                occurrences: Union[int, Iterable[int]] = None,
                **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
@@ -70,7 +71,13 @@ def create_tag(xmltree: Union[etree._Element, etree._ElementTree],
     parent_xpath, tag_name = split_off_tag(base_xpath)
 
     if complex_xpath is None:
-        complex_xpath = parent_xpath
+        complex_xpath = XPathBuilder(parent_xpath, filters=filters)
+    elif filters is not None:
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
 
     xmltree = xml_create_tag_schema_dict(xmltree,
                                          schema_dict,
@@ -87,6 +94,7 @@ def delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
                schema_dict: 'fleur_schema.SchemaDict',
                tag_name: str,
                complex_xpath: XPathLike = None,
+               filters: FilterType = None,
                occurrences: Union[int, Iterable[int]] = None,
                **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -111,7 +119,13 @@ def delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
     base_xpath = schema_dict.tag_xpath(tag_name, **kwargs)
 
     if complex_xpath is None:
-        complex_xpath = base_xpath
+        complex_xpath = XPathBuilder(base_xpath, filters=filters)
+    elif filters is not None:
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
     check_complex_xpath(xmltree, base_xpath, complex_xpath)
 
     return xml_delete_tag(xmltree, complex_xpath, occurrences=occurrences)
@@ -121,6 +135,7 @@ def delete_att(xmltree: Union[etree._Element, etree._ElementTree],
                schema_dict: 'fleur_schema.SchemaDict',
                attrib_name: str,
                complex_xpath: XPathLike = None,
+               filters: FilterType = None,
                occurrences: Union[int, Iterable[int]] = None,
                **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -149,7 +164,13 @@ def delete_att(xmltree: Union[etree._Element, etree._ElementTree],
     tag_xpath, attrib_name = split_off_attrib(base_xpath)
 
     if complex_xpath is None:
-        complex_xpath = tag_xpath
+        complex_xpath = XPathBuilder(tag_xpath, filters=filters)
+    elif filters is not None:
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
     check_complex_xpath(xmltree, tag_xpath, complex_xpath)
 
     return xml_delete_att(xmltree, complex_xpath, attrib_name, occurrences=occurrences)
@@ -160,6 +181,7 @@ def replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
                 tag_name: str,
                 newelement: etree._Element,
                 complex_xpath: XPathLike = None,
+                filters: FilterType = None,
                 occurrences: Union[int, Iterable[int]] = None,
                 **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -185,7 +207,13 @@ def replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
     base_xpath = schema_dict.tag_xpath(tag_name, **kwargs)
 
     if complex_xpath is None:
-        complex_xpath = base_xpath
+        complex_xpath = XPathBuilder(base_xpath, filters=filters)
+    elif filters is not None:
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
     check_complex_xpath(xmltree, base_xpath, complex_xpath)
 
     return xml_replace_tag(xmltree, complex_xpath, newelement, occurrences=occurrences)
@@ -196,6 +224,7 @@ def add_number_to_attrib(xmltree: Union[etree._Element, etree._ElementTree],
                          attributename: str,
                          add_number: Any,
                          complex_xpath: XPathLike = None,
+                         filters: FilterType = None,
                          mode: Literal['abs', 'rel'] = 'abs',
                          occurrences: Union[int, Iterable[int]] = None,
                          **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
@@ -230,7 +259,13 @@ def add_number_to_attrib(xmltree: Union[etree._Element, etree._ElementTree],
     base_xpath, attributename = split_off_attrib(attrib_xpath)
 
     if complex_xpath is None:
-        complex_xpath = base_xpath
+        complex_xpath = XPathBuilder(base_xpath, filters=filters)
+    elif filters is not None:
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
 
     return xml_add_number_to_attrib(xmltree,
                                     schema_dict,
@@ -247,6 +282,7 @@ def add_number_to_first_attrib(xmltree: Union[etree._Element, etree._ElementTree
                                attributename: str,
                                add_number: Any,
                                complex_xpath: XPathLike = None,
+                               filters: FilterType = None,
                                mode: Literal['abs', 'rel'] = 'abs',
                                **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -279,6 +315,7 @@ def add_number_to_first_attrib(xmltree: Union[etree._Element, etree._ElementTree
                                 complex_xpath=complex_xpath,
                                 mode=mode,
                                 occurrences=0,
+                                filters=filters,
                                 **kwargs)
 
 
@@ -287,6 +324,7 @@ def set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
                      attributename: str,
                      attribv: Any,
                      complex_xpath: XPathLike = None,
+                     filters: FilterType = None,
                      occurrences: Union[int, Iterable[int]] = None,
                      create: bool = False,
                      **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
@@ -328,7 +366,13 @@ def set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
     base_xpath, attributename = split_off_attrib(base_xpath)
 
     if complex_xpath is None:
-        complex_xpath = base_xpath
+        complex_xpath = XPathBuilder(base_xpath, filters=filters)
+    elif filters is not None:
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
 
     return xml_set_attrib_value(xmltree,
                                 schema_dict,
@@ -345,6 +389,7 @@ def set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
                            attributename: str,
                            attribv: Any,
                            complex_xpath: XPathLike = None,
+                           filters: FilterType = None,
                            create: bool = False,
                            **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -378,6 +423,7 @@ def set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
                             complex_xpath=complex_xpath,
                             create=create,
                             occurrences=0,
+                            filters=filters,
                             **kwargs)
 
 
@@ -386,6 +432,7 @@ def set_text(xmltree: Union[etree._Element, etree._ElementTree],
              tag_name: str,
              text: Any,
              complex_xpath: XPathLike = None,
+             filters: FilterType = None,
              occurrences: Union[int, Iterable[int]] = None,
              create: bool = False,
              **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
@@ -416,7 +463,13 @@ def set_text(xmltree: Union[etree._Element, etree._ElementTree],
     base_xpath = schema_dict.tag_xpath(tag_name, **kwargs)
 
     if complex_xpath is None:
-        complex_xpath = base_xpath
+        complex_xpath = XPathBuilder(base_xpath, filters=filters)
+    elif filters is not None:
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
 
     return xml_set_text(xmltree, schema_dict, complex_xpath, base_xpath, text, occurrences=occurrences, create=create)
 
@@ -426,6 +479,7 @@ def set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
                    attributename: str,
                    attribv: Any,
                    complex_xpath: XPathLike = None,
+                   filters: FilterType = None,
                    create: bool = False,
                    **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -456,6 +510,7 @@ def set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
                     complex_xpath=complex_xpath,
                     create=create,
                     occurrences=0,
+                    filters=filters,
                     **kwargs)
 
 
@@ -464,6 +519,7 @@ def set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
                    tag_name: str,
                    changes: Union[List[Dict[str, Any]], Dict[str, Any]],
                    complex_xpath: XPathLike = None,
+                   filters: FilterType = None,
                    create_parents: bool = False,
                    **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -500,7 +556,13 @@ def set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
     assert len(tag_info['simple'] | tag_info['complex']) == 0, f"Given tag '{tag_name}' is not simple"
 
     if complex_xpath is None:
-        complex_xpath = parent_xpath
+        complex_xpath = XPathBuilder(parent_xpath, filters=filters)
+    elif filters is not None:
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
 
     return xml_set_simple_tag(xmltree,
                               schema_dict,
@@ -516,6 +578,7 @@ def set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
                     tag_name: str,
                     changes: Dict[str, Any],
                     complex_xpath: XPathLike = None,
+                    filters: FilterType = None,
                     create: bool = False,
                     **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -551,7 +614,13 @@ def set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
     base_xpath = schema_dict.tag_xpath(tag_name, **kwargs)
 
     if complex_xpath is None:
-        complex_xpath = base_xpath
+        complex_xpath = XPathBuilder(base_xpath, filters=filters)
+    elif filters is not None:
+        if not isinstance(complex_xpath, XPathBuilder):
+            raise ValueError(
+                'Provide only one of filters or complex_xpath (Except when complx_xpath is given as a XPathBuilder)')
+        for key, val in filters.items():
+            complex_xpath.add_filter(key, val)
 
     return xml_set_complex_tag(xmltree, schema_dict, complex_xpath, base_xpath, changes, create=create)
 

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -1042,11 +1042,7 @@ def shift_value(xmltree: Union[etree._Element, etree._ElementTree],
 
         key_spec = path_spec_case.get(key, {})
         #This method only support unique and unique_path attributes
-        if 'exclude' not in key_spec:
-            key_spec['exclude'] = ['other']
-        elif 'other' not in key_spec['exclude']:
-            key_spec['exclude'].append('other')
-
+        key_spec.setdefault('exclude', []).append('other')
         xmltree = add_number_to_first_attrib(xmltree, schema_dict, key, value_given, mode=mode, **key_spec)
 
     return xmltree
@@ -1097,10 +1093,7 @@ def set_inpchanges(xmltree: Union[etree._Element, etree._ElementTree],
 
         key_spec = path_spec_case.get(key, {})
         #This method only support unique and unique_path attributes
-        if 'exclude' not in key_spec:
-            key_spec['exclude'] = ['other']
-        elif 'other' not in key_spec['exclude']:
-            key_spec['exclude'].append('other')
+        key_spec.setdefault('exclude',[]).append('other')
 
         key_xpath = schema_dict.attrib_xpath(key, **key_spec)
 

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -47,6 +47,8 @@ def create_tag(xmltree: Union[etree._Element, etree._ElementTree],
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param tag: str of the tag to create or etree Element with the same name to insert
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param create_parents: bool optional (default False), if True and the given xpath has no results the
                            the parent tags are created recursively
     :param occurrences: int or list of int. Which occurence of the parent nodes to create a tag.
@@ -104,6 +106,8 @@ def delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param tag: str of the tag to delete
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param occurrences: int or list of int. Which occurence of the parent nodes to delete a tag.
                         By default all nodes are used.
 
@@ -145,6 +149,8 @@ def delete_att(xmltree: Union[etree._Element, etree._ElementTree],
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param tag: str of the attribute to delete
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param occurrences: int or list of int. Which occurence of the parent nodes to delete a attribute.
                         By default all nodes are used.
 
@@ -192,6 +198,8 @@ def replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
     :param tag: str of the tag to replace
     :param newelement: etree Element to replace the tag
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param occurrences: int or list of int. Which occurence of the parent nodes to replace a tag.
                         By default all nodes are used.
 
@@ -238,6 +246,8 @@ def add_number_to_attrib(xmltree: Union[etree._Element, etree._ElementTree],
     :param attributename: the attribute name to change
     :param add_number: number to add/multiply with the old attribute value
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param mode: str (either `rel` or `abs`).
                  `rel` multiplies the old value with `add_number`
                  `abs` adds the old value and `add_number`
@@ -341,6 +351,8 @@ def set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
     :param attributename: the attribute name to set
     :param attribv: value or list of values to set
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param occurrences: int or list of int. Which occurence of the node to set. By default all are set.
     :param create: bool optional (default False), if True the tag is created if is missing
 
@@ -405,6 +417,8 @@ def set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
     :param attributename: the attribute name to set
     :param attribv: value or list of values to set
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param create: bool optional (default False), if True the tag is created if is missing
 
     Kwargs:
@@ -449,6 +463,8 @@ def set_text(xmltree: Union[etree._Element, etree._ElementTree],
     :param tag_name: str name of the tag, where the text should be set
     :param text: value or list of values to set
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param occurrences: int or list of int. Which occurence of the node to set. By default all are set.
     :param create: bool optional (default False), if True the tag is created if is missing
 
@@ -495,6 +511,8 @@ def set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
     :param tag_name: str name of the tag, where the text should be set
     :param text: value or list of values to set
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param create: bool optional (default False), if True the tag is created if is missing
 
     Kwargs:
@@ -534,6 +552,8 @@ def set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
     :param changes: list of dicts or dict with the changes. Elements in list describe multiple tags.
                     Keys in the dictionary correspond to {'attributename': attributevalue}
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param create_parents: bool optional (default False), if True and the path, where the simple tags are
                            set does not exist it is created
 
@@ -600,6 +620,8 @@ def set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
     :param attributedict: Keys in the dictionary correspond to names of tags and the values are the modifications
                           to do on this tag (attributename, subdict with changes to the subtag, ...)
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
     :param create: bool optional (default False), if True and the path, where the complex tag is
                    set does not exist it is created
 
@@ -682,6 +704,8 @@ def set_species(xmltree: Union[etree._Element, etree._ElementTree],
                          Can be name of the species, 'all' or 'all-<string>' (sets species with the string in the species name)
     :param attributedict: a python dict specifying what you want to change.
     :param create: bool, if species does not exist create it and all subtags?
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     :raises ValueError: if species name is non existent in inp.xml and should not be created.
                         also if other given tags are garbage. (errors from eval_xpath() methods)
@@ -888,6 +912,8 @@ def set_atomgroup(xmltree: Union[etree._Element, etree._ElementTree],
     :param position: position of an atom group to be changed. If equals to 'all', all species will be changed
     :param species: atom groups, corresponding to the given species will be changed
     :param create: bool, if species does not exist create it and all subtags?
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     :returns: xml etree of the new inp.xml
 
@@ -988,6 +1014,8 @@ def switch_species(xmltree: Union[etree._Element, etree._ElementTree],
     :param clone: if True and the new species name does not exist and it corresponds to changing
                   from one species the species will be cloned with :py:func:`clone_species()`
     :param changes: changes to do if the species is cloned
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     :returns: xml etree of the new inp.xml
     """

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -20,6 +20,8 @@ try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal  #type:ignore
+from masci_tools.util.typing import XPathLike
+from masci_tools.util.xml.xpathbuilder import XPathBuilder
 from lxml import etree
 from masci_tools.io.parsers.fleur_schema import schema_dict_version_dispatch
 from masci_tools.io.parsers import fleur_schema
@@ -28,7 +30,7 @@ from masci_tools.io.parsers import fleur_schema
 def create_tag(xmltree: Union[etree._Element, etree._ElementTree],
                schema_dict: 'fleur_schema.SchemaDict',
                tag: Union[str, etree._Element],
-               complex_xpath: 'etree._xpath' = None,
+               complex_xpath: XPathLike = None,
                create_parents: bool = False,
                occurrences: Union[int, Iterable[int]] = None,
                **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
@@ -82,7 +84,7 @@ def create_tag(xmltree: Union[etree._Element, etree._ElementTree],
 def delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
                schema_dict: 'fleur_schema.SchemaDict',
                tag_name: str,
-               complex_xpath: 'etree._xpath' = None,
+               complex_xpath: XPathLike = None,
                occurrences: Union[int, Iterable[int]] = None,
                **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -119,7 +121,7 @@ def delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
 def delete_att(xmltree: Union[etree._Element, etree._ElementTree],
                schema_dict: 'fleur_schema.SchemaDict',
                attrib_name: str,
-               complex_xpath: 'etree._xpath' = None,
+               complex_xpath: XPathLike = None,
                occurrences: Union[int, Iterable[int]] = None,
                **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -162,7 +164,7 @@ def replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
                 schema_dict: 'fleur_schema.SchemaDict',
                 tag_name: str,
                 newelement: etree._Element,
-                complex_xpath: 'etree._xpath' = None,
+                complex_xpath: XPathLike = None,
                 occurrences: Union[int, Iterable[int]] = None,
                 **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -201,7 +203,7 @@ def add_number_to_attrib(xmltree: Union[etree._Element, etree._ElementTree],
                          schema_dict: 'fleur_schema.SchemaDict',
                          attributename: str,
                          add_number: Any,
-                         complex_xpath: 'etree._xpath' = None,
+                         complex_xpath: XPathLike = None,
                          mode: Literal['abs', 'rel'] = 'abs',
                          occurrences: Union[int, Iterable[int]] = None,
                          **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
@@ -255,7 +257,7 @@ def add_number_to_first_attrib(xmltree: Union[etree._Element, etree._ElementTree
                                schema_dict: 'fleur_schema.SchemaDict',
                                attributename: str,
                                add_number: Any,
-                               complex_xpath: 'etree._xpath' = None,
+                               complex_xpath: XPathLike = None,
                                mode: Literal['abs', 'rel'] = 'abs',
                                **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -295,7 +297,7 @@ def set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
                      schema_dict: 'fleur_schema.SchemaDict',
                      attributename: str,
                      attribv: Any,
-                     complex_xpath: 'etree._xpath' = None,
+                     complex_xpath: XPathLike = None,
                      occurrences: Union[int, Iterable[int]] = None,
                      create: bool = False,
                      **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
@@ -359,7 +361,7 @@ def set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
                            schema_dict: 'fleur_schema.SchemaDict',
                            attributename: str,
                            attribv: Any,
-                           complex_xpath: 'etree._xpath' = None,
+                           complex_xpath: XPathLike = None,
                            create: bool = False,
                            **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -400,7 +402,7 @@ def set_text(xmltree: Union[etree._Element, etree._ElementTree],
              schema_dict: 'fleur_schema.SchemaDict',
              tag_name: str,
              text: Any,
-             complex_xpath: 'etree._xpath' = None,
+             complex_xpath: XPathLike = None,
              occurrences: Union[int, Iterable[int]] = None,
              create: bool = False,
              **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
@@ -448,7 +450,7 @@ def set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
                    schema_dict: 'fleur_schema.SchemaDict',
                    attributename: str,
                    attribv: Any,
-                   complex_xpath: 'etree._xpath' = None,
+                   complex_xpath: XPathLike = None,
                    create: bool = False,
                    **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -486,7 +488,7 @@ def set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
                    schema_dict: 'fleur_schema.SchemaDict',
                    tag_name: str,
                    changes: Union[List[Dict[str, Any]], Dict[str, Any]],
-                   complex_xpath: 'etree._xpath' = None,
+                   complex_xpath: XPathLike = None,
                    create_parents: bool = False,
                    **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -538,7 +540,7 @@ def set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
                     schema_dict: 'fleur_schema.SchemaDict',
                     tag_name: str,
                     changes: Dict[str, Any],
-                    complex_xpath: 'etree._xpath' = None,
+                    complex_xpath: XPathLike = None,
                     create: bool = False,
                     **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
     """
@@ -665,15 +667,14 @@ def set_species(xmltree: Union[etree._Element, etree._ElementTree],
 
     base_xpath_species = schema_dict.tag_xpath('species')
 
+    xpath_species = XPathBuilder(base_xpath_species)
     # TODO lowercase everything
     # TODO make a general specifier for species, not only the name i.e. also
     # number, other parameters
-    if species_name == 'all':
-        xpath_species = base_xpath_species
+    if not species_name.startswith('all'):
+        xpath_species.add_filter('species', {'name': {'=': species_name}})
     elif species_name[:4] == 'all-':  #format all-<string>
-        xpath_species = f'{base_xpath_species}[contains(@name,"{species_name[4:]}")]'
-    else:
-        xpath_species = f'{base_xpath_species}[@name = "{species_name}"]'
+        xpath_species.add_filter('species', {'name': {'contains': species_name[4:]}})
 
     return xml_set_complex_tag(xmltree, schema_dict, xpath_species, base_xpath_species, attributedict, create=create)
 

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -20,11 +20,13 @@ try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal  #type:ignore
+
 from masci_tools.util.typing import XPathLike
 from masci_tools.util.xml.xpathbuilder import XPathBuilder
-from lxml import etree
 from masci_tools.io.parsers.fleur_schema import schema_dict_version_dispatch
 from masci_tools.io.parsers import fleur_schema
+
+from lxml import etree
 
 
 def create_tag(xmltree: Union[etree._Element, etree._ElementTree],
@@ -667,7 +669,7 @@ def set_species(xmltree: Union[etree._Element, etree._ElementTree],
 
     base_xpath_species = schema_dict.tag_xpath('species')
 
-    xpath_species = XPathBuilder(base_xpath_species)
+    xpath_species = XPathBuilder(base_xpath_species, strict=True)
     # TODO lowercase everything
     # TODO make a general specifier for species, not only the name i.e. also
     # number, other parameters

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -889,22 +889,21 @@ def set_atomgroup(xmltree: Union[etree._Element, etree._ElementTree],
 
     """
     from masci_tools.util.xml.xml_setters_xpaths import xml_set_complex_tag
+    from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
     atomgroup_base_path = schema_dict.tag_xpath('atomGroup')
-    atomgroup_xpath = atomgroup_base_path
+    atomgroup_xpath = XPathBuilder(atomgroup_base_path, strict=True)
 
     if not position and not species:  # not specfied what to change
         return xmltree
 
-    if position:
-        if not position == 'all':
-            atomgroup_xpath = f'{atomgroup_base_path}[{position}]'
-    if species:
-        if not species == 'all':
-            if species[:4] == 'all-':  #format all-<string>
-                atomgroup_xpath = f'{atomgroup_base_path}[contains(@species,"{species[4:]}")]'
-            else:
-                atomgroup_xpath = f'{atomgroup_base_path}[@species = "{species}"]'
+    if position and position != 'all':
+        atomgroup_xpath.add_filter('atomGroup',{'index': position})
+    if species and species != 'all':
+        if species[:4] == 'all-':  #format all-<string>
+            atomgroup_xpath.add_filter('atomGroup', {'species': {'contains': species[4:]}})
+        else:
+            atomgroup_xpath.add_filter('atomGroup', {'species': {'=': species}})
 
     species_change = dict(attributedict).pop('species', None)  #dict to avoid mutating attributedict
     if species_change is not None:

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -673,10 +673,10 @@ def set_species(xmltree: Union[etree._Element, etree._ElementTree],
     # TODO lowercase everything
     # TODO make a general specifier for species, not only the name i.e. also
     # number, other parameters
-    if not species_name.startswith('all'):
-        xpath_species.add_filter('species', {'name': {'=': species_name}})
-    elif species_name[:4] == 'all-':  #format all-<string>
+    if species_name[:4] == 'all-':  #format all-<string>
         xpath_species.add_filter('species', {'name': {'contains': species_name[4:]}})
+    elif species_name != 'all':
+        xpath_species.add_filter('species', {'name': {'=': species_name}})
 
     return xml_set_complex_tag(xmltree, schema_dict, xpath_species, base_xpath_species, attributedict, create=create)
 

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -15,8 +15,7 @@ Functions for modifying the xml input file of Fleur utilizing the schema dict
 and as little knowledge of the concrete xpaths as possible
 """
 import warnings
-from typing import Any, Iterable, List, Set, Union, Dict, Tuple
-from masci_tools.util.schema_dict_util import evaluate_attribute
+from typing import Any, Iterable, List, Union, Dict, Tuple
 try:
     from typing import Literal
 except ImportError:
@@ -115,7 +114,7 @@ def delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
         complex_xpath = base_xpath
     check_complex_xpath(xmltree, base_xpath, complex_xpath)
 
-    return  xml_delete_tag(xmltree, complex_xpath, occurrences=occurrences)
+    return xml_delete_tag(xmltree, complex_xpath, occurrences=occurrences)
 
 
 def delete_att(xmltree: Union[etree._Element, etree._ElementTree],
@@ -156,7 +155,6 @@ def delete_att(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_delete_att(xmltree, complex_xpath, attrib_name, occurrences=occurrences)
 
 
-
 def replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
                 schema_dict: 'fleur_schema.SchemaDict',
                 tag_name: str,
@@ -191,7 +189,6 @@ def replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
     check_complex_xpath(xmltree, base_xpath, complex_xpath)
 
     return xml_replace_tag(xmltree, complex_xpath, newelement, occurrences=occurrences)
-
 
 
 def add_number_to_attrib(xmltree: Union[etree._Element, etree._ElementTree],
@@ -236,13 +233,13 @@ def add_number_to_attrib(xmltree: Union[etree._Element, etree._ElementTree],
         complex_xpath = base_xpath
 
     return xml_add_number_to_attrib(xmltree,
-                                       schema_dict,
-                                       complex_xpath,
-                                       base_xpath,
-                                       attributename,
-                                       add_number,
-                                       mode=mode,
-                                       occurrences=occurrences)
+                                    schema_dict,
+                                    complex_xpath,
+                                    base_xpath,
+                                    attributename,
+                                    add_number,
+                                    mode=mode,
+                                    occurrences=occurrences)
 
 
 def add_number_to_first_attrib(xmltree: Union[etree._Element, etree._ElementTree],
@@ -334,13 +331,13 @@ def set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
         complex_xpath = base_xpath
 
     return xml_set_attrib_value(xmltree,
-                                   schema_dict,
-                                   complex_xpath,
-                                   base_xpath,
-                                   attributename,
-                                   attribv,
-                                   occurrences=occurrences,
-                                   create=create)
+                                schema_dict,
+                                complex_xpath,
+                                base_xpath,
+                                attributename,
+                                attribv,
+                                occurrences=occurrences,
+                                create=create)
 
 
 def set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
@@ -421,13 +418,7 @@ def set_text(xmltree: Union[etree._Element, etree._ElementTree],
     if complex_xpath is None:
         complex_xpath = base_xpath
 
-    return xml_set_text(xmltree,
-                           schema_dict,
-                           complex_xpath,
-                           base_xpath,
-                           text,
-                           occurrences=occurrences,
-                           create=create)
+    return xml_set_text(xmltree, schema_dict, complex_xpath, base_xpath, text, occurrences=occurrences, create=create)
 
 
 def set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
@@ -588,12 +579,18 @@ def set_species_label(xmltree: Union[etree._Element, etree._ElementTree],
         return set_species(xmltree, schema_dict, 'all', attributedict, create=create)
 
     film = tag_exists(xmltree, schema_dict, 'filmPos')
-    label_path = f"/{'filmPos' if film else 'relPos'}/@label"        
-    
-    species_to_set = set(evaluate_attribute(xmltree, schema_dict, 'species', filters = {
-            'atomGroup': {label_path: {'=': f'{atom_label: >20}'}}
-        }, list_return=True))
+    label_path = f"/{'filmPos' if film else 'relPos'}/@label"
 
+    species_to_set = set(
+        evaluate_attribute(xmltree,
+                           schema_dict,
+                           'species',
+                           filters={'atomGroup': {
+                               label_path: {
+                                   '=': f'{atom_label: >20}'
+                               }
+                           }},
+                           list_return=True))
 
     for species_name in species_to_set:
         xmltree = set_species(xmltree, schema_dict, species_name, attributedict, create=create)
@@ -605,7 +602,7 @@ def set_species(xmltree: Union[etree._Element, etree._ElementTree],
                 schema_dict: 'fleur_schema.SchemaDict',
                 species_name: str,
                 attributedict: Dict[str, Any],
-                filters: FilterType=None,
+                filters: FilterType = None,
                 create: bool = False) -> Union[etree._Element, etree._ElementTree]:
     """
     Method to set parameters of a species tag of the fleur inp.xml file.
@@ -748,10 +745,8 @@ def shift_value_species_label(xmltree: Union[etree._Element, etree._ElementTree]
     label_path = f"/{'filmPos' if film else 'relPos'}/@label"
     filters = None
     if atom_label != 'all':
-        filters = {
-            'atomGroup': {label_path: {'=': f'{atom_label: >20}'}}
-        }
-    
+        filters = {'atomGroup': {label_path: {'=': f'{atom_label: >20}'}}}
+
     species_to_set = set(evaluate_attribute(xmltree, schema_dict, 'species', filters=filters, list_return=True))
 
     for species_name in species_to_set:
@@ -1050,7 +1045,7 @@ def set_inpchanges(xmltree: Union[etree._Element, etree._ElementTree],
 
         key_spec = path_spec_case.get(key, {})
         #This method only support unique and unique_path attributes
-        key_spec.setdefault('exclude',[]).append('other')
+        key_spec.setdefault('exclude', []).append('other')
 
         key_xpath = schema_dict.attrib_xpath(key, **key_spec)
         if key not in schema_dict['attrib_types']:

--- a/masci_tools/util/xml/xml_setters_nmmpmat.py
+++ b/masci_tools/util/xml/xml_setters_nmmpmat.py
@@ -47,6 +47,8 @@ def set_nmmpmat(xmltree: Union[etree._Element, etree._ElementTree],
     :param denmat: matrix, specify the density matrix explicitely
     :param phi: float, optional angle (radian), by which to rotate the density matrix before writing it
     :param theta: float, optional angle (radian), by which to rotate the density matrix before writing it
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     :raises ValueError: If something in the input is wrong
     :raises KeyError: If no LDA+U procedure is found on a species
@@ -156,6 +158,8 @@ def rotate_nmmpmat(xmltree: Union[etree._Element, etree._ElementTree],
     :param orbital: integer, orbital quantum number of the LDA+U procedure to be modified
     :param phi: float, angle (radian), by which to rotate the density matrix
     :param theta: float, angle (radian), by which to rotate the density matrix
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     :raises ValueError: If something in the input is wrong
     :raises KeyError: If no LDA+U procedure is found on a species

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -15,6 +15,8 @@ Functions for modifying the xml input file of Fleur with explicit xpath argument
 These can still use the schema dict for finding information about the xpath
 """
 from typing import Any, Iterable, List, Union, Dict, cast, Tuple
+
+from masci_tools.util.xml.xpathbuilder import XPathBuilder
 try:
     from typing import Literal
 except ImportError:
@@ -415,12 +417,15 @@ def xml_add_number_to_attrib(
             f'Allowed attributes are: {attribs.original_case.values()}')
     attributename = attribs.original_case[attributename]
 
-    if not str(xpath).endswith(f'/@{attributename}'):
+    if isinstance(xpath, XPathBuilder):
+        if '@' not in xpath.components[-1]:
+            xpath.append_tag(f'@{attributename}')
+    elif not str(xpath).endswith(f'/@{attributename}'):
         xpath = '/@'.join([str(xpath), attributename])
 
     stringattribute: List[str] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
 
-    tag_xpath, attributename = split_off_attrib(str(xpath))
+    tag_xpath, attributename = split_off_attrib(xpath)
 
     if len(stringattribute) == 0:
         raise ValueError(f"No attribute values found for '{attributename}'. Cannot add number")

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -19,11 +19,12 @@ try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal  #type:ignore
+
 from masci_tools.util.typing import XPathLike
-from lxml import etree
 from masci_tools.util.xml.common_functions import eval_xpath, add_tag
 from masci_tools.io.parsers import fleur_schema
-######################CREATING/DELETING TAGS###############################################
+
+from lxml import etree
 
 
 def xml_create_tag_schema_dict(
@@ -61,8 +62,6 @@ def xml_create_tag_schema_dict(
     from masci_tools.util.xml.common_functions import check_complex_xpath, split_off_tag
 
     check_complex_xpath(xmltree, base_xpath, xpath)
-
-    print(repr(xpath), xpath)
 
     tag_info = schema_dict['tag_info'][base_xpath]
 

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -15,13 +15,12 @@ Functions for modifying the xml input file of Fleur with explicit xpath argument
 These can still use the schema dict for finding information about the xpath
 """
 from typing import Any, Iterable, List, Union, Dict, cast, Tuple
-
-from masci_tools.util.xml.xpathbuilder import XPathBuilder
 try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal  #type:ignore
 
+from masci_tools.util.xml.xpathbuilder import XPathBuilder
 from masci_tools.util.typing import XPathLike
 from masci_tools.util.xml.common_functions import eval_xpath, add_tag
 from masci_tools.io.parsers import fleur_schema

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -19,8 +19,9 @@ try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal  #type:ignore
+from masci_tools.util.typing import XPathLike
 from lxml import etree
-from masci_tools.util.xml.common_functions import eval_xpath
+from masci_tools.util.xml.common_functions import eval_xpath, add_tag
 from masci_tools.io.parsers import fleur_schema
 ######################CREATING/DELETING TAGS###############################################
 
@@ -28,7 +29,7 @@ from masci_tools.io.parsers import fleur_schema
 def xml_create_tag_schema_dict(
         xmltree: Union[etree._Element, etree._ElementTree],
         schema_dict: 'fleur_schema.SchemaDict',
-        xpath: 'etree._xpath',
+        xpath: XPathLike,
         base_xpath: str,
         element: Union[str, etree._Element],
         create_parents: bool = False,
@@ -61,6 +62,8 @@ def xml_create_tag_schema_dict(
 
     check_complex_xpath(xmltree, base_xpath, xpath)
 
+    print(repr(xpath), xpath)
+
     tag_info = schema_dict['tag_info'][base_xpath]
 
     if not etree.iselement(element):
@@ -88,7 +91,7 @@ def xml_create_tag_schema_dict(
     if len(parent_nodes) == 0:
         if create_parents:
             parent_xpath, parent_name = split_off_tag(base_xpath)
-            complex_parent_xpath, _ = split_off_tag(str(xpath))
+            complex_parent_xpath, _ = split_off_tag(xpath)
             xmltree = xml_create_tag_schema_dict(xmltree,
                                                  schema_dict,
                                                  complex_parent_xpath,
@@ -106,7 +109,7 @@ def xml_create_tag_schema_dict(
 
 def eval_xpath_create(xmltree: Union[etree._Element, etree._ElementTree],
                       schema_dict: 'fleur_schema.SchemaDict',
-                      xpath: 'etree._xpath',
+                      xpath: XPathLike,
                       base_xpath: str,
                       create_parents: bool = False,
                       occurrences: Union[int, Iterable[int]] = None,
@@ -136,7 +139,7 @@ def eval_xpath_create(xmltree: Union[etree._Element, etree._ElementTree],
 
     if len(nodes) == 0:
         parent_xpath, tag_name = split_off_tag(base_xpath)
-        complex_parent_xpath, _ = split_off_tag(str(xpath))
+        complex_parent_xpath, _ = split_off_tag(xpath)
         xmltree = xml_create_tag_schema_dict(xmltree,
                                              schema_dict,
                                              complex_parent_xpath,
@@ -155,7 +158,7 @@ def eval_xpath_create(xmltree: Union[etree._Element, etree._ElementTree],
 
 def xml_set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
                          schema_dict: 'fleur_schema.SchemaDict',
-                         xpath: 'etree._xpath',
+                         xpath: XPathLike,
                          base_xpath: str,
                          attributename: str,
                          attribv: Any,
@@ -226,7 +229,7 @@ def xml_set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
 
 def xml_set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
                                schema_dict: 'fleur_schema.SchemaDict',
-                               xpath: 'etree._xpath',
+                               xpath: XPathLike,
                                base_xpath: str,
                                attributename: str,
                                attribv: Any,
@@ -265,7 +268,7 @@ def xml_set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree
 
 def xml_set_text(xmltree: Union[etree._Element, etree._ElementTree],
                  schema_dict: 'fleur_schema.SchemaDict',
-                 xpath: 'etree._xpath',
+                 xpath: XPathLike,
                  base_xpath: str,
                  text: Any,
                  occurrences: Union[int, Iterable[int]] = None,
@@ -324,7 +327,7 @@ def xml_set_text(xmltree: Union[etree._Element, etree._ElementTree],
 
 def xml_set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
                        schema_dict: 'fleur_schema.SchemaDict',
-                       xpath: 'etree._xpath',
+                       xpath: XPathLike,
                        base_xpath: str,
                        text: Any,
                        create: bool = False) -> Union[etree._Element, etree._ElementTree]:
@@ -353,7 +356,7 @@ def xml_set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
 def xml_add_number_to_attrib(
         xmltree: Union[etree._Element, etree._ElementTree],
         schema_dict: 'fleur_schema.SchemaDict',
-        xpath: 'etree._xpath',
+        xpath: XPathLike,
         base_xpath: str,
         attributename: str,
         add_number: Any,
@@ -464,7 +467,7 @@ def xml_add_number_to_attrib(
 
 def xml_add_number_to_first_attrib(xmltree: Union[etree._Element, etree._ElementTree],
                                    schema_dict: 'fleur_schema.SchemaDict',
-                                   xpath: 'etree._xpath',
+                                   xpath: XPathLike,
                                    base_xpath: str,
                                    attributename: str,
                                    add_number: Any,
@@ -501,7 +504,7 @@ def xml_add_number_to_first_attrib(xmltree: Union[etree._Element, etree._Element
 
 def xml_set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
                        schema_dict: 'fleur_schema.SchemaDict',
-                       xpath: 'etree._xpath',
+                       xpath: XPathLike,
                        base_xpath: str,
                        tag_name: str,
                        changes: Union[List[Dict[str, Any]], Dict[str, Any]],
@@ -531,7 +534,7 @@ def xml_set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
 
     tag_info = schema_dict['tag_info'][base_xpath]
 
-    tag_xpath = f'{str(xpath)}/{tag_name}'
+    tag_xpath = add_tag(xpath, tag_name)
     tag_base_xpath = f'{base_xpath}/{tag_name}'
 
     if tag_name in tag_info['several']:
@@ -579,7 +582,7 @@ def xml_set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
 
 def xml_set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
                         schema_dict: 'fleur_schema.SchemaDict',
-                        xpath: 'etree._xpath',
+                        xpath: XPathLike,
                         base_xpath: str,
                         attributedict: Dict[str, Any],
                         create: bool = False) -> Union[etree._Element, etree._ElementTree]:
@@ -629,7 +632,7 @@ def xml_set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
 
         key = (tag_info['complex'] | tag_info['simple'] | tag_info['attribs']).original_case[key]
 
-        sub_xpath = f'{str(xpath)}/{key}'
+        sub_xpath = add_tag(xpath, key)
         sub_base_xpath = f'{base_xpath}/{key}'
         if key in tag_info['attribs']:
             xml_set_attrib_value(xmltree, schema_dict, xpath, base_xpath, key, val, create=create)
@@ -660,7 +663,7 @@ def xml_set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
 
             for indx, tagdict in enumerate(val):
                 for k in range(len(eval_xpath(xmltree, sub_xpath, list_return=True)) // len(val)):  #type:ignore
-                    current_elem_xpath = f'{sub_xpath}[{k*len(val)+indx+1}]'
+                    current_elem_xpath = f'{str(sub_xpath)}[{k*len(val)+indx+1}]'
                     xmltree = xml_set_complex_tag(xmltree,
                                                   schema_dict,
                                                   current_elem_xpath,

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -54,9 +54,15 @@ class XPathBuilder:
                 
                 if condition_name == 'has':
                     if predicate:
-                        predicate = f'{predicate} or ${tag}_has'
+                        predicate = f'{predicate} and ${tag}_has'
                     else:
                         predicate = f'${tag}_has'
+                    self.path_variables[f'{tag}_has'] = condition
+                if condition_name == 'has-not':
+                    if predicate:
+                        predicate = f'{predicate} and ${tag}_has_not'
+                    else:
+                        predicate = f'${tag}_has_not'
                     self.path_variables[f'{tag}_has'] = condition
                 elif condition_name == 'index':
                     if isinstance(condition, int):
@@ -76,7 +82,7 @@ class XPathBuilder:
                         self.path_variables[f'{tag}_index'] = index
 
                     if predicate:
-                        predicate = f'{predicate} or {index_condition}'
+                        predicate = f'{predicate} and {index_condition}'
                     else:
                         predicate = index_condition
                 else:
@@ -90,7 +96,7 @@ class XPathBuilder:
                     value_conditions += 1
 
                     if predicate:
-                        predicate = f'{predicate} or {value_condition}'
+                        predicate = f'{predicate} and {value_condition}'
                     else:
                         predicate = value_condition
 

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -1,0 +1,114 @@
+"""
+
+"""
+from typing import Dict, Any, Set
+from lxml import etree
+
+FilterType = Dict[str,Any]
+
+class XPathBuilder:
+    """
+    Class for building a complex xpath (restricted to adding filters)
+    from a simple xpath expression
+    """
+
+    def __init__(self, simple_path: 'etree._xpath', filters: Dict[str,FilterType]=None, compile_path:bool = False) -> None:
+        self.compile_path = compile_path
+        if isinstance(simple_path, str):
+            self.components = simple_path.split('/')
+        elif isinstance(simple_path, etree.XPath):
+            self.components = simple_path.path.split('/')
+        else:
+            raise TypeError(f'Wrong type for simple path. Expected str or etree.Xpath. Got {type(simple_path)}')
+
+        if len(set(self.components)) != len(self.components):
+            raise NotImplementedError('The given xpath has multiple tags with the same name')
+
+        self.filters: Dict[str,FilterType] = {}
+        self.path_variables: Dict[str, 'etree._XPathObject'] = {}
+        if filters is not None:
+            for key, val in filters.items():
+                self.add_filter(key, val)
+
+    def add_filter(self, tag, conditions: FilterType):
+        """
+        """
+        if tag not in self.components:
+            raise ValueError(f"The tag {tag} is not part of the given xpath expression: {'/'.join(self.components)}")
+
+        self.filters[tag] = {**self.filters.get(tag,{}),**conditions}
+
+    @property
+    def path(self) -> 'etree._xpath':
+
+        predicates = [''] * len(self.components)
+        self.path_variables = {}
+
+        for tag, conditions in self.filters.items():
+
+            component_index = self.components.index(tag)
+            predicate = ''
+
+            value_conditions = 0
+            for condition_name, condition in conditions.items():
+                
+                if condition_name == 'has':
+                    if predicate:
+                        predicate = f'{predicate} or ${tag}_has'
+                    else:
+                        predicate = f'${tag}_has'
+                    self.path_variables[f'{tag}_has'] = condition
+                elif condition_name == 'index':
+                    if isinstance(condition, int):
+                        if condition == -1:
+                            index_condition = 'last()'
+                        elif condition == 1:
+                            index_condition = 'first()'
+                        elif condition < 0:
+                            index_condition = f'last() - ${tag}_index'
+                            self.path_variables[f'{tag}_index'] = condition + 1
+                        else:
+                            index_condition = f'${tag}_index'
+                            self.path_variables[f'{tag}_index'] = condition
+                    else:
+                        cond, index = dict(condition).popitem()
+                        index_condition = f'position() {cond} ${tag}_index'
+                        self.path_variables[f'{tag}_index'] = index
+
+                    if predicate:
+                        predicate = f'{predicate} or {index_condition}'
+                    else:
+                        predicate = index_condition
+                else:
+                    cond, value = dict(condition).popitem()
+
+                    value_condition = f'${tag}_cond_{value_conditions} {cond} ${tag}_cond_{value_conditions}_value'
+
+                    self.path_variables[f'{tag}_cond_{value_conditions}'] = condition_name
+                    self.path_variables[f'{tag}_cond_{value_conditions}_value'] = value
+
+                    value_conditions += 1
+
+                    if predicate:
+                        predicate = f'{predicate} or {value_condition}'
+                    else:
+                        predicate = value_condition
+
+            predicates[component_index] = predicate
+
+        path = '/'.join([f'{tag}[{predicate}]' if predicate else tag for tag, predicate in zip(self.components, predicates)])
+        if self.compile_path:
+            return etree.XPath(path)
+        return path
+
+    def __repr__(self):
+        return f"{self.__class__.__qualname__}({'/'.join(self.components)!r}, {self.filters!r}, compile_path={self.compile_path!r})"
+
+    def __str__(self) -> str:
+        path = self.path
+        if not isinstance(path, str):
+            path = path.path
+
+        for name, value in self.path_variables.items():
+            path = path.replace(f'${name}', str(value))
+        return path

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -31,7 +31,31 @@ class XPathBuilder:
         the path if compile_path=True
 
     .. note::
-        Filters dictionary syntax (TODO)
+        Filters/Constraints (or predicates like they are called for XPaths) can either
+        be added by providing the ``filters`` argument in the constructor or by calling
+        the :py:meth:`add_filter()` method.
+
+        The ``filters`` argument is a dictionary with the tag names, where to apply the condition,
+        as keys and the condition as values while the :py:meth:`add_filter()` method takes these
+        as it's two arguments. The tag name has to be a part of the original simple xpath expression.
+        The conditition is a dictionary with one key specifying the kind of condition and the value for the
+        condition. The condition can also be the name of an attribute or path, in which case the value can be another
+        condition dictionary. The following conditions operators i.e. keys in the dictionary are supported:
+
+            - ``=``/``==``: equal to
+            - ``!=``: not equal to
+            - ``<``: less than
+            - ``>``: greater than
+            - ``<=``: less than or equal to
+            - ``>=``: greater than or equal to
+            - ``contains``: attribute/tag contains the given value (case sensitive)
+            - ``not-contains``: attribute/tag does not contains the given value
+            - ``index``: Select tags based on their index in the parent tag (either explicit index or another condition)
+            - ``has``: Select tags based on the presence of the given attribute/tag
+            - ``has-not``: Select tags based on the absence of the given attribute/tag
+            - ``and``: Provide multiple conditions in a list joined by ``and``
+            - ``or``: Provide multiple conditions in a list joined by ``or``
+            - ``<string>``: All other strings are interpreted as paths to attributes/tags specifying conditions on their value
 
     :param simple_path: basic simple XPath expression to start from
     :param filters: dictionary with filters

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -161,12 +161,16 @@ class XPathBuilder:
                     self.path_variables[f'{tag}_index'] = content
             else:
                 cond, index = dict(content).popitem()
+                if cond == '==':
+                    cond = '='
                 predicate = f'position() {cond} ${tag}_index'
                 self.path_variables[f'{tag}_index'] = index
         elif '/' not in operator:
             if not isinstance(content, dict):
                 content = {'=': content}
             cond, value = dict(content).popitem()
+            if cond == '==':
+                cond = '='
 
             variable_name = f'{tag}_cond_{self.value_conditions}_name'
             value_variable_name = f'{tag}_cond_{self.value_conditions}'
@@ -185,6 +189,8 @@ class XPathBuilder:
             if not isinstance(content, dict):
                 content = {'=': content}
             cond, value = dict(content).popitem()
+            if cond == '==':
+                cond = '='
             parts = operator.strip('/').split('/')
             variable_name = f'{tag}_cond_{self.value_conditions}_name'
             value_variable_name = f'{tag}_cond_{self.value_conditions}'

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -128,7 +128,7 @@ class XPathBuilder:
 
         return self.components.pop(-1)
 
-    def get_predicate(self, tag, condition):
+    def get_predicate(self, tag: str, condition: Any) -> str:
         """
         Construct the predicate for the given tag and condition
 
@@ -148,7 +148,7 @@ class XPathBuilder:
 
         return self.process_condition(tag, operator, content)
 
-    def process_condition(self, tag, operator, content):
+    def process_condition(self, tag: str, operator: str, content: Any) -> str:
         """
         Process the condition for the given tag and condition
 
@@ -227,14 +227,14 @@ class XPathBuilder:
             for indx, part in enumerate(parts):
                 path_variable.append(f"{'@' if '@' in part else ''}*[local-name()=${variable_name}_{indx}]")
                 self.path_variables[f'{variable_name}_{indx}'] = part.lstrip('@')
-            path_variable = '/'.join(path_variable)
+            path_variable_str = '/'.join(path_variable)
 
             if cond == 'contains':
-                predicate = f'contains({path_variable},${value_variable_name})'
+                predicate = f'contains({path_variable_str},${value_variable_name})'
             elif cond == 'not-contains':
-                predicate = f'not(contains({path_variable},${value_variable_name}))'
+                predicate = f'not(contains({path_variable_str},${value_variable_name}))'
             else:
-                predicate = f'{path_variable} {cond} ${value_variable_name}'
+                predicate = f'{path_variable_str} {cond} ${value_variable_name}'
 
             self.path_variables[variable_name] = operator
             self.path_variables[value_variable_name] = value
@@ -262,7 +262,7 @@ class XPathBuilder:
             return etree.XPath(path, **self.path_kwargs)
         return path
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__qualname__}({'/'.join(self.components)!r}, {self.filters!r}, compile_path={self.compile_path!r}, strict={self.strict!r})"
 
     def __str__(self) -> str:

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -90,7 +90,7 @@ class XPathBuilder:
         if not self.compile_path and kwargs:
             raise ValueError('Keyword arguments only available for compiled Xpaths')
         if isinstance(simple_path, str):
-            self.components = simple_path.split('/')
+            self.components = simple_path.rstrip('/').split('/')
         elif isinstance(simple_path, etree.XPath):
             self.components = simple_path.path.split('/')  #type: ignore
         else:

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -1,42 +1,74 @@
+# -*- coding: utf-8 -*-
 """
 
 """
-from typing import Dict, Any, Set
+from typing import Dict, Any, Set, cast
 from lxml import etree
 
-FilterType = Dict[str,Any]
+FilterType = Dict[str, Any]
+
 
 class XPathBuilder:
     """
     Class for building a complex xpath (restricted to adding filters)
     from a simple xpath expression
+
+    .. note::
+        passing in an etree.XPath object will not respect the options
+        passed into it. Only the kwargs in __init__ are used to compile
+        the path if compile_path=True
+
     """
 
-    def __init__(self, simple_path: 'etree._xpath', filters: Dict[str,FilterType]=None, compile_path:bool = False) -> None:
+    def __init__(self,
+                 simple_path: 'etree._xpath',
+                 filters: Dict[str, FilterType] = None,
+                 compile_path: bool = False,
+                 **kwargs) -> None:
         self.compile_path = compile_path
+        if not self.compile_path and kwargs:
+            raise ValueError('Keyword arguments only available for compiled Xpaths')
         if isinstance(simple_path, str):
             self.components = simple_path.split('/')
         elif isinstance(simple_path, etree.XPath):
-            self.components = simple_path.path.split('/')
+            self.components = simple_path.path.split('/')  #type: ignore
         else:
             raise TypeError(f'Wrong type for simple path. Expected str or etree.XPath. Got {type(simple_path)}')
 
         if len(set(self.components)) != len(self.components):
             raise NotImplementedError('The given xpath has multiple tags with the same name')
 
-        self.filters: Dict[str,FilterType] = {}
+        self.path_kwargs = kwargs
+        self.filters: Dict[str, FilterType] = {}
         self.path_variables: Dict[str, 'etree._XPathObject'] = {}
         if filters is not None:
             for key, val in filters.items():
                 self.add_filter(key, val)
 
-    def add_filter(self, tag, conditions: FilterType):
+    def add_filter(self, tag: str, conditions: FilterType) -> None:
         """
         """
         if tag not in self.components:
             raise ValueError(f"The tag {tag} is not part of the given xpath expression: {'/'.join(self.components)}")
 
-        self.filters[tag] = {**self.filters.get(tag,{}),**conditions}
+        self.filters[tag] = {**self.filters.get(tag, {}), **conditions}
+
+    def append_tag(self, tag: str) -> None:
+        """
+        """
+        if tag in self.components:
+            raise NotImplementedError(
+                f"The tag {tag} is already part of the given xpath expression: {'/'.join(self.components)}")
+
+        self.components.append(tag)
+
+    def strip_off_tag(self) -> str:
+        """
+        """
+        if not self.components:
+            raise ValueError('Cannot strip off tag. Path is empty')
+
+        return self.components.pop(-1)
 
     @property
     def path(self) -> 'etree._xpath':
@@ -51,7 +83,7 @@ class XPathBuilder:
 
             value_conditions = 0
             for condition_name, condition in conditions.items():
-                
+
                 if condition_name == 'has':
                     if predicate:
                         predicate = f'{predicate} and ${tag}_has'
@@ -85,26 +117,32 @@ class XPathBuilder:
                         predicate = f'{predicate} and {index_condition}'
                     else:
                         predicate = index_condition
-                else:
+                elif '/' not in condition_name:
                     cond, value = dict(condition).popitem()
+                    if cond == 'contains':
+                        value_condition = f'contains(@*[local-name()=${tag}_cond_{value_conditions}_name],${tag}_cond_{value_conditions})'
+                    elif cond == 'not-contains':
+                        value_condition = f'not contains(@*[local-name()=${tag}_cond_{value_conditions}_name],${tag}_cond_{value_conditions})'
+                    else:
+                        value_condition = f'@*[local-name()=${tag}_cond_{value_conditions}_name] {cond} ${tag}_cond_{value_conditions}'
 
-                    value_condition = f'${tag}_cond_{value_conditions} {cond} ${tag}_cond_{value_conditions}_value'
-
-                    self.path_variables[f'{tag}_cond_{value_conditions}'] = condition_name
-                    self.path_variables[f'{tag}_cond_{value_conditions}_value'] = value
-
+                    self.path_variables[f'{tag}_cond_{value_conditions}_name'] = condition_name
+                    self.path_variables[f'{tag}_cond_{value_conditions}'] = value
                     value_conditions += 1
 
                     if predicate:
                         predicate = f'{predicate} and {value_condition}'
                     else:
                         predicate = value_condition
+                else:
+                    raise NotImplementedError('Conditions based on subtags not implemented')
 
             predicates[component_index] = predicate
 
-        path = '/'.join([f'{tag}[{predicate}]' if predicate else tag for tag, predicate in zip(self.components, predicates)])
+        path = '/'.join(
+            [f'{tag}[{predicate}]' if predicate else tag for tag, predicate in zip(self.components, predicates)])
         if self.compile_path:
-            return etree.XPath(path)
+            return etree.XPath(path, **self.path_kwargs)
         return path
 
     def __repr__(self):
@@ -112,9 +150,10 @@ class XPathBuilder:
 
     def __str__(self) -> str:
         path = self.path
-        if not isinstance(path, str):
-            path = path.path
+        if isinstance(path, etree.XPath):
+            path = path.path  #type: ignore
+        path = cast(str, path)
 
-        for name, value in self.path_variables.items():
-            path = path.replace(f'${name}', str(value))
+        for name, value in sorted(self.path_variables.items(), key=lambda x: len(x[0]), reverse=True):
+            path = path.replace(f'${name}', f'{value!r}')
         return path

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -1,8 +1,20 @@
 # -*- coding: utf-8 -*-
+###############################################################################
+# Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
+#                All rights reserved.                                         #
+# This file is part of the Masci-tools package.                               #
+# (Material science tools)                                                    #
+#                                                                             #
+# The code is hosted on GitHub at https://github.com/judftteam/masci-tools.   #
+# For further information on the license, see the LICENSE.txt file.           #
+# For further information please visit http://judft.de/.                      #
+#                                                                             #
+###############################################################################
 """
-
+This module contains Classes for building complex XPath expressions based on
+general attribute conditions from simple XPath expressions
 """
-from typing import Dict, Any, Set, cast
+from typing import Dict, Any, cast
 from lxml import etree
 
 FilterType = Dict[str, Any]
@@ -18,6 +30,15 @@ class XPathBuilder:
         passed into it. Only the kwargs in __init__ are used to compile
         the path if compile_path=True
 
+    .. note::
+        Filters dictionary syntax (TODO)
+
+    :param simple_path: basic simple XPath expression to start from
+    :param filters: dictionary with filters
+    :param compile_path: bool if True the path property will be compiled as etree.XPath
+    :param strict: bool if True the __str__ conversion will raise an error
+
+    Other Kwargs will be passed on to the etree.XPath compilation if ``compile_path=True``
     """
 
     def __init__(self,
@@ -50,6 +71,10 @@ class XPathBuilder:
 
     def add_filter(self, tag: str, conditions: FilterType) -> None:
         """
+        Add a filter to the filters dictionary
+
+        :param tag: str name of the tag name to add a filter to
+        :param conditions: dictionary specifying the filter
         """
         if tag not in self.components:
             raise ValueError(f"The tag {tag} is not part of the given xpath expression: {'/'.join(self.components)}")
@@ -58,6 +83,9 @@ class XPathBuilder:
 
     def append_tag(self, tag: str) -> None:
         """
+        Append another tag to the end of the simple xpath expression
+
+        :param tag: str name of the tag to append
         """
         if tag in self.components:
             raise NotImplementedError(
@@ -67,13 +95,22 @@ class XPathBuilder:
 
     def strip_off_tag(self) -> str:
         """
+        Strip off the last tag of the simple xpath expression
         """
         if not self.components:
             raise ValueError('Cannot strip off tag. Path is empty')
 
+        #TODO: Check if the filters contains filters fot the last tag
+
         return self.components.pop(-1)
 
     def get_predicate(self, tag, condition):
+        """
+        Construct the predicate for the given tag and condition
+
+        :param tag: str name of the tag
+        :param condition: condition specified, either dict or single value
+        """
 
         if not isinstance(condition, dict):
             condition = {'=': condition}
@@ -88,6 +125,13 @@ class XPathBuilder:
         return self.process_condition(tag, operator, content)
 
     def process_condition(self, tag, operator, content):
+        """
+        Process the condition for the given tag and condition
+
+        :param tag: str name of the tag
+        :param operator: operator for condition
+        :param content: content of condition
+        """
 
         if operator == 'and':
             if not isinstance(content, (list, tuple)):
@@ -168,6 +212,9 @@ class XPathBuilder:
 
     @property
     def path(self) -> 'etree._xpath':
+        """
+        Property for constructing the complex Xpath
+        """
 
         predicates = [''] * len(self.components)
         self.path_variables = {}

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -100,7 +100,7 @@ class XPathBuilder:
         if not self.components:
             raise ValueError('Cannot strip off tag. Path is empty')
 
-        #TODO: Check if the filters contains filters fot the last tag
+        #TODO: Check if the filters contains filters for the last tag
 
         return self.components.pop(-1)
 

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -57,6 +57,20 @@ class XPathBuilder:
             - ``or``: Provide multiple conditions in a list joined by ``or``
             - ``<string>``: All other strings are interpreted as paths to attributes/tags specifying conditions on their value
 
+    Example::
+
+        from masci_tools.util.xml.xpathbuilder import XPathBuilder
+
+        # XPath selecting all lo tags for SCLO type LOs and Iron species
+        xpath = XPathBuilder('/fleurInput/atomSpecies/species/lo',
+                             filters = {'species': {
+                                            'name': {'contains': 'Fe'},
+                                        }
+                                        'lo': {
+                                            'type': 'SCLO'
+                                        }
+                                    })
+
     :param simple_path: basic simple XPath expression to start from
     :param filters: dictionary with filters
     :param compile_path: bool if True the path property will be compiled as etree.XPath

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -41,6 +41,7 @@ class XPathBuilder:
         self.path_kwargs = kwargs
         self.filters: Dict[str, FilterType] = {}
         self.path_variables: Dict[str, 'etree._XPathObject'] = {}
+        self.value_conditions: int = 0
         if filters is not None:
             for key, val in filters.items():
                 self.add_filter(key, val)
@@ -70,74 +71,85 @@ class XPathBuilder:
 
         return self.components.pop(-1)
 
+    def get_predicate(self, tag, condition):
+
+        if not isinstance(condition, dict):
+            condition = {'=': condition}
+
+        if len(condition) > 1:
+            raise ValueError('Only one condition allowed in dict')
+
+        operator, content = dict(condition).popitem()
+        if operator == '==':
+            operator = '='
+
+        return self.process_condition(tag, operator, content)
+
+    def process_condition(self, tag, operator, content):
+
+        if operator == 'and':
+            if not isinstance(content, (list, tuple)):
+                raise TypeError('For and operator and provide the conditions as a list')
+            predicates = [self.get_predicate(tag, condition_part) for condition_part in content]
+            predicate = ' and '.join(predicates)
+        elif operator == 'or':
+            if not isinstance(content, (list, tuple)):
+                raise TypeError('For or operator and provide the conditions as a list')
+            predicates = [self.get_predicate(tag, condition_part) for condition_part in content]
+            predicate = ' or '.join(predicates)
+        elif operator == 'has':
+            predicate = f'${tag}_has'
+            self.path_variables[f'{tag}_has'] = content
+        elif operator == 'has-not':
+            predicate = f'${tag}_has_not'
+            self.path_variables[f'{tag}_has_not'] = content
+        elif operator == 'index':
+            if isinstance(content, int):
+                if content == -1:
+                    predicate = 'last()'
+                elif content == 1:
+                    predicate = 'first()'
+                elif content < 0:
+                    predicate = f'last() - ${tag}_index'
+                    self.path_variables[f'{tag}_index'] = content + 1
+                else:
+                    predicate = f'${tag}_index'
+                    self.path_variables[f'{tag}_index'] = content
+            else:
+                cond, index = dict(content).popitem()
+                predicate = f'position() {cond} ${tag}_index'
+                self.path_variables[f'{tag}_index'] = index
+        elif '/' not in tag:
+            cond, value = dict(content).popitem()
+
+            variable_name = f'${tag}_cond_{self.value_conditions}_name'
+            value_variable_name = f'${tag}_cond_{self.value_conditions}'
+
+            if cond == 'contains':
+                predicate = f'contains(@*[local-name()={variable_name}],{value_variable_name})'
+            elif cond == 'not-contains':
+                predicate = f'not contains(@*[local-name()={variable_name}],{value_variable_name})'
+            else:
+                predicate = f'@*[local-name()={variable_name}] {cond} {value_variable_name}'
+
+            self.path_variables[variable_name] = operator
+            self.path_variables[value_variable_name] = value
+            self.value_conditions += 1
+        else:
+            raise NotImplementedError('Conditions based on subtags not implemented')
+
+        return predicate
+
     @property
     def path(self) -> 'etree._xpath':
 
         predicates = [''] * len(self.components)
         self.path_variables = {}
+        self.value_conditions = 0
 
-        for tag, conditions in self.filters.items():
-
+        for tag, condition in self.filters.items():
             component_index = self.components.index(tag)
-            predicate = ''
-
-            value_conditions = 0
-            for condition_name, condition in conditions.items():
-
-                if condition_name == 'has':
-                    if predicate:
-                        predicate = f'{predicate} and ${tag}_has'
-                    else:
-                        predicate = f'${tag}_has'
-                    self.path_variables[f'{tag}_has'] = condition
-                if condition_name == 'has-not':
-                    if predicate:
-                        predicate = f'{predicate} and ${tag}_has_not'
-                    else:
-                        predicate = f'${tag}_has_not'
-                    self.path_variables[f'{tag}_has'] = condition
-                elif condition_name == 'index':
-                    if isinstance(condition, int):
-                        if condition == -1:
-                            index_condition = 'last()'
-                        elif condition == 1:
-                            index_condition = 'first()'
-                        elif condition < 0:
-                            index_condition = f'last() - ${tag}_index'
-                            self.path_variables[f'{tag}_index'] = condition + 1
-                        else:
-                            index_condition = f'${tag}_index'
-                            self.path_variables[f'{tag}_index'] = condition
-                    else:
-                        cond, index = dict(condition).popitem()
-                        index_condition = f'position() {cond} ${tag}_index'
-                        self.path_variables[f'{tag}_index'] = index
-
-                    if predicate:
-                        predicate = f'{predicate} and {index_condition}'
-                    else:
-                        predicate = index_condition
-                elif '/' not in condition_name:
-                    cond, value = dict(condition).popitem()
-                    if cond == 'contains':
-                        value_condition = f'contains(@*[local-name()=${tag}_cond_{value_conditions}_name],${tag}_cond_{value_conditions})'
-                    elif cond == 'not-contains':
-                        value_condition = f'not contains(@*[local-name()=${tag}_cond_{value_conditions}_name],${tag}_cond_{value_conditions})'
-                    else:
-                        value_condition = f'@*[local-name()=${tag}_cond_{value_conditions}_name] {cond} ${tag}_cond_{value_conditions}'
-
-                    self.path_variables[f'{tag}_cond_{value_conditions}_name'] = condition_name
-                    self.path_variables[f'{tag}_cond_{value_conditions}'] = value
-                    value_conditions += 1
-
-                    if predicate:
-                        predicate = f'{predicate} and {value_condition}'
-                    else:
-                        predicate = value_condition
-                else:
-                    raise NotImplementedError('Conditions based on subtags not implemented')
-
-            predicates[component_index] = predicate
+            predicates[component_index] = self.get_predicate(tag, condition)
 
         path = '/'.join(
             [f'{tag}[{predicate}]' if predicate else tag for tag, predicate in zip(self.components, predicates)])

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -179,7 +179,7 @@ class XPathBuilder:
                     predicate = 'last()'
                 elif content < 0:
                     predicate = f'last() - ${tag}_index'
-                    self.path_variables[f'{tag}_index'] = content + 1
+                    self.path_variables[f'{tag}_index'] = abs(content + 1)
                 else:
                     predicate = f'${tag}_index'
                     self.path_variables[f'{tag}_index'] = content
@@ -187,7 +187,11 @@ class XPathBuilder:
                 cond, index = dict(content).popitem()
                 if cond == '==':
                     cond = '='
-                predicate = f'position() {cond} ${tag}_index'
+                if index < 0:
+                    index = abs(index + 1)
+                    predicate = f'position() {cond} last() - ${tag}_index'
+                else:
+                    predicate = f'position() {cond} ${tag}_index'
                 self.path_variables[f'{tag}_index'] = index
         elif '/' not in operator:
             if not isinstance(content, dict):
@@ -202,7 +206,7 @@ class XPathBuilder:
             if cond == 'contains':
                 predicate = f'contains(@*[local-name()=${variable_name}],${value_variable_name})'
             elif cond == 'not-contains':
-                predicate = f'not contains(@*[local-name()=${variable_name}],${value_variable_name})'
+                predicate = f'not(contains(@*[local-name()=${variable_name}],${value_variable_name}))'
             else:
                 predicate = f'@*[local-name()=${variable_name}] {cond} ${value_variable_name}'
 
@@ -228,7 +232,7 @@ class XPathBuilder:
             if cond == 'contains':
                 predicate = f'contains({path_variable},${value_variable_name})'
             elif cond == 'not-contains':
-                predicate = f'not contains({path_variable},${value_variable_name})'
+                predicate = f'not(contains({path_variable},${value_variable_name}))'
             else:
                 predicate = f'{path_variable} {cond} ${value_variable_name}'
 

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -153,8 +153,6 @@ class XPathBuilder:
             if isinstance(content, int):
                 if content == -1:
                     predicate = 'last()'
-                elif content == 1:
-                    predicate = 'first()'
                 elif content < 0:
                     predicate = f'last() - ${tag}_index'
                     self.path_variables[f'{tag}_index'] = content + 1

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -19,7 +19,7 @@ class XPathBuilder:
         elif isinstance(simple_path, etree.XPath):
             self.components = simple_path.path.split('/')
         else:
-            raise TypeError(f'Wrong type for simple path. Expected str or etree.Xpath. Got {type(simple_path)}')
+            raise TypeError(f'Wrong type for simple path. Expected str or etree.XPath. Got {type(simple_path)}')
 
         if len(set(self.components)) != len(self.components):
             raise NotImplementedError('The given xpath has multiple tags with the same name')

--- a/tests/test_fleurxmlmodifier.py
+++ b/tests/test_fleurxmlmodifier.py
@@ -22,7 +22,7 @@ def test_fleurxmlmodifier_facade_methods():
 
     actions = fm.get_avail_actions()
 
-    assert fm._tasks == []  #pylint: disable=protected-access
+    assert len(fm._tasks) == 0  #pylint: disable=protected-access
 
     for action in actions.values():
         action('TEST_ARG', random_kwarg='TEST2')
@@ -226,7 +226,7 @@ def test_fleurxml_modifier_modify_xmlfile_undo_revert_all():
 
     fm.undo(revert_all=True)
 
-    assert fm.changes() == []
+    assert len(fm.changes()) == 0
 
     #The underlying methods are tested in the specific tests for the setters
     #We only want to ensure that the procedure finishes without error

--- a/tests/xml/test_schema_dict_util.py
+++ b/tests/xml/test_schema_dict_util.py
@@ -227,7 +227,7 @@ def test_evaluate_tag(caplog, load_inpxml, load_outxml):
         evaluate_tag(root, schema_dict, 'qss', FLEUR_DEFINED_CONSTANTS, text=False)
 
     with caplog.at_level(logging.WARNING):
-        assert evaluate_tag(root, schema_dict, 'qss', FLEUR_DEFINED_CONSTANTS, logger=LOGGER, text=False) == {}
+        assert len(evaluate_tag(root, schema_dict, 'qss', FLEUR_DEFINED_CONSTANTS, logger=LOGGER, text=False)) == 0
     assert 'Failed to evaluate attributes from tag qss' in caplog.text
 
     assert evaluate_tag(root, schema_dict, 'qss', FLEUR_DEFINED_CONSTANTS) == {'qss': [0.0, 0.0, 0.0]}

--- a/tests/xml/test_schema_dict_util.py
+++ b/tests/xml/test_schema_dict_util.py
@@ -536,7 +536,7 @@ def test_schema_dict_util_abs_to_rel_path(load_inpxml):
 
 def test_schema_dict_util_complex_xpath(load_inpxml):
     """
-    Test of the absolute to relative xpath conversion in schema_dict_util functions
+    Test of the complex xpath argument in schema_dict_util functions
     """
     from masci_tools.util.schema_dict_util import evaluate_attribute, evaluate_tag, evaluate_parent_tag, \
                                                   evaluate_text
@@ -617,7 +617,7 @@ def test_schema_dict_util_complex_xpath(load_inpxml):
 
 def test_schema_dict_util_filters(load_inpxml):
     """
-    Test of the absolute to relative xpath conversion in schema_dict_util functions
+    Test of the filters argument in schema_dict_util functions
     """
     from masci_tools.util.schema_dict_util import eval_simple_xpath, get_number_of_nodes, tag_exists, \
                                                   evaluate_attribute, evaluate_tag, evaluate_parent_tag, \

--- a/tests/xml/test_xml_common_functions.py
+++ b/tests/xml/test_xml_common_functions.py
@@ -168,10 +168,37 @@ def test_split_off_tag():
     Test of the split_off_tag function
     """
     from masci_tools.util.xml.common_functions import split_off_tag
+    from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
     assert split_off_tag('/fleurInput/calculationSetup/cutoffs') == ('/fleurInput/calculationSetup', 'cutoffs')
     assert split_off_tag('/fleurInput/calculationSetup/cutoffs/') == ('/fleurInput/calculationSetup', 'cutoffs')
     assert split_off_tag('./calculationSetup/cutoffs') == ('./calculationSetup', 'cutoffs')
+
+    path, tag = split_off_tag(XPathBuilder('/fleurInput/calculationSetup/cutoffs'))
+    assert str(path) == '/fleurInput/calculationSetup'
+    assert tag == 'cutoffs'
+
+    path, tag = split_off_tag(etree.XPath('/fleurInput/calculationSetup/cutoffs'))
+    assert str(path) == '/fleurInput/calculationSetup'
+    assert tag == 'cutoffs'
+
+
+def test_add_tag():
+    """
+    Test of the add_tag function
+    """
+    from masci_tools.util.xml.common_functions import add_tag
+    from masci_tools.util.xml.xpathbuilder import XPathBuilder
+
+    assert add_tag('/fleurInput/calculationSetup', 'cutoffs') == '/fleurInput/calculationSetup/cutoffs'
+    assert add_tag('/fleurInput/calculationSetup/', 'cutoffs') == '/fleurInput/calculationSetup/cutoffs'
+    assert add_tag('./calculationSetup', 'cutoffs') == './calculationSetup/cutoffs'
+
+    path = add_tag(XPathBuilder('/fleurInput/calculationSetup/'), 'cutoffs')
+    assert str(path) == '/fleurInput/calculationSetup/cutoffs'
+
+    path = add_tag(etree.XPath('/fleurInput/calculationSetup'), 'cutoffs')
+    assert str(path) == '/fleurInput/calculationSetup/cutoffs'
 
 
 def test_split_off_attrib():
@@ -179,11 +206,24 @@ def test_split_off_attrib():
     Test of the split_off_tag function
     """
     from masci_tools.util.xml.common_functions import split_off_attrib
+    from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
     assert split_off_attrib('/fleurInput/calculationSetup/cutoffs/@Kmax') == ('/fleurInput/calculationSetup/cutoffs',
                                                                               'Kmax')
+    path, attrib = split_off_attrib(XPathBuilder('/fleurInput/calculationSetup/cutoffs/@Kmax'))
+
+    assert str(path) == '/fleurInput/calculationSetup/cutoffs'
+    assert attrib == 'Kmax'
+
+    path, attrib = split_off_attrib(etree.XPath('/fleurInput/calculationSetup/cutoffs/@Kmax'))
+
+    assert str(path) == '/fleurInput/calculationSetup/cutoffs'
+    assert attrib == 'Kmax'
+
     with pytest.raises(ValueError):
         split_off_attrib('/fleurInput/calculationSetup/cutoffs')
+    with pytest.raises(ValueError):
+        split_off_attrib(XPathBuilder('/fleurInput/calculationSetup/cutoffs'))
     with pytest.raises(ValueError):
         split_off_attrib("/fleurInput/atomSpecies/species[@name='TEST']")
     assert split_off_attrib('./calculationSetup/cutoffs/@Kmax') == ('./calculationSetup/cutoffs', 'Kmax')

--- a/tests/xml/test_xml_getters.py
+++ b/tests/xml/test_xml_getters.py
@@ -124,7 +124,7 @@ def test_get_parameter_data(load_inpxml, inpxmlfilepath):
     para = get_parameter_data(xmltree, schema_dict)
 
     assert isinstance(para, dict)
-    assert para != {}
+    assert len(para) != 0
 
 
 @pytest.mark.parametrize('inpxmlfilepath', inpxmlfilelist)
@@ -139,7 +139,7 @@ def test_get_fleur_modes(load_inpxml, inpxmlfilepath):
     modes = get_fleur_modes(xmltree, schema_dict)
 
     assert isinstance(modes, dict)
-    assert modes != {}
+    assert len(modes) != 0
 
 
 @pytest.mark.parametrize('inpxmlfilepath', inpxmlfilelist)

--- a/tests/xml/test_xml_setter_signatures/test_xml_setter_signatures.yml
+++ b/tests/xml/test_xml_setter_signatures/test_xml_setter_signatures.yml
@@ -14,6 +14,8 @@ nmmpmat:
     - null
   - - theta
     - null
+  - - filters
+    - null
   set_nmmpmat:
   - - xmltree
     - null
@@ -37,6 +39,8 @@ nmmpmat:
     - null
   - - theta
     - null
+  - - filters
+    - null
 schema_dict:
   add_number_to_attrib:
   - - xmltree
@@ -48,6 +52,8 @@ schema_dict:
   - - add_number
     - null
   - - complex_xpath
+    - null
+  - - filters
     - null
   - - mode
     - abs
@@ -65,6 +71,8 @@ schema_dict:
   - - add_number
     - null
   - - complex_xpath
+    - null
+  - - filters
     - null
   - - mode
     - abs
@@ -90,6 +98,8 @@ schema_dict:
     - null
   - - complex_xpath
     - null
+  - - filters
+    - null
   - - create_parents
     - false
   - - occurrences
@@ -105,6 +115,8 @@ schema_dict:
     - null
   - - complex_xpath
     - null
+  - - filters
+    - null
   - - occurrences
     - null
   - - kwargs
@@ -117,6 +129,8 @@ schema_dict:
   - - tag_name
     - null
   - - complex_xpath
+    - null
+  - - filters
     - null
   - - occurrences
     - null
@@ -133,6 +147,8 @@ schema_dict:
     - null
   - - complex_xpath
     - null
+  - - filters
+    - null
   - - occurrences
     - null
   - - kwargs
@@ -147,6 +163,8 @@ schema_dict:
   - - position
     - null
   - - species
+    - null
+  - - filters
     - null
   - - create
     - false
@@ -172,6 +190,8 @@ schema_dict:
     - null
   - - complex_xpath
     - null
+  - - filters
+    - null
   - - occurrences
     - null
   - - create
@@ -189,6 +209,8 @@ schema_dict:
     - null
   - - complex_xpath
     - null
+  - - filters
+    - null
   - - create
     - false
   - - kwargs
@@ -204,6 +226,8 @@ schema_dict:
     - null
   - - complex_xpath
     - null
+  - - filters
+    - null
   - - create
     - false
   - - kwargs
@@ -218,6 +242,8 @@ schema_dict:
   - - attribv
     - null
   - - complex_xpath
+    - null
+  - - filters
     - null
   - - create
     - false
@@ -282,6 +308,8 @@ schema_dict:
     - null
   - - complex_xpath
     - null
+  - - filters
+    - null
   - - create_parents
     - false
   - - kwargs
@@ -294,6 +322,8 @@ schema_dict:
   - - species_name
     - null
   - - attributedict
+    - null
+  - - filters
     - null
   - - create
     - false
@@ -318,6 +348,8 @@ schema_dict:
   - - text
     - null
   - - complex_xpath
+    - null
+  - - filters
     - null
   - - occurrences
     - null
@@ -368,6 +400,8 @@ schema_dict:
   - - position
     - null
   - - species
+    - null
+  - - filters
     - null
   - - clone
     - false

--- a/tests/xml/test_xpathbuilder.py
+++ b/tests/xml/test_xpathbuilder.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""
+Tests of the XPathBuilder class.
+"""
+import pytest
+from lxml import etree
+
+TEST_INPXML_PATH = 'fleur/Max-R5/FePt_film_SSFT_LO/files/inp2.xml'
+
+
+def test_xpathbuilder():
+    """
+    Test the basic behaviour of the XPathBuilder class.
+    """
+    from masci_tools.util.xml.xpathbuilder import XPathBuilder
+
+    simple_xpath = '/test/xpath/simple'
+
+    xpath = XPathBuilder(simple_xpath)
+    assert xpath.path == simple_xpath
+
+    xpath.add_filter('xpath', {'index': -2})
+    assert xpath.path == '/test/xpath[last() - $xpath_index]/simple'
+    assert str(xpath) == '/test/xpath[last() - 1]/simple'
+    assert xpath.path_variables == {'xpath_index': 1}
+
+    xpath = XPathBuilder(simple_xpath, strict=True)
+    with pytest.raises(ValueError):
+        str(xpath)
+
+    xpath = XPathBuilder(simple_xpath, compile_path=True)
+    xpath.add_filter('xpath', {'index': -2})
+    assert isinstance(xpath.path, etree.XPath)
+    assert str(xpath) == '/test/xpath[last() - 1]/simple'
+
+
+@pytest.mark.parametrize('simple_xpath,filters,expected', [
+    ('/fleurInput/atomGroups/atomGroup/@species', {
+        'atomGroup': {
+            'index': -1
+        }
+    }, 'Pt-1'),
+    ('/fleurInput/atomGroups/atomGroup/@species', {
+        'atomGroup': {
+            'index': {
+                '<': -1
+            }
+        }
+    }, 'Fe-1'),
+    ('/fleurInput/atomSpecies/species/@name', {
+        'species': {
+            '/mtSphere/@radius': {
+                '>=': 2.0
+            }
+        }
+    }, ['Fe-1', 'Pt-1']),
+    ('/fleurInput/atomSpecies/species/@name', {
+        'species': {
+            'has': 'lo'
+        }
+    }, ['Fe-1', 'Pt-1']),
+    ('/fleurInput/atomSpecies/species/@name', {
+        'species': {
+            'has-not': 'ldaU'
+        }
+    }, ['Fe-1', 'Pt-1']),
+    ('/fleurInput/atomGroups/atomGroup/@species', {
+        'atomGroup': {
+            'filmPos/@label': {
+                'contains': '22'
+            }
+        }
+    }, 'Fe-1'),
+    ('/fleurInput/atomGroups/atomGroup/@species', {
+        'atomGroup': {
+            'filmPos/@label': {
+                'not-contains': '22'
+            }
+        }
+    }, 'Pt-1'),
+    ('/fleurInput/atomGroups/atomGroup/@species', {
+        'atomGroup': {
+            'and': [{
+                'filmPos/@label': {
+                    'not-contains': '22'
+                }
+            }, {
+                'force/@relaxXYZ': 'TTT'
+            }]
+        }
+    }, 'Pt-1'),
+    ('/fleurInput/atomGroups/atomGroup/@species', {
+        'atomGroup': {
+            'or': [{
+                'filmPos/@label': {
+                    'not-contains': '22'
+                }
+            }, {
+                'filmPos/@label': {
+                    'contains': '22'
+                }
+            }]
+        }
+    }, ['Fe-1', 'Pt-1']),
+])
+def test_xpathbuilder_with_eval(load_inpxml, simple_xpath, filters, expected):
+    """
+    Test the xpathbuilder with a variety of different Xpath expressions and filters
+    """
+    from masci_tools.util.xml.xpathbuilder import XPathBuilder
+    from masci_tools.util.xml.common_functions import eval_xpath
+
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
+
+    xpath = XPathBuilder(simple_xpath, filters=filters)
+    print(f'Complex XPath: {str(xpath)}')
+    res = eval_xpath(xmltree, xpath)
+    assert res == expected
+    assert str(xpath) != simple_xpath  # make sure the path is not the same as the original


### PR DESCRIPTION
See #93

This PR provides a class to construct complex xpath expressions with predicates from simple xpaths via a dictionary inspired by the filters in AiiDAs QueryBuilder.
This functionality is then forwarded by providing the option of passing these filters to schema_dict_util and xml_setters functions

One bonus feature is that the programmatic construction allows usage of xpath variables making the functions much more robust and safe

TODO:
- [x] explicit tests that the filters argument in the functions is handled correctly