### PR TITLE
Modernize type annotations; add pyupgrade hook

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Cache python dependencies
       id: cache-pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Cache python dependencies
       id: cache-pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     - id: double-quote-string-fixer
       types: [python]
     - id: end-of-file-fixer
-    - id: fix-encoding-pragma
     - id: mixed-line-ending
       types: [python]
     - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,14 @@ repos:
           '--fail-on-change',
       ]
 
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.30.0
+    hooks:
+    -   id: pyupgrade
+        args: [
+            '--py37-plus'
+        ]
+
 - repo: local
   hooks:
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ formats:
   - pdf
 
 python:
-  version: 3.8
+  version: 3.9
   install:
     - method: pip
       path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 Nothing here yet
 ### Bugfixes
 - Fixed issue with ``MANIFEST.in``, where non-python files from the ``tools`` subpackage were not included in the built packages
+### For developers
+- More strict ``mypy`` configuration and moved a lot of the annotations to modern syntax with ``from __future__ import annotations``
+- Added ``pyupgrade`` hook to automatically do some easy refactoring, i.e. removing compatibility workarounds move ot modern syntax. Set to apply changes compatible with ``3.7`` and later
 
 ## v.0.7.0
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.6.2...v0.7.0)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Fleur plugin documentation build configuration file, created by
 # sphinx-quickstart on Wed Dec  7 16:39:12 2016.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,9 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode',
               'sphinx.ext.intersphinx',
+              'sphinx_toolbox.more_autodoc.typehints',
+              'sphinx_toolbox.more_autodoc.overloads',
+              'sphinx_autodoc_typehints',
               'sphinx_click']
 
 intersphinx_mapping = {'numpy': ('https://numpy.org/doc/stable/', None),
@@ -263,6 +266,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 autodoc_mock_imports = ['bokeh']
 
+
 # -- Options for manual page output ---------------------------------------
 
 # One entry per manual page. List of tuples
@@ -400,26 +404,17 @@ nitpick_ignore = [
     ('py:obj', 'bool'),
     ('py:obj', 'Mapping'),
     ('py:obj', 'plum'),
-    ('py:class', 'T'),
-    ('py:class', 'S'),
-    ('py:class', 'masci_tools.io.parsers.fleur_schema.schema_dict.F'),
-    ('py:class', 'masci_tools.io.parsers.fleur_schema.schema_dict.SchemaDictDispatch'),
-    ('py:class', '_S'),
-    ('py:class', 'masci_tools.util.case_insensitive_dict._S'),
     ('py:class', 'etree._xpath'),
-    ('py:class', 'etree._Element'),
     ('py:class', 'etree._DictAnyStr'),
     ('py:class', 'etree._XPathObject'),
     ('py:class', 'etree._XPathEvaluatorBase'),
-    ('py:class', 'fleur_schema.SchemaDict'),
-    ('py:class', 'fleur_schema.InputSchemaDict'),
-    ('py:class', 'fleur_schema.OutputSchemaDict'),
-    ('py:class', 'fleur_schema.AttributeType'),
     ('py:class', 'IO'),
     ('py:class', 'h5py._hl.base.HLObject'),
     ('py:class', 'h5py._hl.group.Group'),
-    ('py:class', 'masci_tools.io.common_functions._TVectorType'),
-    ('py:class', 'masci_tools.util.typing.TXPathLike'),
+    ('py:class', 'etree._Element'),
+    ('py:class', 'etree._ElementTree'),
+    ('py:class', 'TypeAlias'),
+    ('py:class', 'TypeGuard'),
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -415,6 +415,8 @@ nitpick_ignore = [
     ('py:class', 'etree._ElementTree'),
     ('py:class', 'TypeAlias'),
     ('py:class', 'TypeGuard'),
+    ('py:class', 'Logger'),
+    ('py:class', 'FilterType'),
 ]
 
 

--- a/docs/source/module_guide/code.rst
+++ b/docs/source/module_guide/code.rst
@@ -109,7 +109,7 @@ Functions for modifying the input file
 Functions/Classes for loading/validating fleur XML files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: masci_tools.io.parsers.fleur_schema.schema_dict.SchemaDict
+.. automodule:: masci_tools.io.parsers.fleur_schema.schema_dict
    :members:
 
 .. automodule:: masci_tools.io.io_fleurxml

--- a/docs/source/module_guide/tools.rst
+++ b/docs/source/module_guide/tools.rst
@@ -11,6 +11,9 @@ Custom Datatypes
 .. automodule:: masci_tools.util.case_insensitive_dict
    :members:
 
+.. automodule:: masci_tools.util.typing
+   :members:
+
 Common XML utility
 ------------------
 
@@ -49,6 +52,7 @@ Basic IO helper functions
 
 .. automodule:: masci_tools.io.common_functions
    :members:
+   :private-members: _TVectorType
 
 .. automodule:: masci_tools.io.hdf5_util
    :members:

--- a/masci_tools/__init__.py
+++ b/masci_tools/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/cmdline/commands/__init__.py
+++ b/masci_tools/cmdline/commands/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Import all the command groups to include in the cli
 """

--- a/masci_tools/cmdline/commands/fleur_schema.py
+++ b/masci_tools/cmdline/commands/fleur_schema.py
@@ -1,7 +1,6 @@
 """
 CLI commands for interacting with the fleur schemas in the masci-tools repository
 """
-from masci_tools.io.parsers import fleur
 from .root import cli
 import click
 
@@ -14,7 +13,6 @@ from masci_tools.io.parsers.fleur import inpxml_parser, outxml_parser
 from masci_tools.io.parsers.fleur_schema import InputSchemaDict, OutputSchemaDict, list_available_versions
 
 from pathlib import Path
-from itertools import chain
 import os
 import sys
 import shutil
@@ -146,7 +144,7 @@ def add_fleur_schema(schema_file, test_xml_file, overwrite, branch, api_key):
 
         echo.echo_info(f'Testing Schema for file: {test_xml_file}')
         if input_schema:
-            xmltree, schema_dict = load_inpxml(test_xml_file)
+            _, schema_dict = load_inpxml(test_xml_file)
 
             if schema_dict['inp_version'] != schema_version:
                 echo.echo_error(

--- a/masci_tools/cmdline/commands/fleur_schema.py
+++ b/masci_tools/cmdline/commands/fleur_schema.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 CLI commands for interacting with the fleur schemas in the masci-tools repository
 """

--- a/masci_tools/cmdline/commands/parse.py
+++ b/masci_tools/cmdline/commands/parse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Commands for parsing information from KKR/Fleur files
 """

--- a/masci_tools/cmdline/commands/parse.py
+++ b/masci_tools/cmdline/commands/parse.py
@@ -5,7 +5,6 @@ from .root import cli
 
 import click
 from masci_tools.cmdline.utils import echo
-import numpy as np
 
 
 @cli.group('parse')

--- a/masci_tools/cmdline/commands/plot.py
+++ b/masci_tools/cmdline/commands/plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Commands for plotting
 """

--- a/masci_tools/cmdline/commands/root.py
+++ b/masci_tools/cmdline/commands/root.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Main module defining the CLI for parts of the masci-tools repository
 """

--- a/masci_tools/cmdline/commands/tools.py
+++ b/masci_tools/cmdline/commands/tools.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module provides a place for registering click commands from the tools subpackage
 into the main cli

--- a/masci_tools/cmdline/parameters/slice.py
+++ b/masci_tools/cmdline/parameters/slice.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Click parameters for easily selecting multiple elements from a list via indices
 """

--- a/masci_tools/cmdline/utils/echo.py
+++ b/masci_tools/cmdline/utils/echo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #

--- a/masci_tools/io/cif2inp_ase.py
+++ b/masci_tools/io/cif2inp_ase.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/common_functions.py
+++ b/masci_tools/io/common_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/common_functions.py
+++ b/masci_tools/io/common_functions.py
@@ -13,13 +13,16 @@
 Here commonly used functions that do not need aiida-stuff (i.e. can be tested
 without a database) are collected.
 """
+from __future__ import annotations
+
 import io
-from typing import Any, Dict, Generator, Iterable, NamedTuple, Tuple, List, TypeVar, Union
+from typing import Any, Generator, Iterable, NamedTuple, TypeVar
 try:
-    from typing import TypeAlias  #type:ignore
+    from typing import TypeAlias, TypeGuard  #type:ignore
 except ImportError:
-    from typing_extensions import TypeAlias
+    from typing_extensions import TypeAlias, TypeGuard
 import numpy as np
+from collections.abc import Sequence
 import warnings
 ####################################################################################
 
@@ -72,7 +75,7 @@ def skipHeader(seq: Iterable[Any], n: int) -> Generator[Any, None, None]:
             yield item
 
 
-def filter_out_empty_dict_entries(dict_to_filter: Dict) -> Dict:
+def filter_out_empty_dict_entries(dict_to_filter: dict) -> dict:
     """
     Filter out entries in a given dict that correspond to empty values.
     At the moment this is empty lists, dicts and None
@@ -82,7 +85,7 @@ def filter_out_empty_dict_entries(dict_to_filter: Dict) -> Dict:
     :returns: dict without empty entries
     """
 
-    EMPTY_VALUES: Tuple[None, List, Dict] = (None, [], {})
+    EMPTY_VALUES: tuple[None, list, dict] = (None, [], {})
 
     return {key: val for key, val in dict_to_filter.items() if val not in EMPTY_VALUES}
 
@@ -437,20 +440,19 @@ def convert_to_fortran_string(string: str) -> str:
     return string
 
 
-def is_sequence(arg: Any) -> bool:
+def is_sequence(arg: Any) -> TypeGuard[Sequence[Any]]:
     """
     Checks if arg is a sequence
     """
-    from collections.abc import Sequence
     return isinstance(arg, Sequence) and not isinstance(arg, str)
 
 
-_TVectorType = TypeVar('_TVectorType', Tuple[float, float, float], List[float], np.ndarray)
+_TVectorType = TypeVar('_TVectorType', 'tuple[float, float, float]', 'list[float]', np.ndarray)
 """Generic type variable for atom position types"""
-VectorType: TypeAlias = Union[Tuple[float, float, float], List[float], np.ndarray]
+VectorType: TypeAlias = 'tuple[float, float, float] | list[float] |  np.ndarray'
 
 
-def abs_to_rel(vector: _TVectorType, cell: Union[List[List[float]], np.ndarray]) -> _TVectorType:
+def abs_to_rel(vector: _TVectorType, cell: list[list[float]] | np.ndarray) -> _TVectorType:
     """
     Converts a position vector in absolute coordinates to relative coordinates.
 
@@ -478,8 +480,8 @@ def abs_to_rel(vector: _TVectorType, cell: Union[List[List[float]], np.ndarray])
     return relative_vector
 
 
-def abs_to_rel_f(vector: _TVectorType, cell: Union[List[List[float]], np.ndarray], pbc: Tuple[bool, bool,
-                                                                                              bool]) -> _TVectorType:
+def abs_to_rel_f(vector: _TVectorType, cell: list[list[float]] | np.ndarray, pbc: tuple[bool, bool,
+                                                                                        bool]) -> _TVectorType:
     """
     Converts a position vector in absolute coordinates to relative coordinates
     for a film system.
@@ -516,7 +518,7 @@ def abs_to_rel_f(vector: _TVectorType, cell: Union[List[List[float]], np.ndarray
     return relative_vector
 
 
-def rel_to_abs(vector: _TVectorType, cell: Union[List[List[float]], np.ndarray]) -> _TVectorType:
+def rel_to_abs(vector: _TVectorType, cell: list[list[float]] | np.ndarray) -> _TVectorType:
     """
     Converts a position vector in internal coordinates to absolute coordinates
     in Angstrom.
@@ -545,7 +547,7 @@ def rel_to_abs(vector: _TVectorType, cell: Union[List[List[float]], np.ndarray])
     return absolute_vector
 
 
-def rel_to_abs_f(vector: _TVectorType, cell: Union[List[List[float]], np.ndarray]) -> _TVectorType:
+def rel_to_abs_f(vector: _TVectorType, cell: list[list[float]] | np.ndarray) -> _TVectorType:
     """
     Converts a position vector in internal coordinates to absolute coordinates
     in Angstrom for a film structure (2D).
@@ -576,11 +578,11 @@ def rel_to_abs_f(vector: _TVectorType, cell: Union[List[List[float]], np.ndarray
 
 def find_symmetry_relation(from_pos: VectorType,
                            to_pos: VectorType,
-                           rotations: List[np.ndarray],
-                           shifts: List[np.ndarray],
-                           cell: Union[List[List[float]], np.ndarray],
+                           rotations: list[np.ndarray],
+                           shifts: list[np.ndarray],
+                           cell: list[list[float]] | np.ndarray,
                            relative_pos: bool = False,
-                           film: bool = False) -> Tuple[np.ndarray, np.ndarray]:
+                           film: bool = False) -> tuple[np.ndarray, np.ndarray]:
     """
     Find symmetry relation between the given vectors. This functions assumes
     that a symmetry relation exists otherwise an error is raised
@@ -630,7 +632,7 @@ class AtomSiteProperties(NamedTuple):
     """
     namedtuple used for input output of atom sites
     """
-    position: List[float]  #TODO could be made generic with VectorType
+    position: list[float]  #TODO could be made generic with VectorType
     symbol: str
     kind: str
 

--- a/masci_tools/io/common_functions.py
+++ b/masci_tools/io/common_functions.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 import io
 from typing import Any, Generator, Iterable, NamedTuple, TypeVar
 try:
-    from typing import TypeAlias, TypeGuard  #type:ignore
+    from typing import TypeAlias  #type:ignore
 except ImportError:
-    from typing_extensions import TypeAlias, TypeGuard
+    from typing_extensions import TypeAlias
 import numpy as np
 from collections.abc import Sequence
 import warnings
@@ -440,7 +440,7 @@ def convert_to_fortran_string(string: str) -> str:
     return string
 
 
-def is_sequence(arg: Any) -> TypeGuard[Sequence[Any]]:
+def is_sequence(arg: Any) -> bool:
     """
     Checks if arg is a sequence
     """

--- a/masci_tools/io/common_functions.py
+++ b/masci_tools/io/common_functions.py
@@ -23,7 +23,6 @@ except ImportError:
     from typing_extensions import TypeAlias
 import numpy as np
 from collections.abc import Sequence
-import warnings
 ####################################################################################
 
 #helper functions used in calculation, parser etc.

--- a/masci_tools/io/fleur_inpgen.py
+++ b/masci_tools/io/fleur_inpgen.py
@@ -19,8 +19,7 @@ import numpy as np
 import os
 import copy
 import warnings
-from pathlib import Path
-from typing import Iterable, Sequence, IO, Any, cast
+from typing import Iterable, Sequence, Any, cast
 try:
     from typing import TypedDict
 except ImportError:

--- a/masci_tools/io/fleur_inpgen.py
+++ b/masci_tools/io/fleur_inpgen.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #
@@ -494,7 +493,7 @@ def read_inpgen_file(
         contents = file.read()
     else:
         if os.path.exists(file):  #type:ignore
-            with open(file, 'r', encoding='utf-8') as f:  #type:ignore
+            with open(file, encoding='utf-8') as f:  #type:ignore
                 contents = f.read()
         else:
             contents = file

--- a/masci_tools/io/fleur_inpgen.py
+++ b/masci_tools/io/fleur_inpgen.py
@@ -79,11 +79,11 @@ class Kinds(TypedDict, total=False):
 def write_inpgen_file(cell: np.ndarray | list[list[float]],
                       atom_sites: (Sequence[AtomSiteProperties] | Sequence[tuple[list[float], str, str]] |
                                    Sequence[AtomDictProperties]),
-                      kinds: Iterable[Kinds] = None,
+                      kinds: Iterable[Kinds] | None = None,
                       return_contents: bool = False,
                       file: FileLike = 'inpgen.in',
                       pbc: tuple[bool, bool, bool] = (True, True, True),
-                      input_params: dict = None,
+                      input_params: dict | None = None,
                       significant_figures_cell: int = 9,
                       significant_figures_positions: int = 10,
                       convert_from_angstroem: bool = True) -> str | None:
@@ -380,7 +380,7 @@ def write_inpgen_file(cell: np.ndarray | list[list[float]],
     return inpgen_file_content_str
 
 
-def get_input_data_text(key: str, val: Any, value_only: bool, mapping: dict[str, Any] = None) -> str:
+def get_input_data_text(key: str, val: Any, value_only: bool, mapping: dict[str, Any] | None = None) -> str:
     """
     Given a key and a value, return a string (possibly multiline for arrays)
     with the text to be added to the input file.

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -15,21 +15,24 @@ of fleur in a robust way.
 
 Essentially a low-level version of the FleurinpModifier in aiida_fleur.
 """
-from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Union, Optional
+from __future__ import annotations
+
+from typing import Any, Callable, NamedTuple
 
 from masci_tools.util.xml.collect_xml_setters import XPATH_SETTERS, SCHEMA_DICT_SETTERS, NMMPMAT_SETTERS
-from masci_tools.io.io_fleurxml import load_inpxml, XMLInput
+from masci_tools.io.io_fleurxml import load_inpxml
+from masci_tools.util.typing import XMLFileLike, FileLike
 from pathlib import Path
+import lxml
 from lxml import etree
-import os
 #Enable warnings for missing docstrings
 #pylint: enable=missing-function-docstring
 
 
 class ModifierTask(NamedTuple):
     name: str
-    args: Tuple[Any, ...]
-    kwargs: Dict[str, Any]
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
 
 
 class FleurXMLModifier:
@@ -69,11 +72,11 @@ class FleurXMLModifier:
 
     """
 
-    _xpath_functions: Dict[str, Callable] = XPATH_SETTERS
-    _schema_dict_functions: Dict[str, Callable] = SCHEMA_DICT_SETTERS
-    _nmmpmat_functions: Dict[str, Callable] = NMMPMAT_SETTERS
+    _xpath_functions: dict[str, Callable] = XPATH_SETTERS
+    _schema_dict_functions: dict[str, Callable] = SCHEMA_DICT_SETTERS
+    _nmmpmat_functions: dict[str, Callable] = NMMPMAT_SETTERS
 
-    _extra_functions: Dict[str, Callable] = {}
+    _extra_functions: dict[str, Callable] = {}
 
     def __new__(cls, validate_signatures=True):
 
@@ -86,11 +89,11 @@ class FleurXMLModifier:
 
     def __init__(self, validate_signatures: bool = True) -> None:
 
-        self._tasks: List[ModifierTask] = []
+        self._tasks: list[ModifierTask] = []
         self.validate_signatures = validate_signatures
 
     @classmethod
-    def fromList(cls, task_list: List[Tuple[str, Dict[str, Any]]], *args: Any, **kwargs: Any) -> 'FleurXMLModifier':
+    def fromList(cls, task_list: list[tuple[str, dict[str, Any]]], *args: Any, **kwargs: Any) -> FleurXMLModifier:
         """
         Instantiate the FleurXMLModifier from a list of tasks to be added immediately
 
@@ -106,7 +109,7 @@ class FleurXMLModifier:
         fm.add_task_list(task_list)
         return fm
 
-    def add_task_list(self, task_list: List[Tuple[str, Dict[str, Any]]]) -> None:
+    def add_task_list(self, task_list: list[tuple[str, dict[str, Any]]]) -> None:
         """
         Add a list of tasks to be added
 
@@ -133,7 +136,7 @@ class FleurXMLModifier:
 
             if name in self.xpath_functions:
                 func = self.xpath_functions[name]
-                prefix: Tuple[str, ...] = ('xmltree',)
+                prefix: tuple[str, ...] = ('xmltree',)
             elif name in self.schema_dict_functions:
                 func = self.schema_dict_functions[name]
                 prefix = ('xmltree', 'schema_dict')
@@ -161,9 +164,9 @@ class FleurXMLModifier:
     @classmethod
     def apply_modifications(cls,
                             xmltree: etree._ElementTree,
-                            nmmp_lines: Optional[List[str]],
-                            modification_tasks: List[ModifierTask],
-                            validate_changes: bool = True) -> Tuple[etree._ElementTree, Optional[List[str]]]:
+                            nmmp_lines: list[str] | None,
+                            modification_tasks: list[ModifierTask],
+                            validate_changes: bool = True) -> tuple[etree._ElementTree, list[str] | None]:
         """
         Applies given modifications to the fleurinp lxml tree.
         It also checks if a new lxml tree is validated against schema.
@@ -215,7 +218,7 @@ class FleurXMLModifier:
 
         return xmltree, nmmp_lines
 
-    def get_avail_actions(self) -> Dict[str, Callable]:
+    def get_avail_actions(self) -> dict[str, Callable]:
         """
         Returns the allowed functions from FleurXMLModifier
         """
@@ -257,7 +260,7 @@ class FleurXMLModifier:
         }
         return outside_actions
 
-    def undo(self, revert_all: bool = False) -> List[ModifierTask]:
+    def undo(self, revert_all: bool = False) -> list[ModifierTask]:
         """
         Cancels the last change or all of them
 
@@ -272,7 +275,7 @@ class FleurXMLModifier:
                 #del self._tasks[-1]
         return self._tasks
 
-    def changes(self) -> List[ModifierTask]:
+    def changes(self) -> list[ModifierTask]:
         """
         Prints out all changes currently registered on this instance
         """
@@ -280,11 +283,10 @@ class FleurXMLModifier:
         pprint(self._tasks)
         return self._tasks
 
-    def modify_xmlfile(
-            self,
-            original_inpxmlfile: XMLInput,
-            original_nmmp_file: Union[str, Path, bytes, os.PathLike, List[str]] = None,
-            validate_changes: bool = True) -> Union[Tuple[etree._ElementTree, List[str]], etree._ElementTree]:
+    def modify_xmlfile(self,
+                       original_inpxmlfile: XMLFileLike,
+                       original_nmmp_file: FileLike | list[str] | None = None,
+                       validate_changes: bool = True) -> tuple[etree._ElementTree, list[str]] | etree._ElementTree:
         """
         Applies the registered modifications to a given inputfile
 
@@ -304,7 +306,7 @@ class FleurXMLModifier:
                 with open(original_nmmp_file, encoding='utf-8') as n_mmp_file:
                     original_nmmp_lines = n_mmp_file.read().split('\n')
             else:
-                original_nmmp_lines = original_nmmp_file  #type:ignore
+                original_nmmp_lines = original_nmmp_file
         else:
             original_nmmp_lines = None
 

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #
@@ -302,7 +301,7 @@ class FleurXMLModifier:
 
         if original_nmmp_file is not None:
             if isinstance(original_nmmp_file, (str, Path)):
-                with open(original_nmmp_file, mode='r', encoding='utf-8') as n_mmp_file:
+                with open(original_nmmp_file, encoding='utf-8') as n_mmp_file:
                     original_nmmp_lines = n_mmp_file.read().split('\n')
             else:
                 original_nmmp_lines = original_nmmp_file  #type:ignore

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -23,7 +23,6 @@ from masci_tools.util.xml.collect_xml_setters import XPATH_SETTERS, SCHEMA_DICT_
 from masci_tools.io.io_fleurxml import load_inpxml
 from masci_tools.util.typing import XMLFileLike, FileLike
 from pathlib import Path
-import lxml
 from lxml import etree
 #Enable warnings for missing docstrings
 #pylint: enable=missing-function-docstring

--- a/masci_tools/io/hdf5_util.py
+++ b/masci_tools/io/hdf5_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/hdf5_util.py
+++ b/masci_tools/io/hdf5_util.py
@@ -15,11 +15,11 @@ complete file structure into a python dictionary
 """
 from __future__ import annotations
 
-from typing import IO, Any
+from typing import Any
 import h5py
 import numpy as np
-from pathlib import Path
-import os
+
+from masci_tools.util.typing import FileLike
 
 
 def hdfList(name: str, obj: h5py.HLObject) -> None:
@@ -45,7 +45,7 @@ def hdfList(name: str, obj: h5py.HLObject) -> None:
         print('')
 
 
-def h5dump(file: str | bytes | Path | os.PathLike | IO, group: str = '/') -> None:
+def h5dump(file: FileLike, group: str = '/') -> None:
     """
     Shows the overall filestructure of an hdf file
     Goes through all groups and subgroups and prints the attributes
@@ -61,7 +61,7 @@ def h5dump(file: str | bytes | Path | os.PathLike | IO, group: str = '/') -> Non
         file_hdf[group].visititems(hdfList)
 
 
-def read_hdf_simple(file: str | bytes | Path | os.PathLike | IO,
+def read_hdf_simple(file: FileLike,
                     flatten: bool = False) -> tuple[dict[str, Any], dict[str, Any]]:
     """
     Reads in an hdf file and returns its context in a nested dictionary

--- a/masci_tools/io/hdf5_util.py
+++ b/masci_tools/io/hdf5_util.py
@@ -13,8 +13,9 @@
 Small utility functions for inspecting hdf files and converting the
 complete file structure into a python dictionary
 """
+from __future__ import annotations
 
-from typing import IO, Tuple, Union, Dict, Any
+from typing import IO, Any
 import h5py
 import numpy as np
 from pathlib import Path
@@ -44,7 +45,7 @@ def hdfList(name: str, obj: h5py.HLObject) -> None:
         print('')
 
 
-def h5dump(file: Union[str, bytes, Path, os.PathLike, IO], group: str = '/') -> None:
+def h5dump(file: str | bytes | Path | os.PathLike | IO, group: str = '/') -> None:
     """
     Shows the overall filestructure of an hdf file
     Goes through all groups and subgroups and prints the attributes
@@ -60,8 +61,8 @@ def h5dump(file: Union[str, bytes, Path, os.PathLike, IO], group: str = '/') -> 
         file_hdf[group].visititems(hdfList)
 
 
-def read_hdf_simple(file: Union[str, bytes, Path, os.PathLike, IO],
-                    flatten: bool = False) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+def read_hdf_simple(file: str | bytes | Path | os.PathLike | IO,
+                    flatten: bool = False) -> tuple[dict[str, Any], dict[str, Any]]:
     """
     Reads in an hdf file and returns its context in a nested dictionary
 
@@ -80,7 +81,7 @@ def read_hdf_simple(file: Union[str, bytes, Path, os.PathLike, IO],
     return datasets, group_attrs
 
 
-def read_groups(hdfdata: h5py.Group, flatten: bool = False) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+def read_groups(hdfdata: h5py.Group, flatten: bool = False) -> tuple[dict[str, Any], dict[str, Any]]:
     """
     Recursive function to read a hdf datastructure and extract the datasets
     and attributes
@@ -91,8 +92,8 @@ def read_groups(hdfdata: h5py.Group, flatten: bool = False) -> Tuple[Dict[str, A
     :returns: two dictionaries, one with the datasets the other
               with the attributes in the file
     """
-    datasets: Dict[str, Any] = {}
-    attrs: Dict[str, Any] = {}
+    datasets: dict[str, Any] = {}
+    attrs: dict[str, Any] = {}
 
     for name, attr_val in hdfdata.attrs.items():
         if len(attr_val) == 1:

--- a/masci_tools/io/hdf5_util.py
+++ b/masci_tools/io/hdf5_util.py
@@ -61,8 +61,7 @@ def h5dump(file: FileLike, group: str = '/') -> None:
         file_hdf[group].visititems(hdfList)
 
 
-def read_hdf_simple(file: FileLike,
-                    flatten: bool = False) -> tuple[dict[str, Any], dict[str, Any]]:
+def read_hdf_simple(file: FileLike, flatten: bool = False) -> tuple[dict[str, Any], dict[str, Any]]:
     """
     Reads in an hdf file and returns its context in a nested dictionary
 

--- a/masci_tools/io/io_fleurxml.py
+++ b/masci_tools/io/io_fleurxml.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/io_fleurxml.py
+++ b/masci_tools/io/io_fleurxml.py
@@ -13,6 +13,8 @@
 This module provides easy functions for loading a input/output xml file of
 fleur and providing a parsed xml etree together with its corresponding schema dict
 """
+from __future__ import annotations
+
 from lxml import etree
 import warnings
 import io
@@ -20,16 +22,15 @@ import os
 from pathlib import Path
 from functools import partial
 from logging import Logger
-from typing import Callable, Tuple, Union, Any, IO
+from typing import Callable, Any
 from masci_tools.io.parsers import fleur_schema
+from masci_tools.util.typing import XMLFileLike
 
-XMLInput = Union[etree._ElementTree, str, Path, bytes, os.PathLike, IO]
 
-
-def load_inpxml(inpxmlfile: XMLInput,
-                logger: Logger = None,
-                base_url: str = None,
-                **kwargs: Any) -> Tuple[etree._ElementTree, 'fleur_schema.InputSchemaDict']:
+def load_inpxml(inpxmlfile: XMLFileLike,
+                logger: Logger | None = None,
+                base_url: str | None = None,
+                **kwargs: Any) -> tuple[etree._ElementTree, fleur_schema.InputSchemaDict]:
     """
     Loads a inp.xml file for fleur together with its corresponding schema dictionary
 
@@ -96,10 +97,10 @@ def load_inpxml(inpxmlfile: XMLInput,
     return xmltree, schema_dict
 
 
-def load_outxml(outxmlfile: XMLInput,
-                logger: Logger = None,
-                base_url: str = None,
-                **kwargs: Any) -> Tuple[etree._ElementTree, 'fleur_schema.OutputSchemaDict']:
+def load_outxml(outxmlfile: XMLFileLike,
+                logger: Logger | None = None,
+                base_url: str | None = None,
+                **kwargs: Any) -> tuple[etree._ElementTree, fleur_schema.OutputSchemaDict]:
     """
     Loads a out.xml file for fleur together with its corresponding schema dictionary
 

--- a/masci_tools/io/io_nmmpmat.py
+++ b/masci_tools/io/io_nmmpmat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/io_nmmpmat.py
+++ b/masci_tools/io/io_nmmpmat.py
@@ -12,11 +12,12 @@
 """
 Simple IO routines for creating text for nmmp_mat files
 """
-from typing import List
+from __future__ import annotations
+
 import numpy as np
 
 
-def format_nmmpmat(denmat: np.ndarray) -> List[str]:
+def format_nmmpmat(denmat: np.ndarray) -> list[str]:
     """
     Format a given 7x7 complex numpy array into the format for the n_mmp_mat file
 
@@ -46,7 +47,10 @@ def format_nmmpmat(denmat: np.ndarray) -> List[str]:
     return nmmp_lines
 
 
-def rotate_nmmpmat_block(denmat: np.ndarray, orbital: int, phi: float = None, theta: float = None) -> np.ndarray:
+def rotate_nmmpmat_block(denmat: np.ndarray,
+                         orbital: int,
+                         phi: float | None = None,
+                         theta: float | None = None) -> np.ndarray:
     """
     Rotate the given 7x7 complex numpy array with the d-wigner matrix
     corresponding to the given orbital and angles
@@ -75,7 +79,7 @@ def rotate_nmmpmat_block(denmat: np.ndarray, orbital: int, phi: float = None, th
     return denmat
 
 
-def write_nmmpmat(orbital: int, denmat: np.ndarray, phi: float = None, theta: float = None) -> List[str]:
+def write_nmmpmat(orbital: int, denmat: np.ndarray, phi: float | None = None, theta: float | None = None) -> list[str]:
     """
     Generate list of str for n_mmp_mat file from given numpy array
 
@@ -97,9 +101,9 @@ def write_nmmpmat(orbital: int, denmat: np.ndarray, phi: float = None, theta: fl
 
 
 def write_nmmpmat_from_states(orbital: int,
-                              state_occupations: List[float],
-                              phi: float = None,
-                              theta: float = None) -> List[str]:
+                              state_occupations: list[float],
+                              phi: float | None = None,
+                              theta: float | None = None) -> list[str]:
     """
     Generate list of str for n_mmp_mat file from diagonal occupations
 
@@ -121,9 +125,9 @@ def write_nmmpmat_from_states(orbital: int,
 
 
 def write_nmmpmat_from_orbitals(orbital: int,
-                                orbital_occupations: List[float],
-                                phi: float = None,
-                                theta: float = None) -> List[str]:
+                                orbital_occupations: list[float],
+                                phi: float | None = None,
+                                theta: float | None = None) -> list[str]:
     """
     Generate list of str for n_mmp_mat file from orbital occupations
 
@@ -167,7 +171,7 @@ def write_nmmpmat_from_orbitals(orbital: int,
     return write_nmmpmat(orbital, denmat, phi=phi, theta=theta)
 
 
-def read_nmmpmat_block(nmmp_lines: List[str], block_index: int) -> np.ndarray:
+def read_nmmpmat_block(nmmp_lines: list[str], block_index: int) -> np.ndarray:
     """
     Convert 14 line block of given nmmp_lines into 7x7 complex numpy array
 

--- a/masci_tools/io/kkr_params.py
+++ b/masci_tools/io/kkr_params.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/kkr_read_shapefun_info.py
+++ b/masci_tools/io/kkr_read_shapefun_info.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), 2018 Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.    #
 #                All rights reserved.                                         #

--- a/masci_tools/io/modify_potential.py
+++ b/masci_tools/io/modify_potential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #
@@ -97,7 +96,7 @@ class modify_potential:
 
         order = list(range(len(index1)))
 
-        with open(scoefpath, 'r') as f:
+        with open(scoefpath) as f:
             lines = f.readlines()
             natomtemp = int(lines[0])
             filedata = lines[1:natomtemp + 1]

--- a/masci_tools/io/parsers/fleur/__init__.py
+++ b/masci_tools/io/parsers/fleur/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur/default_parse_tasks.py
+++ b/masci_tools/io/parsers/fleur/default_parse_tasks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
@@ -18,21 +18,22 @@ from __future__ import annotations
 from lxml import etree
 from pprint import pprint
 
-from masci_tools.io.io_fleurxml import load_inpxml, XMLInput
+from masci_tools.io.io_fleurxml import load_inpxml
 from masci_tools.util.xml.common_functions import clear_xml, validate_xml
 from masci_tools.util.xml.converters import convert_from_xml
 from masci_tools.util.schema_dict_util import read_constants, evaluate_attribute
 from masci_tools.util.logging_util import DictHandler
+from masci_tools.util.typing import XMLFileLike
 import logging
-from typing import Dict, Any, Optional
+from typing import Any
 from masci_tools.io.parsers.fleur_schema import InputSchemaDict
 
 
-def inpxml_parser(inpxmlfile: XMLInput,
-                  parser_info_out: dict[str, Any] = None,
+def inpxml_parser(inpxmlfile: XMLFileLike,
+                  parser_info_out: dict[str, Any] | None = None,
                   strict: bool = False,
                   debug: bool = False,
-                  base_url: str = None) -> dict[str, Any]:
+                  base_url: str | None = None) -> dict[str, Any]:
     """
     Parses the given inp.xml file to a python dictionary utilizing the schema
     defined by the version number to validate and corretly convert to the dictionary

--- a/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
@@ -122,8 +122,8 @@ def inpxml_todict(parent: etree._Element,
                   schema_dict: InputSchemaDict,
                   constants: dict[str, float],
                   omitted_tags: bool = False,
-                  base_xpath: str = None,
-                  logger: logging.Logger = None) -> dict[str, Any]:
+                  base_xpath: str | None = None,
+                  logger: logging.Logger | None = None) -> dict[str, Any]:
     """
     Recursive operation which transforms an xml etree to
     python nested dictionaries and lists.

--- a/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_inpxml_parser.py
@@ -13,6 +13,8 @@
 This module contains functions to load an fleur inp.xml file, parse it with a schema
 and convert its content to a dict
 """
+from __future__ import annotations
+
 from lxml import etree
 from pprint import pprint
 
@@ -27,10 +29,10 @@ from masci_tools.io.parsers.fleur_schema import InputSchemaDict
 
 
 def inpxml_parser(inpxmlfile: XMLInput,
-                  parser_info_out: Dict[str, Any] = None,
+                  parser_info_out: dict[str, Any] = None,
                   strict: bool = False,
                   debug: bool = False,
-                  base_url: str = None) -> Dict[str, Any]:
+                  base_url: str = None) -> dict[str, Any]:
     """
     Parses the given inp.xml file to a python dictionary utilizing the schema
     defined by the version number to validate and corretly convert to the dictionary
@@ -48,7 +50,7 @@ def inpxml_parser(inpxmlfile: XMLInput,
     """
 
     __parser_version__ = '0.3.0'
-    logger: Optional[logging.Logger] = logging.getLogger(__name__)
+    logger: logging.Logger | None = logging.getLogger(__name__)
 
     if strict:
         logger = None
@@ -116,11 +118,11 @@ def inpxml_parser(inpxmlfile: XMLInput,
 
 
 def inpxml_todict(parent: etree._Element,
-                  schema_dict: 'InputSchemaDict',
-                  constants: Dict[str, float],
+                  schema_dict: InputSchemaDict,
+                  constants: dict[str, float],
                   omitted_tags: bool = False,
                   base_xpath: str = None,
-                  logger: logging.Logger = None) -> Dict[str, Any]:
+                  logger: logging.Logger = None) -> dict[str, Any]:
     """
     Recursive operation which transforms an xml etree to
     python nested dictionaries and lists.
@@ -142,7 +144,7 @@ def inpxml_todict(parent: etree._Element,
     if base_xpath is None:
         base_xpath = f'/{parent.tag}'
 
-    return_dict: Dict[str, Any] = {}
+    return_dict: dict[str, Any] = {}
     if list(parent.items()):
         return_dict = {str(key): val for key, val in parent.items()}
         # Now we have to convert lazy fortan style into pretty things for the Database

--- a/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
@@ -18,33 +18,34 @@ from __future__ import annotations
 from masci_tools.util.parse_tasks import ParseTasks
 from masci_tools.util.schema_dict_util import tag_exists, read_constants, eval_simple_xpath, evaluate_attribute
 from masci_tools.util.xml.common_functions import clear_xml, validate_xml
-from masci_tools.io.io_fleurxml import load_outxml, XMLInput
+from masci_tools.io.io_fleurxml import load_outxml
 from masci_tools.util.logging_util import DictHandler, OutParserLogAdapter
 from masci_tools.io.parsers.fleur_schema import OutputSchemaDict
+from masci_tools.util.typing import XMLFileLike
 from lxml import etree
 import copy
 import warnings
 import logging
-from typing import Dict, Any, Iterable, Optional, Tuple, Union, List
+from typing import Any, Iterable
 try:
     from typing import Literal
 except ImportError:
     from typing_extensions import Literal  #type:ignore
 
 
-def outxml_parser(outxmlfile: XMLInput,
-                  parser_info_out: dict[str, Any] = None,
+def outxml_parser(outxmlfile: XMLFileLike,
+                  parser_info_out: dict[str, Any] | None = None,
                   iteration_to_parse: Literal['all', 'last', 'first'] | int = 'last',
                   minimal_mode: bool = False,
-                  additional_tasks: dict[str, dict[str, Any]] = None,
-                  optional_tasks: Iterable[str] = None,
+                  additional_tasks: dict[str, dict[str, Any]] | None = None,
+                  optional_tasks: Iterable[str] | None = None,
                   overwrite: bool = False,
                   append: bool = False,
                   list_return: bool = False,
                   strict: bool = False,
                   debug: bool = False,
                   ignore_validation: bool = False,
-                  base_url: str = None) -> dict[str, Any]:
+                  base_url: str | None = None) -> dict[str, Any]:
     """
     Parses the out.xml file to a dictionary based on the version and the given tasks
 

--- a/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
+++ b/masci_tools/io/parsers/fleur/fleur_outxml_parser.py
@@ -13,6 +13,8 @@
 This module contains functions to load an fleur out.xml file, parse it with a schema
 and convert its content to a dict, based on the tasks given
 """
+from __future__ import annotations
+
 from masci_tools.util.parse_tasks import ParseTasks
 from masci_tools.util.schema_dict_util import tag_exists, read_constants, eval_simple_xpath, evaluate_attribute
 from masci_tools.util.xml.common_functions import clear_xml, validate_xml
@@ -31,10 +33,10 @@ except ImportError:
 
 
 def outxml_parser(outxmlfile: XMLInput,
-                  parser_info_out: Dict[str, Any] = None,
-                  iteration_to_parse: Union[Literal['all', 'last', 'first'], int] = 'last',
+                  parser_info_out: dict[str, Any] = None,
+                  iteration_to_parse: Literal['all', 'last', 'first'] | int = 'last',
                   minimal_mode: bool = False,
-                  additional_tasks: Dict[str, Dict[str, Any]] = None,
+                  additional_tasks: dict[str, dict[str, Any]] = None,
                   optional_tasks: Iterable[str] = None,
                   overwrite: bool = False,
                   append: bool = False,
@@ -42,7 +44,7 @@ def outxml_parser(outxmlfile: XMLInput,
                   strict: bool = False,
                   debug: bool = False,
                   ignore_validation: bool = False,
-                  base_url: str = None) -> Dict[str, Any]:
+                  base_url: str = None) -> dict[str, Any]:
     """
     Parses the out.xml file to a dictionary based on the version and the given tasks
 
@@ -76,7 +78,7 @@ def outxml_parser(outxmlfile: XMLInput,
 
     __parser_version__ = '0.6.0'
 
-    logger: Optional[logging.Logger] = logging.getLogger(__name__)
+    logger: logging.Logger | None = logging.getLogger(__name__)
     if strict:
         logger = None
 
@@ -235,7 +237,7 @@ def outxml_parser(outxmlfile: XMLInput,
                          "Valid values are: 'first', 'last', 'all', or int")
 
     logger_info = {'iteration': 'unknown'}
-    iteration_logger: Optional[logging.LoggerAdapter] = None
+    iteration_logger: logging.LoggerAdapter | None = None
     if logger is not None:
         iteration_logger = OutParserLogAdapter(logger, logger_info)
 
@@ -274,11 +276,10 @@ def outxml_parser(outxmlfile: XMLInput,
     return out_dict
 
 
-def parse_general_information(root: etree._Element, parser: ParseTasks, outschema_dict: 'OutputSchemaDict',
-                              logger: Optional[logging.Logger], iteration_to_parse: Union[Literal['all', 'last',
-                                                                                                  'first'],
-                                                                                          int], minimal_mode: bool,
-                              optional_tasks: Optional[Iterable[str]]) -> Tuple[Dict[str, Any], Dict[str, float]]:
+def parse_general_information(root: etree._Element, parser: ParseTasks, outschema_dict: OutputSchemaDict,
+                              logger: logging.Logger | None,
+                              iteration_to_parse: (Literal['all', 'last', 'first'] | int), minimal_mode: bool,
+                              optional_tasks: Iterable[str] | None) -> tuple[dict[str, Any], dict[str, float]]:
     """
     Parses the information from the out.xml outside scf iterations
 
@@ -336,9 +337,9 @@ def parse_general_information(root: etree._Element, parser: ParseTasks, outschem
     return out_dict, constants
 
 
-def parse_iteration(iteration_node: etree._Element, parser: ParseTasks, outschema_dict: 'OutputSchemaDict',
-                    out_dict: Dict[str, Any], constants: Dict[str, float], logger: Optional[logging.LoggerAdapter],
-                    minimal_mode: bool) -> Dict[str, Any]:
+def parse_iteration(iteration_node: etree._Element, parser: ParseTasks, outschema_dict: OutputSchemaDict,
+                    out_dict: dict[str, Any], constants: dict[str, float], logger: logging.LoggerAdapter | None,
+                    minimal_mode: bool) -> dict[str, Any]:
     """
     Parses an scf iteration node. Which tasks to perform is stored in parser.iteration_tasks
 

--- a/masci_tools/io/parsers/fleur/fleur_schema/__init__.py
+++ b/masci_tools/io/parsers/fleur/fleur_schema/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module is only here for backwards compatibility
 """

--- a/masci_tools/io/parsers/fleur/outxml_conversions.py
+++ b/masci_tools/io/parsers/fleur/outxml_conversions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur/outxml_conversions.py
+++ b/masci_tools/io/parsers/fleur/outxml_conversions.py
@@ -13,18 +13,20 @@
 This module contains custom conversion functions for the outxml_parser, which
 cannot be handled by the standard parsing framework
 """
+from __future__ import annotations
+
 from datetime import date
 import numpy as np
 from pprint import pprint
 from masci_tools.util.constants import HTR_TO_EV
 from masci_tools.util.parse_tasks_decorators import conversion_function
 from masci_tools.io.common_functions import convert_to_pystd
-from typing import Dict, Any
+from typing import Any
 from logging import Logger
 
 
 @conversion_function
-def convert_total_energy(out_dict: Dict[str, Any], logger: Logger) -> Dict[str, Any]:
+def convert_total_energy(out_dict: dict[str, Any], logger: Logger) -> dict[str, Any]:
     """
     Convert total energy to eV
     """
@@ -56,7 +58,7 @@ def convert_total_energy(out_dict: Dict[str, Any], logger: Logger) -> Dict[str, 
 
 
 @conversion_function
-def calculate_total_magnetic_moment(out_dict: Dict[str, Any], logger: Logger) -> Dict[str, Any]:
+def calculate_total_magnetic_moment(out_dict: dict[str, Any], logger: Logger) -> dict[str, Any]:
     """
     Calculate the the total magnetic moment per cell
 
@@ -80,7 +82,7 @@ def calculate_total_magnetic_moment(out_dict: Dict[str, Any], logger: Logger) ->
 
 
 @conversion_function
-def calculate_walltime(out_dict: Dict[str, Any], logger: Logger) -> Dict[str, Any]:
+def calculate_walltime(out_dict: dict[str, Any], logger: Logger) -> dict[str, Any]:
     """
     Calculate the walltime from start and end time
 
@@ -139,7 +141,7 @@ def calculate_walltime(out_dict: Dict[str, Any], logger: Logger) -> Dict[str, An
 
 
 @conversion_function
-def convert_ldau_definitions(out_dict: Dict[str, Any], logger: Logger) -> Dict[str, Any]:
+def convert_ldau_definitions(out_dict: dict[str, Any], logger: Logger) -> dict[str, Any]:
     """
     Convert the parsed information from LDA+U into a more readable dict
 
@@ -183,7 +185,7 @@ def convert_ldau_definitions(out_dict: Dict[str, Any], logger: Logger) -> Dict[s
 
 
 @conversion_function
-def convert_relax_info(out_dict: Dict[str, Any], logger: Logger) -> Dict[str, Any]:
+def convert_relax_info(out_dict: dict[str, Any], logger: Logger) -> dict[str, Any]:
     """
     Convert the general relaxation information
 
@@ -211,7 +213,7 @@ def convert_relax_info(out_dict: Dict[str, Any], logger: Logger) -> Dict[str, An
 
 
 @conversion_function
-def convert_forces(out_dict: Dict[str, Any], logger: Logger) -> Dict[str, Any]:
+def convert_forces(out_dict: dict[str, Any], logger: Logger) -> dict[str, Any]:
     """
     Convert the parsed forces from a iteration
 

--- a/masci_tools/io/parsers/fleur/task_migrations.py
+++ b/masci_tools/io/parsers/fleur/task_migrations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur/task_migrations.py
+++ b/masci_tools/io/parsers/fleur/task_migrations.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import copy
 from masci_tools.util.parse_tasks_decorators import register_migration
-from typing import Dict, Any
+from typing import Any
 
 
 @register_migration(base_version='0.33', target_version=['0.31', '0.30', '0.29'])

--- a/masci_tools/io/parsers/fleur/task_migrations.py
+++ b/masci_tools/io/parsers/fleur/task_migrations.py
@@ -12,13 +12,15 @@
 """
 In this module migration functions for the task definitions are collected
 """
+from __future__ import annotations
+
 import copy
 from masci_tools.util.parse_tasks_decorators import register_migration
 from typing import Dict, Any
 
 
 @register_migration(base_version='0.33', target_version=['0.31', '0.30', '0.29'])
-def migrate_033_to_031(definition_dict: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+def migrate_033_to_031(definition_dict: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
     """
     Migrate definitions for MaX5 release to MaX4 release
 
@@ -33,7 +35,7 @@ def migrate_033_to_031(definition_dict: Dict[str, Dict[str, Any]]) -> Dict[str, 
 
 
 @register_migration(base_version='0.34', target_version='0.33')
-def migrate_034_to_033(definition_dict: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+def migrate_034_to_033(definition_dict: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
     """
     Migrate definitions for MaX5 bugfix release to MaX5 release
 

--- a/masci_tools/io/parsers/fleur_schema/__init__.py
+++ b/masci_tools/io/parsers/fleur_schema/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
+++ b/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
+++ b/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
@@ -48,7 +48,25 @@ BASE_TYPES = {
 NAMESPACES = {'xsd': 'http://www.w3.org/2001/XMLSchema'}
 
 
+def convert_str_version_number(version_str: str) -> tuple[int, int]:
+    """
+    Convert the version number as a integer for easy comparisons
+
+    :param version_str: str of the version number, e.g. '0.33'
+
+    :returns: tuple of ints representing the version str
+    """
+
+    version_numbers = version_str.split('.')
+
+    if len(version_numbers) != 2:
+        raise ValueError(f"Version number is malformed: '{version_str}'")
+
+    return tuple(int(part) for part in version_numbers)  #type:ignore
+
+
 class AttributeType(NamedTuple):
+    """Type for describing the types of attributes/text"""
     base_type: str
     length: int | Literal['unbounded'] | None
 

--- a/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
+++ b/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
@@ -233,7 +233,7 @@ def _get_parent_fleur_type(elem: etree._Element,
 def _get_base_types(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                     type_elem: etree._Element,
                     convert_to_base: bool = True,
-                    basic_types_mapping: dict[str, list[AttributeType]] = None) -> list[AttributeType]:
+                    basic_types_mapping: dict[str, list[AttributeType]] | None = None) -> list[AttributeType]:
     """
     Analyses the given type element to deduce its base_types and length restrictions
 
@@ -381,8 +381,8 @@ def _get_length(xmlschema_evaluator: etree.XPathDocumentEvaluator,
 @_cache_xpath_construction
 def _get_xpath(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                tag_name: str,
-               enforce_end_type: str = None,
-               ref: str = None,
+               enforce_end_type: str | None = None,
+               ref: str | None = None,
                stop_non_unique: bool = False,
                stop_iteration: bool = False,
                iteration_root: bool = False) -> set[str]:
@@ -595,7 +595,7 @@ def _is_simple(elem: etree._Element) -> bool:
 
 def _get_simple_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                      elem: etree._Element,
-                     input_mapping: dict[str, list[AttributeType]] = None) -> CaseInsensitiveFrozenSet[str]:
+                     input_mapping: dict[str, list[AttributeType]] | None = None) -> CaseInsensitiveFrozenSet[str]:
     """
     Get all defined tags contained in the given etree Element of the schema
     which can only contain attributes or text (no sub elements)

--- a/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
+++ b/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
@@ -12,9 +12,11 @@
 """
 functions to extract information about the fleur schema input or output
 """
+from __future__ import annotations
+
 from masci_tools.util.case_insensitive_dict import CaseInsensitiveDict, CaseInsensitiveFrozenSet
 from functools import wraps
-from typing import Callable, List, NamedTuple, Set, Union, Dict, Any, Tuple, Optional
+from typing import Callable, NamedTuple, Any
 from lxml import etree
 try:
     from typing import Literal, TypedDict
@@ -48,7 +50,7 @@ NAMESPACES = {'xsd': 'http://www.w3.org/2001/XMLSchema'}
 
 class AttributeType(NamedTuple):
     base_type: str
-    length: Union[int, Literal['unbounded'], None]
+    length: int | Literal['unbounded'] | None
 
 
 class TagInfo(TypedDict):
@@ -58,7 +60,7 @@ class TagInfo(TypedDict):
     optional_attribs: CaseInsensitiveDict[str, str]
     optional: CaseInsensitiveFrozenSet[str]
     several: CaseInsensitiveFrozenSet[str]
-    order: List[str]
+    order: list[str]
     simple: CaseInsensitiveFrozenSet[str]
     complex: CaseInsensitiveFrozenSet[str]
     text: CaseInsensitiveFrozenSet[str]
@@ -73,10 +75,10 @@ def _cache_xpath_construction(func: Callable) -> Callable:
     xml schemas by caching results
     """
 
-    results: Dict[str, Dict[int, Set[str]]] = {}
+    results: dict[str, dict[int, set[str]]] = {}
 
     @wraps(func)
-    def wrapper(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', name: str, **kwargs: Any) -> Set[str]:
+    def wrapper(xmlschema_evaluator: etree.XPathDocumentEvaluator, name: str, **kwargs: Any) -> set[str]:
         """
         This function produces a hash from all the arguments modifying the behaviour of the wrapped function
         and looks up results in dict based on this hash. If the version of the schema
@@ -111,11 +113,11 @@ def _cache_xpath_eval(func: Callable) -> Callable:
     Decorator for the `_xpath_eval` function to speed up concrete xpath calls on the schema
     by caching the results
     """
-    results: Dict[str, Dict[int, 'etree._XPathObject']] = {}
+    results: dict[str, dict[int, etree._XPathObject]] = {}
 
     @wraps(func)
-    def wrapper(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', xpath: str,
-                **variables: 'etree._XPathObject') -> 'etree._XPathObject':
+    def wrapper(xmlschema_evaluator: etree.XPathDocumentEvaluator, xpath: str,
+                **variables: etree._XPathObject) -> etree._XPathObject:
         """
         This function produces a hash from all the arguments modifying the behaviour of the wrapped function
         and looks up results in dict based on this hash. If the version of the schema
@@ -145,8 +147,8 @@ def _cache_xpath_eval(func: Callable) -> Callable:
 
 
 @_cache_xpath_eval
-def _xpath_eval(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', xpath: str,
-                **variables: 'etree._XPathObject') -> 'etree._XPathObject':
+def _xpath_eval(xmlschema_evaluator: etree.XPathDocumentEvaluator, xpath: str,
+                **variables: etree._XPathObject) -> etree._XPathObject:
     """
     Wrapper around the xpath calls in this module. Used for caching the
     results
@@ -176,7 +178,7 @@ def _is_base_type(type_name: str) -> bool:
 
 
 def _get_parent_fleur_type(elem: etree._Element,
-                           stop_non_unique: bool = False) -> Tuple[Optional[etree._Element], Optional[str]]:
+                           stop_non_unique: bool = False) -> tuple[etree._Element | None, str | None]:
     """
     Returns the parent simple or complexType to the given element
     If stop_sequence is given and True None is returned when a sequence is encountered
@@ -208,10 +210,10 @@ def _get_parent_fleur_type(elem: etree._Element,
     return parent, parent_type
 
 
-def _get_base_types(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def _get_base_types(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                     type_elem: etree._Element,
                     convert_to_base: bool = True,
-                    basic_types_mapping: Dict[str, List[AttributeType]] = None) -> List[AttributeType]:
+                    basic_types_mapping: dict[str, list[AttributeType]] = None) -> list[AttributeType]:
     """
     Analyses the given type element to deduce its base_types and length restrictions
 
@@ -299,8 +301,8 @@ def _get_base_types(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return list(possible_types)
 
 
-def _get_length(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
-                type_elem: etree._Element) -> Union[int, Literal['unbounded'], None]:
+def _get_length(xmlschema_evaluator: etree.XPathDocumentEvaluator,
+                type_elem: etree._Element) -> int | Literal['unbounded'] | None:
     """
     Analyse the given type to determine, whether there is a length restriction
 
@@ -357,13 +359,13 @@ def _get_length(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
 
 
 @_cache_xpath_construction
-def _get_xpath(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def _get_xpath(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                tag_name: str,
                enforce_end_type: str = None,
                ref: str = None,
                stop_non_unique: bool = False,
                stop_iteration: bool = False,
-               iteration_root: bool = False) -> Set[str]:
+               iteration_root: bool = False) -> set[str]:
     """
     construct all possible simple xpaths to a given tag
 
@@ -379,7 +381,7 @@ def _get_xpath(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
              otherwise a list with all possible paths is returned
     """
 
-    possible_paths: Set[str] = set()
+    possible_paths: set[str] = set()
     if enforce_end_type in _RECURSIVE_TYPES:
         return possible_paths
     root_tag = get_root_tag(xmlschema_evaluator)
@@ -456,7 +458,7 @@ def _get_xpath(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return possible_paths
 
 
-def _get_contained_optional_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def _get_contained_optional_attribs(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                                     elem: etree._Element) -> CaseInsensitiveDict[str, str]:
     """
     Get all defined attributes contained in the given etree Element of the schema
@@ -487,7 +489,7 @@ def _get_contained_optional_attribs(xmlschema_evaluator: 'etree.XPathDocumentEva
     return CaseInsensitiveDict(attrib_list)
 
 
-def _get_contained_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def _get_contained_attribs(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                            elem: etree._Element) -> CaseInsensitiveFrozenSet[str]:
     """
     Get all defined attributes contained in the given etree Element of the schema
@@ -515,7 +517,7 @@ def _get_contained_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return attrib_res
 
 
-def _get_optional_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def _get_optional_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                        elem: etree._Element) -> CaseInsensitiveFrozenSet[str]:
     """
     Get all defined tags contained in the given etree Element of the schema
@@ -571,9 +573,9 @@ def _is_simple(elem: etree._Element) -> bool:
     return simple
 
 
-def _get_simple_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def _get_simple_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                      elem: etree._Element,
-                     input_mapping: Dict[str, List[AttributeType]] = None) -> CaseInsensitiveFrozenSet[str]:
+                     input_mapping: dict[str, list[AttributeType]] = None) -> CaseInsensitiveFrozenSet[str]:
     """
     Get all defined tags contained in the given etree Element of the schema
     which can only contain attributes or text (no sub elements)
@@ -622,7 +624,7 @@ def _get_simple_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return simple_set
 
 
-def _get_several_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def _get_several_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                       elem: etree._Element) -> CaseInsensitiveFrozenSet[str]:
     """
     Get all defined tags contained in the given etree Element of the schema
@@ -660,8 +662,8 @@ def _get_several_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return several_set
 
 
-def _get_contained_text_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', elem: etree._Element,
-                             text_tags: Set[str]) -> CaseInsensitiveFrozenSet[str]:
+def _get_contained_text_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator, elem: etree._Element,
+                             text_tags: set[str]) -> CaseInsensitiveFrozenSet[str]:
     """
     Get all defined tags contained in the given etree Element of the schema
     which can contain text
@@ -693,11 +695,11 @@ def _get_contained_text_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator'
 
 
 @_cache_xpath_construction
-def _get_attrib_xpath(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def _get_attrib_xpath(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                       attrib_name: str,
                       stop_non_unique: bool = False,
                       stop_iteration: bool = False,
-                      iteration_root: bool = False) -> Set[str]:
+                      iteration_root: bool = False) -> set[str]:
     """
     construct all possible simple xpaths to a given attribute
 
@@ -745,8 +747,7 @@ def _get_attrib_xpath(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return possible_paths
 
 
-def _get_sequence_order(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
-                        sequence_elem: etree._Element) -> List[str]:
+def _get_sequence_order(xmlschema_evaluator: etree.XPathDocumentEvaluator, sequence_elem: etree._Element) -> list[str]:
     """
     Extract the enforced order of elements in the given sequence element
 
@@ -778,7 +779,7 @@ def _get_sequence_order(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return elem_order
 
 
-def _get_valid_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', sequence_elem: etree._Element) -> List[str]:
+def _get_valid_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator, sequence_elem: etree._Element) -> list[str]:
     """
     Extract all allowed elements in the given sequence element
 
@@ -810,9 +811,9 @@ def _get_valid_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', sequenc
     return elems
 
 
-def _extract_all_types(elems: List[etree._Element],
+def _extract_all_types(elems: list[etree._Element],
                        ignore_unknown: bool = False,
-                       **kwargs: Any) -> CaseInsensitiveDict[str, Set[AttributeType]]:
+                       **kwargs: Any) -> CaseInsensitiveDict[str, set[AttributeType]]:
     """
     Determine the required type of all given attributes/elements
 
@@ -824,7 +825,7 @@ def _extract_all_types(elems: List[etree._Element],
              types are possible a list is inserted for the tag
     """
 
-    types_dict: CaseInsensitiveDict[str, Set[AttributeType]] = CaseInsensitiveDict()
+    types_dict: CaseInsensitiveDict[str, set[AttributeType]] = CaseInsensitiveDict()
     for elem in elems:
         name = str(elem.attrib['name'])
         type_name = str(elem.attrib['type'])
@@ -851,7 +852,7 @@ def _extract_all_types(elems: List[etree._Element],
     return types_dict
 
 
-def type_order(type_def: AttributeType) -> Tuple[int, float]:
+def type_order(type_def: AttributeType) -> tuple[int, float]:
     """
     Key function for sorting the type definitions to avoid conflicts
 
@@ -877,8 +878,8 @@ def type_order(type_def: AttributeType) -> Tuple[int, float]:
     return type_index, length
 
 
-def extract_attribute_types(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
-                            **kwargs: Any) -> CaseInsensitiveDict[str, List[AttributeType]]:
+def extract_attribute_types(xmlschema_evaluator: etree.XPathDocumentEvaluator,
+                            **kwargs: Any) -> CaseInsensitiveDict[str, list[AttributeType]]:
     """
     Determine the required type of all attributes
 
@@ -891,15 +892,15 @@ def extract_attribute_types(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
 
     types_dict = _extract_all_types(possible_attrib, **kwargs)
 
-    types_dict_sorted: CaseInsensitiveDict[str, List[AttributeType]] = CaseInsensitiveDict()
+    types_dict_sorted: CaseInsensitiveDict[str, list[AttributeType]] = CaseInsensitiveDict()
     for name, types in types_dict.items():
         types_dict_sorted[name] = sorted(types, key=type_order)
 
     return types_dict_sorted
 
 
-def extract_text_types(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
-                       **kwargs: Any) -> CaseInsensitiveDict[str, List[AttributeType]]:
+def extract_text_types(xmlschema_evaluator: etree.XPathDocumentEvaluator,
+                       **kwargs: Any) -> CaseInsensitiveDict[str, list[AttributeType]]:
     """
     Determine the required type of all elements with text
 
@@ -912,15 +913,15 @@ def extract_text_types(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
 
     types_dict = _extract_all_types(possible_elems, ignore_unknown=True, **kwargs)
 
-    types_dict_sorted: CaseInsensitiveDict[str, List[AttributeType]] = CaseInsensitiveDict()
+    types_dict_sorted: CaseInsensitiveDict[str, list[AttributeType]] = CaseInsensitiveDict()
     for name, types in types_dict.items():
         types_dict_sorted[name] = sorted(types, key=type_order)
 
     return types_dict_sorted
 
 
-def get_tag_paths(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
-                  **kwargs: Any) -> CaseInsensitiveDict[str, Union[List[str], str]]:
+def get_tag_paths(xmlschema_evaluator: etree.XPathDocumentEvaluator,
+                  **kwargs: Any) -> CaseInsensitiveDict[str, list[str] | str]:
     """
     Determine simple xpaths to all possible tags
 
@@ -934,7 +935,7 @@ def get_tag_paths(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     iteration_root = kwargs.get('iteration_root', False)
 
     possible_tags = set(_xpath_eval(xmlschema_evaluator, '//xsd:element/@name'))
-    tag_paths: CaseInsensitiveDict[str, Union[List[str], str]] = CaseInsensitiveDict()
+    tag_paths: CaseInsensitiveDict[str, list[str] | str] = CaseInsensitiveDict()
     for tag in sorted(possible_tags):
         paths = _get_xpath(xmlschema_evaluator, tag, stop_iteration=stop_iteration, iteration_root=iteration_root)
         if len(paths) == 1:
@@ -944,7 +945,7 @@ def get_tag_paths(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return tag_paths
 
 
-def get_unique_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def get_unique_attribs(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                        **kwargs: Any) -> CaseInsensitiveDict[str, str]:
     """
     Determine all attributes, which can be set through set_inpchanges in aiida_fleur
@@ -988,8 +989,8 @@ def get_unique_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return settable
 
 
-def get_unique_path_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
-                            **kwargs: Any) -> CaseInsensitiveDict[str, List[str]]:
+def get_unique_path_attribs(xmlschema_evaluator: etree.XPathDocumentEvaluator,
+                            **kwargs: Any) -> CaseInsensitiveDict[str, list[str]]:
     """
     Determine all attributes, with multiple possible path that do have at
     least one path with all contained tags maxOccurs!=1
@@ -1010,7 +1011,7 @@ def get_unique_path_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
         settable_key = 'unique_attribs'
         settable_contains_key = 'unique_path_attribs'
 
-    settable: CaseInsensitiveDict[str, List[str]] = CaseInsensitiveDict()
+    settable: CaseInsensitiveDict[str, list[str]] = CaseInsensitiveDict()
     possible_attrib = set(_xpath_eval(xmlschema_evaluator, '//xsd:attribute/@name'))
     for attrib in sorted(possible_attrib):
         if attrib in kwargs[settable_key]:
@@ -1037,8 +1038,8 @@ def get_unique_path_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return settable
 
 
-def get_other_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
-                      **kwargs: Any) -> CaseInsensitiveDict[str, List[str]]:
+def get_other_attribs(xmlschema_evaluator: etree.XPathDocumentEvaluator,
+                      **kwargs: Any) -> CaseInsensitiveDict[str, list[str]]:
     """
     Determine all other attributes not contained in settable or settable_contains
 
@@ -1058,7 +1059,7 @@ def get_other_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
         settable_key = 'unique_attribs'
         settable_contains_key = 'unique_path_attribs'
 
-    other: CaseInsensitiveDict[str, List[str]] = CaseInsensitiveDict()
+    other: CaseInsensitiveDict[str, list[str]] = CaseInsensitiveDict()
     possible_attrib = set(_xpath_eval(xmlschema_evaluator, '//xsd:attribute/@name'))
     for attrib in sorted(possible_attrib):
         path = _get_attrib_xpath(xmlschema_evaluator,
@@ -1091,7 +1092,7 @@ def get_other_attribs(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return other
 
 
-def get_omittable_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kwargs: Any) -> List[str]:
+def get_omittable_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator, **kwargs: Any) -> list[str]:
     """
     find tags with no attributes and, which are only used to mask a list of one other possible tag (e.g. atomSpecies)
 
@@ -1136,7 +1137,7 @@ def get_omittable_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kw
     return omittable_tags
 
 
-def get_text_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kwargs: Any) -> CaseInsensitiveFrozenSet[str]:
+def get_text_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator, **kwargs: Any) -> CaseInsensitiveFrozenSet[str]:
     """
     find all elements, who can contain text
 
@@ -1164,8 +1165,7 @@ def get_text_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kwargs:
     return text_tags
 
 
-def get_basic_types(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
-                    **kwargs: Any) -> Dict[str, List[AttributeType]]:
+def get_basic_types(xmlschema_evaluator: etree.XPathDocumentEvaluator, **kwargs: Any) -> dict[str, list[AttributeType]]:
     """
     find all types, which can be traced back directly to a base_type
 
@@ -1203,7 +1203,7 @@ def get_basic_types(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
     return basic_types
 
 
-def get_tag_info(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kwargs: Any) -> Dict[str, TagInfo]:
+def get_tag_info(xmlschema_evaluator: etree.XPathDocumentEvaluator, **kwargs: Any) -> dict[str, TagInfo]:
     """
     Get all important information about the tags
         - allowed attributes
@@ -1261,7 +1261,7 @@ def get_tag_info(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kwargs: 
     return tag_info
 
 
-def get_root_tag(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kwargs: Any) -> str:
+def get_root_tag(xmlschema_evaluator: etree.XPathDocumentEvaluator, **kwargs: Any) -> str:
     """
     Returns the tag for the root element of the xmlschema
 
@@ -1272,7 +1272,7 @@ def get_root_tag(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kwargs: 
     return str(_xpath_eval(xmlschema_evaluator, '/xsd:schema/xsd:element/@name')[0])
 
 
-def get_input_tag(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kwargs: Any) -> str:
+def get_input_tag(xmlschema_evaluator: etree.XPathDocumentEvaluator, **kwargs: Any) -> str:
     """
     Returns the tag for the input type element of the outxmlschema
 
@@ -1283,7 +1283,7 @@ def get_input_tag(xmlschema_evaluator: 'etree.XPathDocumentEvaluator', **kwargs:
     return str(_xpath_eval(xmlschema_evaluator, '//xsd:element[@type=$type]/@name', type=_INPUT_TYPE)[0])
 
 
-def get_iteration_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
+def get_iteration_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator,
                        **kwargs: Any) -> CaseInsensitiveFrozenSet[str]:
     """
     Returns the tags that can contain the information from a SCF iteration
@@ -1292,7 +1292,7 @@ def get_iteration_tags(xmlschema_evaluator: 'etree.XPathDocumentEvaluator',
 
     :return: set of tag names that contain elements from the group 'GeneralIterationType'
     """
-    tag_names: Set[str] = set()
+    tag_names: set[str] = set()
     group_nodes = _xpath_eval(xmlschema_evaluator, '//xsd:group[@ref=$ref]', ref=_ITERATION_GROUP_TYPE)
 
     for node in group_nodes:

--- a/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
+++ b/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
@@ -21,7 +21,7 @@ from lxml import etree
 try:
     from typing import Literal, TypedDict
 except ImportError:
-    from typing_extensions import Literal, TypedDict  #type: ignore
+    from typing_extensions import Literal, TypedDict  #type: ignore[misc]
 import warnings
 import math
 
@@ -62,7 +62,7 @@ def convert_str_version_number(version_str: str) -> tuple[int, int]:
     if len(version_numbers) != 2:
         raise ValueError(f"Version number is malformed: '{version_str}'")
 
-    return tuple(int(part) for part in version_numbers)  #type:ignore
+    return tuple(int(part) for part in version_numbers)  #type: ignore[return-value]
 
 
 class AttributeType(NamedTuple):
@@ -158,8 +158,10 @@ def _cache_xpath_eval(func: Callable) -> Callable:
                 results[version].clear()
                 return res
             results[version][hash_args] = res
+        else:
+            res = results[version][hash_args]
 
-        return results[version][hash_args].copy()  #type:ignore
+        return res.copy() if getattr(res, 'copy', None) is not None else res
 
     return wrapper
 
@@ -336,10 +338,10 @@ def _get_length(xmlschema_evaluator: etree.XPathDocumentEvaluator,
 
     if type_tag == 'simpleType':
 
-        child = type_elem.getchildren()  #type:ignore
-        if len(child) != 1:
+        children = list(type_elem)
+        if len(children) != 1:
             return 1
-        child = child[0]
+        child = children[0]
 
         child_type = _normalized_name(child.tag)
         if child_type == 'restriction':

--- a/masci_tools/io/parsers/fleur_schema/inpschema_todict.py
+++ b/masci_tools/io/parsers/fleur_schema/inpschema_todict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur_schema/inpschema_todict.py
+++ b/masci_tools/io/parsers/fleur_schema/inpschema_todict.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 from .fleur_schema_parser_functions import *  #pylint: disable=unused-wildcard-import
 from masci_tools.util.xml.common_functions import clear_xml
-from masci_tools.util.xml.converters import convert_str_version_number
 from masci_tools.util.case_insensitive_dict import CaseInsensitiveDict, CaseInsensitiveFrozenSet
 from masci_tools.util.lockable_containers import LockableDict, LockableList
 from typing import AnyStr, Callable

--- a/masci_tools/io/parsers/fleur_schema/inpschema_todict.py
+++ b/masci_tools/io/parsers/fleur_schema/inpschema_todict.py
@@ -13,12 +13,14 @@
 This module provides the functionality to create/load the schema_dict for the
 FleurInputSchema.xsd
 """
+from __future__ import annotations
+
 from .fleur_schema_parser_functions import *  #pylint: disable=unused-wildcard-import
 from masci_tools.util.xml.common_functions import clear_xml
 from masci_tools.util.xml.converters import convert_str_version_number
 from masci_tools.util.case_insensitive_dict import CaseInsensitiveDict, CaseInsensitiveFrozenSet
 from masci_tools.util.lockable_containers import LockableDict, LockableList
-from typing import Tuple, List, AnyStr, Union, Callable, Dict, Set
+from typing import AnyStr, Callable
 try:
     from typing import TypedDict, Literal
 except ImportError:
@@ -32,16 +34,16 @@ class InputSchemaData(TypedDict, total=False):
     """
     root_tag: str
     inp_version: str
-    tag_paths: CaseInsensitiveDict[str, Union[List[str], str]]
-    attrib_types: CaseInsensitiveDict[str, List[AttributeType]]
-    text_types: CaseInsensitiveDict[str, List[AttributeType]]
+    tag_paths: CaseInsensitiveDict[str, list[str] | str]
+    attrib_types: CaseInsensitiveDict[str, list[AttributeType]]
+    text_types: CaseInsensitiveDict[str, list[AttributeType]]
     text_tags: CaseInsensitiveFrozenSet[str]
     unique_attribs: CaseInsensitiveDict[str, str]
-    unique_path_attribs: CaseInsensitiveDict[str, List[str]]
-    other_attribs: CaseInsensitiveDict[str, List[str]]
+    unique_path_attribs: CaseInsensitiveDict[str, list[str]]
+    other_attribs: CaseInsensitiveDict[str, list[str]]
     omitt_contained_tags: LockableList[str]
     tag_info: LockableDict[str, TagInfo]
-    _basic_types: LockableDict[str, List[AttributeType]]
+    _basic_types: LockableDict[str, list[AttributeType]]
 
 
 KEYS = Literal['root_tag', 'tag_paths', '_basic_types', 'attrib_types', 'text_types', 'text_tags', 'unique_attribs',
@@ -60,7 +62,7 @@ def create_inpschema_dict(path: AnyStr, apply_patches: bool = True) -> InputSche
     """
 
     #Add new functionality to this dictionary here
-    schema_actions: Dict[KEYS, Callable] = {
+    schema_actions: dict[KEYS, Callable] = {
         'root_tag': get_root_tag,
         'tag_paths': get_tag_paths,
         '_basic_types': get_basic_types,
@@ -98,7 +100,7 @@ def create_inpschema_dict(path: AnyStr, apply_patches: bool = True) -> InputSche
     return schema_dict
 
 
-def convert_string_to_float_expr(schema_dict: InputSchemaData, inp_version: Tuple[int, int]) -> None:
+def convert_string_to_float_expr(schema_dict: InputSchemaData, inp_version: tuple[int, int]) -> None:
     """
     Converts specified string attributes to float_expression for schema_dicts of versions
     0.32 and before.
@@ -140,8 +142,8 @@ def convert_string_to_float_expr(schema_dict: InputSchemaData, inp_version: Tupl
         #After this version the issue was solved
         return
 
-    replace_set: Set[str] = set()
-    add_set: Set[str] = set()
+    replace_set: set[str] = set()
+    add_set: set[str] = set()
 
     for version, changes in sorted(CHANGE_TYPES.items(), key=lambda x: x[0]):
 
@@ -174,7 +176,7 @@ def convert_string_to_float_expr(schema_dict: InputSchemaData, inp_version: Tupl
         schema_dict[TYPES_ENTRY][name].insert(0, EXPR_NAME)
 
 
-def patch_forcetheorem_attributes(schema_dict: InputSchemaData, inp_version: Tuple[int, int]) -> None:
+def patch_forcetheorem_attributes(schema_dict: InputSchemaData, inp_version: tuple[int, int]) -> None:
     """
     Special patch for theta, phi and ef_shift attributes on forceTheorem tags
     In Max5/5.1 They are entered as FleurDouble but can be a list.
@@ -193,8 +195,8 @@ def patch_forcetheorem_attributes(schema_dict: InputSchemaData, inp_version: Tup
                                                   [AttributeType(base_type='float_expression', length='unbounded')], key=type_order)
 
 
-def patch_basic_types(basic_types: LockableDict[str, List[AttributeType]],
-                      inp_version: Tuple[int, int]) -> LockableDict[str, List[AttributeType]]:
+def patch_basic_types(basic_types: LockableDict[str, list[AttributeType]],
+                      inp_version: tuple[int, int]) -> LockableDict[str, list[AttributeType]]:
     """
     Patch the _basic_types entry to correct ambigouities
 
@@ -221,7 +223,7 @@ def patch_basic_types(basic_types: LockableDict[str, List[AttributeType]],
         },
     }
 
-    all_changes: Dict[str, List[AttributeType]] = {}
+    all_changes: dict[str, list[AttributeType]] = {}
 
     for version, changes in sorted(CHANGE_TYPES.items(), key=lambda x: x[0]):
 
@@ -229,7 +231,7 @@ def patch_basic_types(basic_types: LockableDict[str, List[AttributeType]],
             continue
 
         version_add = changes.get('add', {})
-        version_remove: Set[str] = changes.get('remove', set())  #type: ignore
+        version_remove: set[str] = changes.get('remove', set())  #type: ignore
 
         all_changes = {key: val for key, val in {**all_changes, **version_add}.items() if key not in version_remove}
 
@@ -241,7 +243,7 @@ def patch_basic_types(basic_types: LockableDict[str, List[AttributeType]],
     return basic_types
 
 
-def patch_text_types(schema_dict: InputSchemaData, inp_version: Tuple[int, int]) -> None:
+def patch_text_types(schema_dict: InputSchemaData, inp_version: tuple[int, int]) -> None:
     """
     Patch the simple_elememnts entry to correct ambigouities
 
@@ -293,7 +295,7 @@ def patch_text_types(schema_dict: InputSchemaData, inp_version: Tuple[int, int])
         }
     }
 
-    all_changes: Dict[str, List[AttributeType]] = {}
+    all_changes: dict[str, list[AttributeType]] = {}
 
     for version, changes in sorted(CHANGE_TYPES.items(), key=lambda x: x[0]):
 

--- a/masci_tools/io/parsers/fleur_schema/outschema_todict.py
+++ b/masci_tools/io/parsers/fleur_schema/outschema_todict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/fleur_schema/outschema_todict.py
+++ b/masci_tools/io/parsers/fleur_schema/outschema_todict.py
@@ -22,13 +22,12 @@ from masci_tools.util.lockable_containers import LockableDict, LockableList
 from lxml import etree
 import copy
 from collections import UserList
-from typing import AnyStr, TYPE_CHECKING, Callable
+from typing import AnyStr, Callable
 try:
     from typing import TypedDict, Literal
 except ImportError:
     from typing_extensions import TypedDict, Literal  #type:ignore
-if TYPE_CHECKING:
-    from .inpschema_todict import InputSchemaData
+from . import inpschema_todict
 
 
 class OutputSchemaData(TypedDict, total=False):
@@ -64,7 +63,7 @@ KEYS = Literal['root_tag', 'input_tag', 'iteration_tags', 'tag_paths', 'iteratio
                'omitt_contained_tags', 'tag_info', 'iteration_tag_info']
 
 
-def create_outschema_dict(path: AnyStr, inpschema_dict: InputSchemaData) -> OutputSchemaData:
+def create_outschema_dict(path: AnyStr, inpschema_dict: inpschema_todict.InputSchemaData) -> OutputSchemaData:
     """
     Creates dictionary with information about the FleurOutputSchema.xsd.
     The functions, whose results are added to the schema_dict and the corresponding keys
@@ -124,7 +123,8 @@ def create_outschema_dict(path: AnyStr, inpschema_dict: InputSchemaData) -> Outp
     return schema_dict
 
 
-def merge_schema_dicts(inputschema_dict: InputSchemaData, outputschema_dict: OutputSchemaData) -> OutputSchemaData:
+def merge_schema_dicts(inputschema_dict: inpschema_todict.InputSchemaData,
+                       outputschema_dict: OutputSchemaData) -> OutputSchemaData:
     """
     Merge the information from the input schema into the outputschema
     This combines the type information and adjusts the paths from the inputschema

--- a/masci_tools/io/parsers/fleur_schema/outschema_todict.py
+++ b/masci_tools/io/parsers/fleur_schema/outschema_todict.py
@@ -13,6 +13,8 @@
 This module provides the functionality to create/load the schema_dict for the
 FleurInputSchema.xsd
 """
+from __future__ import annotations
+
 from .fleur_schema_parser_functions import *  #pylint: disable=unused-wildcard-import
 from masci_tools.util.xml.common_functions import clear_xml
 from masci_tools.util.case_insensitive_dict import CaseInsensitiveDict, CaseInsensitiveFrozenSet
@@ -20,7 +22,7 @@ from masci_tools.util.lockable_containers import LockableDict, LockableList
 from lxml import etree
 import copy
 from collections import UserList
-from typing import AnyStr, List, TYPE_CHECKING, Union, Dict, Set, Callable
+from typing import AnyStr, TYPE_CHECKING, Callable
 try:
     from typing import TypedDict, Literal
 except ImportError:
@@ -38,22 +40,22 @@ class OutputSchemaData(TypedDict, total=False):
     iteration_tags: CaseInsensitiveFrozenSet[str]
     inp_version: str
     out_version: str
-    tag_paths: CaseInsensitiveDict[str, Union[List[str], str]]
-    iteration_tag_paths: CaseInsensitiveDict[str, Union[List[str], str]]
-    attrib_types: CaseInsensitiveDict[str, List[AttributeType]]
-    text_types: CaseInsensitiveDict[str, List[AttributeType]]
+    tag_paths: CaseInsensitiveDict[str, list[str] | str]
+    iteration_tag_paths: CaseInsensitiveDict[str, list[str] | str]
+    attrib_types: CaseInsensitiveDict[str, list[AttributeType]]
+    text_types: CaseInsensitiveDict[str, list[AttributeType]]
     text_tags: CaseInsensitiveFrozenSet[str]
     unique_attribs: CaseInsensitiveDict[str, str]
-    unique_path_attribs: CaseInsensitiveDict[str, List[str]]
-    other_attribs: CaseInsensitiveDict[str, List[str]]
+    unique_path_attribs: CaseInsensitiveDict[str, list[str]]
+    other_attribs: CaseInsensitiveDict[str, list[str]]
     iteration_unique_attribs: CaseInsensitiveDict[str, str]
-    iteration_unique_path_attribs: CaseInsensitiveDict[str, List[str]]
-    iteration_other_attribs: CaseInsensitiveDict[str, List[str]]
+    iteration_unique_path_attribs: CaseInsensitiveDict[str, list[str]]
+    iteration_other_attribs: CaseInsensitiveDict[str, list[str]]
     omitt_contained_tags: LockableList[str]
     tag_info: LockableDict[str, TagInfo]
     iteration_tag_info: LockableDict[str, TagInfo]
-    _basic_types: LockableDict[str, List[AttributeType]]
-    _input_basic_types: LockableDict[str, List[AttributeType]]
+    _basic_types: LockableDict[str, list[AttributeType]]
+    _input_basic_types: LockableDict[str, list[AttributeType]]
 
 
 KEYS = Literal['root_tag', 'input_tag', 'iteration_tags', 'tag_paths', 'iteration_tag_paths', '_basic_types',
@@ -62,7 +64,7 @@ KEYS = Literal['root_tag', 'input_tag', 'iteration_tags', 'tag_paths', 'iteratio
                'omitt_contained_tags', 'tag_info', 'iteration_tag_info']
 
 
-def create_outschema_dict(path: AnyStr, inpschema_dict: 'InputSchemaData') -> OutputSchemaData:
+def create_outschema_dict(path: AnyStr, inpschema_dict: InputSchemaData) -> OutputSchemaData:
     """
     Creates dictionary with information about the FleurOutputSchema.xsd.
     The functions, whose results are added to the schema_dict and the corresponding keys
@@ -73,7 +75,7 @@ def create_outschema_dict(path: AnyStr, inpschema_dict: 'InputSchemaData') -> Ou
     """
 
     #Add new functionality to this dictionary here
-    schema_actions: Dict[KEYS, Callable] = {
+    schema_actions: dict[KEYS, Callable] = {
         'input_tag': get_input_tag,
         'root_tag': get_root_tag,
         'iteration_tags': get_iteration_tags,
@@ -106,7 +108,7 @@ def create_outschema_dict(path: AnyStr, inpschema_dict: 'InputSchemaData') -> Ou
     schema_dict: OutputSchemaData = {}
     schema_dict['out_version'] = out_version
     for key, action in schema_actions.items():
-        addargs: Dict[str, Union[Dict[str, List[AttributeType]], bool]] = {'input_basic_types': input_basic_types}
+        addargs: dict[str, dict[str, list[AttributeType]] | bool] = {'input_basic_types': input_basic_types}
         if key in ['unique_attribs', 'unique_path_attribs', 'other_attribs', 'tag_paths', 'tag_info']:
             addargs['stop_iteration'] = True
         elif key in [
@@ -122,7 +124,7 @@ def create_outschema_dict(path: AnyStr, inpschema_dict: 'InputSchemaData') -> Ou
     return schema_dict
 
 
-def merge_schema_dicts(inputschema_dict: 'InputSchemaData', outputschema_dict: OutputSchemaData) -> OutputSchemaData:
+def merge_schema_dicts(inputschema_dict: InputSchemaData, outputschema_dict: OutputSchemaData) -> OutputSchemaData:
     """
     Merge the information from the input schema into the outputschema
     This combines the type information and adjusts the paths from the inputschema
@@ -146,13 +148,13 @@ def merge_schema_dicts(inputschema_dict: 'InputSchemaData', outputschema_dict: O
     #
     # 1. Merge path entries and modify the input paths
     #
-    path_entries: Set[Literal['tag_paths', 'unique_attribs', 'unique_path_attribs', 'other_attribs']] = {
+    path_entries: set[Literal['tag_paths', 'unique_attribs', 'unique_path_attribs', 'other_attribs']] = {
         'tag_paths', 'unique_attribs', 'unique_path_attribs', 'other_attribs'
     }
     for entry in path_entries:
         for key, val in inputschema_dict[entry].items():
 
-            paths: Union[List[str], str] = merged_outschema_dict[entry].get(key, UserList())
+            paths: list[str] | str = merged_outschema_dict[entry].get(key, UserList())
 
             if not isinstance(paths, (UserList, list)):
                 paths = [paths]

--- a/masci_tools/io/parsers/fleur_schema/schema_dict.py
+++ b/masci_tools/io/parsers/fleur_schema/schema_dict.py
@@ -46,14 +46,12 @@ class NoPathFound(ValueError):
     """
     Exception raised when no path is found for a given tag/attribute
     """
-    pass
 
 
 class NoUniquePathFound(ValueError):
     """
     Exception raised when no unique path is found for a given tag/attribute
     """
-    pass
 
 
 F = TypeVar('F', bound=Callable[..., Any])

--- a/masci_tools/io/parsers/fleur_schema/schema_dict.py
+++ b/masci_tools/io/parsers/fleur_schema/schema_dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #
@@ -252,14 +251,14 @@ class SchemaDict(LockableDict):
         if contains is None:
             contains = set()
         elif isinstance(contains, str):
-            contains = set([contains])
+            contains = {contains}
         else:
             contains = set(contains)
 
         if not_contains is None:
             not_contains = set()
         elif isinstance(not_contains, str):
-            not_contains = set([not_contains])
+            not_contains = {not_contains}
         else:
             not_contains = set(not_contains)
 

--- a/masci_tools/io/parsers/fleur_schema/schema_dict.py
+++ b/masci_tools/io/parsers/fleur_schema/schema_dict.py
@@ -23,7 +23,7 @@ from functools import update_wrapper, wraps
 from pathlib import Path
 from typing import Callable, Iterable, TypeVar, Any, cast
 
-from .fleur_schema_parser_functions import TagInfo
+from .fleur_schema_parser_functions import TagInfo, convert_str_version_number
 try:
     from typing import Literal, Protocol
 except ImportError:
@@ -36,7 +36,6 @@ from lxml import etree
 from masci_tools.util.lockable_containers import LockableDict, LockableList
 from masci_tools.util.case_insensitive_dict import CaseInsensitiveFrozenSet, CaseInsensitiveDict
 from masci_tools.util.xml.common_functions import abs_to_rel_xpath, split_off_tag
-from masci_tools.util.xml.converters import convert_str_version_number
 from .inpschema_todict import create_inpschema_dict, InputSchemaData
 from .outschema_todict import create_outschema_dict, merge_schema_dicts
 

--- a/masci_tools/io/parsers/fleur_schema/schema_dict.py
+++ b/masci_tools/io/parsers/fleur_schema/schema_dict.py
@@ -64,7 +64,7 @@ class SchemaDictDispatch(Protocol[F]):
     """Protocol representing function decorated by the schema_dict_version_dispatch decorator"""
     registry: dict[Callable[[tuple[int, int]], bool] | Literal['default'], F]
 
-    def register(self, min_version: str = None, max_version: str = None) -> Callable[[F], F]:
+    def register(self, min_version: str | None = ..., max_version: str | None = ...) -> Callable[[F], F]:
         ...
 
     dispatch: Callable[[tuple[int, int]], F]
@@ -109,7 +109,7 @@ def schema_dict_version_dispatch(output_schema: bool = False) -> Callable[[F], S
 
             return matches[0]
 
-        def register(min_version: str = None, max_version: str = None) -> Callable[[F], F]:
+        def register(min_version: str | None = None, max_version: str | None = None) -> Callable[[F], F]:
 
             if min_version is not None:
                 min_version_tuple = convert_str_version_number(min_version)
@@ -231,7 +231,7 @@ class SchemaDict(LockableDict):
         """
         cls._schema_dict_cache.clear()
 
-    def __init__(self, *args: Any, xmlschema: etree.XMLSchema = None, **kwargs: Any):
+    def __init__(self, *args: Any, xmlschema: etree.XMLSchema | None = None, **kwargs: Any):
         if xmlschema is None:
             raise ValueError('xmlschema has to be supplied')
         self.xmlschema = xmlschema
@@ -625,7 +625,7 @@ class InputSchemaDict(SchemaDict):
     _info_entries = ('tag_info',)
 
     @classmethod
-    def fromVersion(cls, version: str, logger: Logger = None, no_cache: bool = False) -> InputSchemaDict:
+    def fromVersion(cls, version: str, logger: Logger | None = None, no_cache: bool = False) -> InputSchemaDict:
         """
         load the FleurInputSchema dict for the specified version
 
@@ -746,8 +746,8 @@ class OutputSchemaDict(SchemaDict):
     @classmethod
     def fromVersion(cls,
                     version: str,
-                    inp_version: str = None,
-                    logger: Logger = None,
+                    inp_version: str | None = None,
+                    logger: Logger | None = None,
                     no_cache: bool = False) -> OutputSchemaDict:
         """
         load the FleurOutputSchema dict for the specified version
@@ -814,8 +814,8 @@ class OutputSchemaDict(SchemaDict):
     @classmethod
     def fromPath(cls,
                  path: os.PathLike,
-                 inp_path: os.PathLike = None,
-                 inpschema_dict: InputSchemaDict = None) -> OutputSchemaDict:
+                 inp_path: os.PathLike | None = None,
+                 inpschema_dict: InputSchemaDict | None = None) -> OutputSchemaDict:
         """
         load the FleurOutputSchema dict for the specified paths
 

--- a/masci_tools/io/parsers/hdf5/__init__.py
+++ b/masci_tools/io/parsers/hdf5/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Here the functions from input_transforms are imported to trigger their decorators
 This is needed to make the HDF5Reader aware of their existence

--- a/masci_tools/io/parsers/hdf5/reader.py
+++ b/masci_tools/io/parsers/hdf5/reader.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/hdf5/reader.py
+++ b/masci_tools/io/parsers/hdf5/reader.py
@@ -153,8 +153,8 @@ class HDF5Reader:
     def _transform_dataset(self,
                            transforms: list[Transformation] | list[Transformation | AttribTransformation],
                            dataset: h5py.Dataset,
-                           attributes: dict[str, Any] = None,
-                           dataset_name: str = None) -> Any:
+                           attributes: dict[str, Any] | None = None,
+                           dataset_name: str | None = None) -> Any:
         """
         Transforms the given dataset with the given list of tasks
 
@@ -214,7 +214,7 @@ class HDF5Reader:
 
         return {**output_dict, **unpack_dict}
 
-    def read(self, recipe: HDF5Recipe = None) -> tuple[dict[str, Any], dict[str, Any]]:
+    def read(self, recipe: HDF5Recipe | None = None) -> tuple[dict[str, Any], dict[str, Any]]:
         """Extracts datasets from HDF5 file, transforms them and puts all into a namedtuple.
 
         :param recipe: dict with the format given in :py:mod:`~masci_tools.io.parsers.hdf5.recipes`

--- a/masci_tools/io/parsers/hdf5/reader.py
+++ b/masci_tools/io/parsers/hdf5/reader.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import io
 import os
+from types import TracebackType
 import h5py
 import warnings
 import logging
@@ -121,7 +122,8 @@ class HDF5Reader:
         logger.debug('Opened h5py.File with id %s', self.file.id)
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+    def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None,
+                 exc_traceback: TracebackType | None) -> None:
         self.file.close()
         logger.debug('Closed h5py.File with id %s', self.file.id)
 

--- a/masci_tools/io/parsers/hdf5/reader.py
+++ b/masci_tools/io/parsers/hdf5/reader.py
@@ -20,11 +20,12 @@ import h5py
 import warnings
 import logging
 from pathlib import Path
-from typing import IO, Callable, NamedTuple, Any, cast
+from typing import Callable, NamedTuple, Any, cast
+from masci_tools.util.typing import FileLike
 try:
-    from typing import TypedDict, Required  #type: ignore
+    from typing import TypedDict
 except ImportError:
-    from typing_extensions import TypedDict, Required
+    from typing_extensions import TypedDict
 
 
 class Transformation(NamedTuple):
@@ -41,14 +42,14 @@ class AttribTransformation(NamedTuple):
 
 
 class HDF5Transformation(TypedDict, total=False):
-    h5path: Required[str]
+    h5path: str  #This should strictly be marked as required when it's possible
     transforms: list[Transformation | AttribTransformation]
     unpack_dict: bool
     description: str
 
 
 class HDF5LimitedTransformation(TypedDict, total=False):
-    h5path: Required[str]
+    h5path: str  #This should strictly be marked as required when it's possible
     transforms: list[Transformation]
     unpack_dict: bool
     description: str
@@ -95,13 +96,13 @@ class HDF5Reader:
     _transforms: dict[str, Callable] = {}
     _attribute_transforms: set[str] = set()
 
-    def __init__(self, file: str | bytes | Path | os.PathLike | IO, move_to_memory: bool = True) -> None:
+    def __init__(self, file: FileLike, move_to_memory: bool = True) -> None:
 
         self._original_file = file
         self.file: h5py.File = None
 
         if isinstance(self._original_file, (io.IOBase, Path)):
-            self.filename = self._original_file.name
+            self.filename = self._original_file.name  # type: ignore
         elif isinstance(self._original_file, bytes):
             self.filename = os.fsdecode(self._original_file)
         else:

--- a/masci_tools/io/parsers/hdf5/recipes.py
+++ b/masci_tools/io/parsers/hdf5/recipes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/hdf5/recipes.py
+++ b/masci_tools/io/parsers/hdf5/recipes.py
@@ -58,7 +58,8 @@ Entries in the `attributes` section are read and transformed first and can subse
 for the `datasets`. These correpsond to the transforms created with the :py:class:`~masci_tools.io.parsers.hdf5.reader.AttribTransformation`
 namedtuple instead of :py:class:`~masci_tools.io.parsers.hdf5.reader.Transformation`.
 """
-from typing import Union, List
+from __future__ import annotations
+
 try:
     from typing import Literal
 except ImportError:
@@ -322,7 +323,7 @@ def bands_recipe_format(group: Literal['Local', 'jDOS', 'Orbcomp', 'MCD'], simpl
     return recipe
 
 
-def get_fleur_bands_specific_weights(weight_name: Union[str, List[str]],
+def get_fleur_bands_specific_weights(weight_name: str | list[str],
                                      group: Literal['Local', 'jDOS', 'Orbcomp', 'MCD'] = 'Local') -> HDF5Recipe:
     """
     Recipe for bandstructure calculations only retrieving one

--- a/masci_tools/io/parsers/hdf5/transforms.py
+++ b/masci_tools/io/parsers/hdf5/transforms.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #
@@ -214,7 +213,7 @@ def get_all_child_datasets(group, ignore=None, contains=None):
         ignore = set()
 
     if isinstance(ignore, str):
-        ignore = set([ignore])
+        ignore = {ignore}
 
     transformed = {}
     for key, val in group.items():
@@ -255,7 +254,7 @@ def merge_subgroup_datasets(group,
         ignore_group = set()
 
     if isinstance(ignore_group, str):
-        ignore_group = set([ignore_group])
+        ignore_group = {ignore_group}
 
     transformed = defaultdict(list)
 

--- a/masci_tools/io/parsers/hdf5/transforms.py
+++ b/masci_tools/io/parsers/hdf5/transforms.py
@@ -21,6 +21,8 @@ for the following 3 cases:
        are known. Two options can be chosen apply the transformation to all keys in the dict
        or throw an error
 """
+from __future__ import annotations
+
 from typing import Callable
 import h5py
 import numpy as np

--- a/masci_tools/io/parsers/kkrimp_parser_functions.py
+++ b/masci_tools/io/parsers/kkrimp_parser_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/kkrparser_functions.py
+++ b/masci_tools/io/parsers/kkrparser_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/io/parsers/tabulator/__init__.py
+++ b/masci_tools/io/parsers/tabulator/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=unused-import
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #

--- a/masci_tools/io/parsers/tabulator/recipes.py
+++ b/masci_tools/io/parsers/tabulator/recipes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=unused-import
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=unused-import
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #

--- a/masci_tools/io/parsers/tabulator/transformers.py
+++ b/masci_tools/io/parsers/tabulator/transformers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=unused-import
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #

--- a/masci_tools/io/parsers/voroparser_functions.py
+++ b/masci_tools/io/parsers/voroparser_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/testing/bokeh.py
+++ b/masci_tools/testing/bokeh.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Fixtures for testing bokeh plots.
 

--- a/masci_tools/tools/cf_calculation.py
+++ b/masci_tools/tools/cf_calculation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/tools/cf_calculation.py
+++ b/masci_tools/tools/cf_calculation.py
@@ -47,16 +47,15 @@ class CFCalculation:
         The function constructs an equidistant mesh between 0 and the muffin tin radius
         defined in `self.reference_radius` and with `self.radial_points` points
 
-    Parameters:
-        :param radial_points: int, number of radial points in the interpolated mesh
-        :param reference_radius: stror float; Either 'pot' or 'cdn' or explicit number. Defines which muffin-tin radius
-                                 is used for the equidistant mesh.
-                                 IMPORTANT! If txt files are used the muffin-tin radius has to be provided explicitly
-        :param pot_cutoff: float Defines minimum value that has to appear in potentials to not be omitted (Only HDF)
-        :param only_m0: bool, Ignores coefficients with m!=0 if True
-        :param quiet: bool, supresses print statements if True
+    :param radial_points: int, number of radial points in the interpolated mesh
+    :param reference_radius: stror float; Either 'pot' or 'cdn' or explicit number. Defines which muffin-tin radius
+                                is used for the equidistant mesh.
+                                IMPORTANT! If txt files are used the muffin-tin radius has to be provided explicitly
+    :param pot_cutoff: float Defines minimum value that has to appear in potentials to not be omitted (Only HDF)
+    :param only_m0: bool, Ignores coefficients with m!=0 if True
+    :param quiet: bool, supresses print statements if True
 
-   """
+    """
 
     __version__ = '0.1.0'
 
@@ -111,16 +110,13 @@ class CFCalculation:
         """Reads in the potentials for the CF coefficient calculation
         If hdf files are given also the muffin tin radius is read in
 
-        Parameters:
-            :param args: Expects string filenames for the potentials to read in
-                         The function expects either HDF files or txt files with the
-                         format (rmesh,vlmup,vlmdn)
-            :param lm: list of tuples, Defines the l and m indices for the given txt files
-
-        kwargs:
-            :param atomType: int, Defines the atomType to read in (only for HDF files)
-            :param header: int, Define how many lines to skip in the beginning of txt file
-            :param complexData: bool, Define if the data in the text file is complex
+        :param args: Expects string filenames for the potentials to read in
+                     The function expects either HDF files or txt files with the
+                     format (rmesh,vlmup,vlmdn)
+        :param lm: list of tuples, Defines the l and m indices for the given txt files
+        :param atomType: int, Defines the atomType to read in (only for HDF files)
+        :param header: int, Define how many lines to skip in the beginning of txt file
+        :param complexData: bool, Define if the data in the text file is complex
 
         Raises:
             ValueError: lm indices list length has to match number of files read in
@@ -457,20 +453,20 @@ def plot_crystal_field_calculation(cfcalc,
                                    pot_colors=None,
                                    save=False,
                                    show=True):
-    """Plot the given potentials and charge densities
+    """
+    Plot the given potentials and charge densities
 
-        Parameters:
-            :param cfcalc: CFcalculation containing the data to plot
-            :param filename: str, Define the filename to save the figure
-            :param pot_title: Title for the potential subplot
-            :param cdn_title: Title for the charge density subplot
-            :param xlabel: label for the x axis of both subplots
-            :param pot_ylabel: label for the y axis of the potential subplot
-            :param cdn_ylabel: label for the y axis f the charge density subplot
-            :param fontsize: fontsize for titles and labels on the axis
-            :param labelsize: fontsize for the ticks on the axis,
+    :param cfcalc: CFcalculation containing the data to plot
+    :param filename: str, Define the filename to save the figure
+    :param pot_title: Title for the potential subplot
+    :param cdn_title: Title for the charge density subplot
+    :param xlabel: label for the x axis of both subplots
+    :param pot_ylabel: label for the y axis of the potential subplot
+    :param cdn_ylabel: label for the y axis f the charge density subplot
+    :param fontsize: fontsize for titles and labels on the axis
+    :param labelsize: fontsize for the ticks on the axis,
 
-        """
+    """
 
     cfcalc._validateInput()
 
@@ -527,19 +523,19 @@ def plot_crystal_field_potential(cfcoeffs,
                                  phi=0.0,
                                  save=False,
                                  show=True):
-    """Plots the angular dependence of the calculated CF potential as well
-        as a plane defined by phi.
+    """
+    Plots the angular dependence of the calculated CF potential as well
+    as a plane defined by phi.
 
-        Parameters:
-            :param cfcoeffs: list of CFCoefficients to construct the potential
-            :param filename: str, defines the filename to save the figure
-            :param spin: str; Either 'up', 'dn' or 'avg'. Which spin direction to plot
-                         ('avg'-> ('up'+'dn')/2.0)
-            :param phi: float, defines the phi angle of the plane
+    :param cfcoeffs: list of CFCoefficients to construct the potential
+    :param filename: str, defines the filename to save the figure
+    :param spin: str; Either 'up', 'dn' or 'avg'. Which spin direction to plot
+                    ('avg'-> ('up'+'dn')/2.0)
+    :param phi: float, defines the phi angle of the plane
 
-        :raises AssertionError: When coefficients are provided as wrong types or in the wrong convention
+    :raises AssertionError: When coefficients are provided as wrong types or in the wrong convention
 
-        """
+    """
 
     assert all(isinstance(coeff, CFCoefficient) for coeff in cfcoeffs), \
            'Only provide a list of CFCoefficients to plot_crystal_field_potential'

--- a/masci_tools/tools/cf_calculation.py
+++ b/masci_tools/tools/cf_calculation.py
@@ -133,7 +133,7 @@ class CFCalculation:
         #Reads in the filenames given in args as potentials
         for index, file in enumerate(args):
             if isinstance(file, (str, Path)):
-                basename, extension = os.path.splitext(file)
+                _, extension = os.path.splitext(file)
                 if extension == '.hdf':
                     with h5py.File(file, 'r') as hdffile:
                         self.__readpotHDF(hdffile, atomType=atomType)
@@ -163,7 +163,7 @@ class CFCalculation:
         header = kwargs.get('header', 0)
 
         if isinstance(file, (str, Path)):
-            basename, extension = os.path.splitext(file)
+            _, extension = os.path.splitext(file)
             if extension == '.hdf':
                 with h5py.File(file, 'r') as hdffile:
                     self.__readcdnHDF(hdffile, atomType=atomType)

--- a/masci_tools/tools/fleur_inpxml_converter.py
+++ b/masci_tools/tools/fleur_inpxml_converter.py
@@ -2,8 +2,10 @@
 This module implements a commandline tool available with ``masci-tools inpxml`` to
 convert inp.xml files between different file versions
 """
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import Iterable, List, NamedTuple, Tuple, Union
+from typing import Iterable, NamedTuple
 import json
 from pathlib import Path
 import os
@@ -37,7 +39,7 @@ class MoveAction(NamedTuple):
     attrib: bool = False
 
     @classmethod
-    def from_path(cls, old: str, new: str) -> 'MoveAction':
+    def from_path(cls, old: str, new: str) -> MoveAction:
         """
         Construct a MoveAction from two given xpaths
 
@@ -57,7 +59,7 @@ class MoveAction(NamedTuple):
         return cls(old_name=old_name, new_name=new_name, old_path=old_path, new_path=new_path, attrib=attrib)
 
     @classmethod
-    def from_remove_and_create(cls, remove: 'RemoveAction', create: 'CreateAction') -> 'MoveAction':
+    def from_remove_and_create(cls, remove: RemoveAction, create: CreateAction) -> MoveAction:
         """
         Construct a MoveAction from a remove and create action, merging them together
 
@@ -91,7 +93,7 @@ class NormalizedMoveAction(NamedTuple):
     attrib: bool = False
 
     @classmethod
-    def from_move(cls, move_action: MoveAction, actual_path: str) -> 'NormalizedMoveAction':
+    def from_move(cls, move_action: MoveAction, actual_path: str) -> NormalizedMoveAction:
         """
         Construct a NormalizedMoveAction from a given move and the additional actual xpath to use
 
@@ -107,12 +109,12 @@ class AmbiguousAction(NamedTuple):
     NamedTuple representing a change in paths that cannot be resolved automatically
     """
     name: str
-    old_paths: Tuple[str]
-    new_paths: Tuple[str]
+    old_paths: tuple[str]
+    new_paths: tuple[str]
     attrib: bool
 
     @classmethod
-    def from_paths(cls, old: Iterable[str], new: Iterable[str]) -> 'AmbiguousAction':
+    def from_paths(cls, old: Iterable[str], new: Iterable[str]) -> AmbiguousAction:
         """
         Construct AmbiguousAction from given paths
 
@@ -139,7 +141,7 @@ class RemoveAction(NamedTuple):
     attrib: bool = False
 
     @classmethod
-    def from_path(cls, xpath: str) -> 'RemoveAction':
+    def from_path(cls, xpath: str) -> RemoveAction:
         """
         Construct a RemoveAction from a given xpath
 
@@ -166,7 +168,7 @@ class CreateAction(NamedTuple):
     element: str = None
 
     @classmethod
-    def from_path(cls, xpath: str, element: str = None) -> 'RemoveAction':
+    def from_path(cls, xpath: str, element: str = None) -> RemoveAction:
         """
         Construct a CreateAction from a given xpath
 
@@ -184,8 +186,8 @@ class CreateAction(NamedTuple):
 
 
 def analyse_paths(
-    schema_start: 'InputSchemaDict', schema_target: 'InputSchemaDict', path_entries: Union[str, List[str]]
-) -> Tuple[List[RemoveAction], List[CreateAction], List[MoveAction], List[AmbiguousAction]]:
+    schema_start: InputSchemaDict, schema_target: InputSchemaDict, path_entries: str | list[str]
+) -> tuple[list[RemoveAction], list[CreateAction], list[MoveAction], list[AmbiguousAction]]:
     """
     Gather the initial path differences between the two given input schema dictionaries
     fro the given entries. If multiple enetries are given they are first merged together
@@ -505,7 +507,7 @@ def dump_conversion(conversion):
         json.dump(conversion, f, indent=2, sort_keys=False)
 
 
-def _rename_elements(remove: List[RemoveAction], create: List[CreateAction], move: List[MoveAction], from_version: str,
+def _rename_elements(remove: list[RemoveAction], create: list[CreateAction], move: list[MoveAction], from_version: str,
                      to_version: str, name: str) -> None:
     """
     Get user input on tags that were renamed
@@ -636,8 +638,8 @@ def _create_attrib_elements(create, to_schema):
     return create
 
 
-def _manual_resolution(ambiguous: List[AmbiguousAction], remove: List[RemoveAction], create: List[CreateAction],
-                       move: List[MoveAction], name: str):
+def _manual_resolution(ambiguous: list[AmbiguousAction], remove: list[RemoveAction], create: list[CreateAction],
+                       move: list[MoveAction], name: str):
     """
     Prompt the user for input on actions that cannot be determined automagically
     """

--- a/masci_tools/tools/fleur_inpxml_converter.py
+++ b/masci_tools/tools/fleur_inpxml_converter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module implements a commandline tool available with ``masci-tools inpxml`` to
 convert inp.xml files between different file versions
@@ -461,7 +460,7 @@ def load_conversion(from_version, to_version):
     """
     filepath = FILE_DIRECTORY / 'conversions' / f"conversion_{from_version.replace('.','')}_to_{to_version.replace('.','')}.json"
 
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, encoding='utf-8') as f:
         conversion = json.load(f)
 
     #convert back to the namedtuples

--- a/masci_tools/tools/fleur_inpxml_converter.py
+++ b/masci_tools/tools/fleur_inpxml_converter.py
@@ -332,10 +332,6 @@ def resolve_ambiguouities(ambiguous, remove, create, move, remove_move=False, ta
             ambiguous.append(AmbiguousAction.from_paths(old=old_paths, new=new_paths))
 
 
-def trim_path_actions(actions):
-    pass
-
-
 def trim_paths(paths):
 
     path_copy = paths.copy()
@@ -788,7 +784,6 @@ def inpxml():
     """
     Tool for converting inp.xml files to different versions
     """
-    pass
 
 
 @inpxml.command('convert')

--- a/masci_tools/tools/greensf_calculations.py
+++ b/masci_tools/tools/greensf_calculations.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module collects functions for calculating properties with the greens functions
 calculated by Fleur. At the moment the following are implemented:

--- a/masci_tools/tools/greensf_calculations.py
+++ b/masci_tools/tools/greensf_calculations.py
@@ -6,12 +6,13 @@ calculated by Fleur. At the moment the following are implemented:
    * Calculating Heisenberg J_ij exchange constants from intersite Green's functions
    * Calculating the hybridization function from onsite Greens functions
 """
+from __future__ import annotations
+
 from .greensfunction import intersite_shells, intersite_shells_from_file
 
 import numpy as np
 from scipy import constants
 from collections import defaultdict
-from typing import Dict, List
 
 
 def calculate_heisenberg_jij(hdffileORgreensfunctions, reference_atom, onsite_delta, show=False):
@@ -34,7 +35,7 @@ def calculate_heisenberg_jij(hdffileORgreensfunctions, reference_atom, onsite_de
     else:
         shells = intersite_shells_from_file(hdffileORgreensfunctions, reference_atom, show=show)
 
-    jij_constants: Dict[float, List[float]] = defaultdict(list)
+    jij_constants: dict[float, list[float]] = defaultdict(list)
 
     for dist, g1, g2 in shells:
 

--- a/masci_tools/tools/greensf_visualization.py
+++ b/masci_tools/tools/greensf_visualization.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Modules with functions for visualizing things related to greensfunctions from fleur
 """

--- a/masci_tools/tools/greensfunction.py
+++ b/masci_tools/tools/greensfunction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/tools/greensfunction.py
+++ b/masci_tools/tools/greensfunction.py
@@ -13,11 +13,13 @@
 This module contains utility and functions to work with Green's functions calculated
 and written to ``greensf.hdf`` files by fleur
 """
+from __future__ import annotations
+
 from collections import namedtuple
 from itertools import groupby, chain
 import numpy as np
 import h5py
-from typing import List, Tuple, Iterator, Dict, Any
+from typing import Iterator, Any
 try:
     from typing import Literal
 except ImportError:
@@ -34,7 +36,7 @@ GreensfElement = namedtuple(
 CoefficientName = Literal['sphavg', 'uu', 'ud', 'du', 'dd', 'ulou', 'uulo', 'ulod', 'dulo', 'uloulo']
 
 
-def _get_sphavg_recipe(group_name: str, index: int, contour: int, version: int = None) -> Dict[str, Any]:
+def _get_sphavg_recipe(group_name: str, index: int, contour: int, version: int = None) -> dict[str, Any]:
     """
     Get the HDF5Reader recipe for reading in a spherically averaged Green's function element
 
@@ -193,7 +195,7 @@ def _get_sphavg_recipe(group_name: str, index: int, contour: int, version: int =
     return recipe
 
 
-def _get_radial_recipe(group_name: str, index: int, contour: int, nLO: int = 0, version: int = None) -> Dict[str, Any]:
+def _get_radial_recipe(group_name: str, index: int, contour: int, nLO: int = 0, version: int = None) -> dict[str, Any]:
     """
     Get the HDF5Reader recipe for reading in a radial Green's function element
 
@@ -394,7 +396,7 @@ def _get_version(hdffile: h5py.File):
     return version
 
 
-def _read_gf_element(file: Any, index: int) -> Tuple[GreensfElement, Dict[str, Any], Dict[str, Any]]:
+def _read_gf_element(file: Any, index: int) -> tuple[GreensfElement, dict[str, Any], dict[str, Any]]:
     """
     Read the information needed for a given Green's function element form a ``greensf.hdf``
     file
@@ -432,7 +434,7 @@ class GreensFunction:
     :param attributes: attributes dict produced by one of the hdf recipes for reading Green's functions
     """
 
-    def __init__(self, element: GreensfElement, data: Dict[str, Any], attributes: Dict[str, Any]) -> None:
+    def __init__(self, element: GreensfElement, data: dict[str, Any], attributes: dict[str, Any]) -> None:
         self.element = element
 
         self.points = data.pop('energy_points')
@@ -479,7 +481,7 @@ class GreensFunction:
         self.lmax = attributes['lmax']
 
     @classmethod
-    def fromFile(cls, file: Any, index: int = None, **selection_params: Any) -> 'GreensFunction':
+    def fromFile(cls, file: Any, index: int = None, **selection_params: Any) -> GreensFunction:
         """
         Classmethod for creating a :py:class:`GreensFunction` instance directly from a hdf file
 
@@ -605,7 +607,7 @@ class GreensFunction:
         return m + 3
 
     @staticmethod
-    def to_spin_indices(spin: int) -> Tuple[int, int]:
+    def to_spin_indices(spin: int) -> tuple[int, int]:
         """
         Convert between spin index (0 to 3) to the corresponding
         two spin indices (0 or 1)
@@ -729,7 +731,7 @@ class colors:
     green = '\033[32m'
 
 
-def printElements(elements: List[GreensfElement], index: List[int] = None, mark: List[int] = None) -> None:
+def printElements(elements: list[GreensfElement], index: list[int] = None, mark: list[int] = None) -> None:
     """
     Print the given list of :py:class:`GreensfElement` in a nice table
 
@@ -764,7 +766,7 @@ def printElements(elements: List[GreensfElement], index: List[int] = None, mark:
             + colors.endc)
 
 
-def listElements(hdffile: Any, show: bool = False) -> List[GreensfElement]:
+def listElements(hdffile: Any, show: bool = False) -> list[GreensfElement]:
     """
     Find the green's function elements contained in the given ``greens.hdf`` file
 
@@ -812,7 +814,7 @@ def select_elements_from_file(hdffile: Any, show: bool = False, **selection_para
     return gf_iterator(found_elements)
 
 
-def select_elements(greensfunctions: List[GreensFunction],
+def select_elements(greensfunctions: list[GreensFunction],
                     show: bool = False,
                     **selection_params) -> Iterator[GreensFunction]:
     """
@@ -836,7 +838,7 @@ def select_elements(greensfunctions: List[GreensFunction],
     return gf_iterator(found_elements)
 
 
-def select_element_indices(elements: List[GreensfElement], show: bool = False, **selection_params) -> List[int]:
+def select_element_indices(elements: list[GreensfElement], show: bool = False, **selection_params) -> list[int]:
     """
     Select :py:class:`GreensfElement` objects from a list based on constraints on their
     values
@@ -867,7 +869,7 @@ def select_element_indices(elements: List[GreensfElement], show: bool = False, *
 
 def intersite_shells_from_file(hdffile: Any,
                                reference_atom: int,
-                               show: bool = False) -> Iterator[Tuple[float, GreensFunction, GreensFunction]]:
+                               show: bool = False) -> Iterator[tuple[float, GreensFunction, GreensFunction]]:
     """
     Construct the green's function pairs to calculate the Jij exchange constants
     for a given reference atom from a given ``greensf.hdf`` file
@@ -894,9 +896,9 @@ def intersite_shells_from_file(hdffile: Any,
     return shell_iterator(jij_pairs)
 
 
-def intersite_shells(greensfunctions: List[GreensFunction],
+def intersite_shells(greensfunctions: list[GreensFunction],
                      reference_atom: int,
-                     show: bool = False) -> Iterator[Tuple[float, GreensFunction, GreensFunction]]:
+                     show: bool = False) -> Iterator[tuple[float, GreensFunction, GreensFunction]]:
     """
     Construct the green's function pairs to calculate the Jij exchange constants
     for a given reference atom from a list of given :py:class:`GreensFunction`
@@ -920,9 +922,9 @@ def intersite_shells(greensfunctions: List[GreensFunction],
     return shell_iterator(jij_pairs)
 
 
-def intersite_shell_indices(elements: List[GreensfElement],
+def intersite_shell_indices(elements: list[GreensfElement],
                             reference_atom: int,
-                            show: bool = False) -> List[Tuple[float, List[Tuple[int, int]]]]:
+                            show: bool = False) -> list[tuple[float, list[tuple[int, int]]]]:
     """
     Construct the green's function pairs to calculate the Jij exchange constants
     for a given reference atom from a list of :py:class:`GreensfElement`

--- a/masci_tools/util/case_insensitive_dict.py
+++ b/masci_tools/util/case_insensitive_dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/case_insensitive_dict.py
+++ b/masci_tools/util/case_insensitive_dict.py
@@ -48,9 +48,9 @@ class CaseInsensitiveDict(LockableDict[S, T]):
 
     """
 
-    def __init__(self, *args: Any, upper: bool = False, **kwargs: bool | object):
+    def __init__(self, *args: Any, upper: bool = False, recursive: bool = True, **kwargs: T):
         self._upper = upper
-        super().__init__(*args, **kwargs)  #type: ignore
+        super().__init__(*args, recursive=recursive, **kwargs)
 
     def _norm_key(self, key: object) -> object:
         if isinstance(key, str):
@@ -91,12 +91,12 @@ class CaseInsensitiveFrozenSet(FrozenSet[T]):
 
     """
 
-    def __new__(cls, iterable: Iterable[T] = None, upper: bool = False) -> CaseInsensitiveFrozenSet[T]:
+    def __new__(cls, iterable: Iterable[T] | None = None, upper: bool = False) -> CaseInsensitiveFrozenSet[T]:
         if iterable is not None:
             return super().__new__(cls, [key.lower() for key in iterable])  #type: ignore
         return super().__new__(cls, [])  #type: ignore
 
-    def __init__(self, iterable: Iterable[T] = None, upper: bool = False) -> None:
+    def __init__(self, iterable: Iterable[T] | None = None, upper: bool = False) -> None:
         self._upper = upper
         if iterable is not None:
             self.original_case = self._get_new_original_case(iterable)

--- a/masci_tools/util/case_insensitive_dict.py
+++ b/masci_tools/util/case_insensitive_dict.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from masci_tools.util.lockable_containers import LockableDict, LockableList
 import pprint
 
-from typing import Any, Union, Iterable, Generator, TypeVar, FrozenSet, cast, AbstractSet
+from typing import Any, Iterable, Generator, TypeVar, FrozenSet, cast, AbstractSet
 
 S = TypeVar('S')
 """ Generic Type """

--- a/masci_tools/util/chemical_elements.py
+++ b/masci_tools/util/chemical_elements.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=protected-access
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
@@ -207,7 +206,7 @@ class ChemicalElements:
 
                 # if from file,
         if filepath:
-            with open(filepath, 'r') as file:
+            with open(filepath) as file:
                 self.__elmts = _json.load(file)
                 # in case any group keys were numeric, they will now be string. rectify that.
                 # in case user WANTS them to be string, can always use 'rename' method to turn them back.
@@ -1038,7 +1037,7 @@ class ChemicalElements:
         :type filepath: str or pathlib.Path
         """
         try:
-            with open(filepath, 'r') as file:
+            with open(filepath) as file:
                 data = _json.load(file)
         except (FileNotFoundError, _json.JSONDecodeError) as err:
             print(f'File {filepath} not found or JSON decoding -> dict failed.')

--- a/masci_tools/util/constants.py
+++ b/masci_tools/util/constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/econfig.py
+++ b/masci_tools/util/econfig.py
@@ -1,8 +1,9 @@
 """
 Functions for expanding/splitting or converting electron configuration strings
 """
+from __future__ import annotations
+
 from masci_tools.util.constants import PERIODIC_TABLE_ELEMENTS
-from typing import Union, Optional
 
 all_econfig = [
     '1s2', '2s2', '2p6', '3s2', '3p6', '4s2', '3d10', '4p6', '5s2', '4d10', '5p6', '6s2', '4f14', '5d10', '6p6', '7s2',
@@ -14,7 +15,7 @@ max_state_occ_spin = {'1/2': 2., '3/2': 4., '5/2': 6., '7/2': 8.}
 ATOMIC_NAMES = {data['symbol']: num for num, data in PERIODIC_TABLE_ELEMENTS.items()}
 
 
-def get_econfig(element: Union[str, int], full: bool = False) -> Optional[str]:
+def get_econfig(element: str | int, full: bool = False) -> str | None:
     """
     returns the econfiguration as a string of an element.
 
@@ -23,7 +24,7 @@ def get_econfig(element: Union[str, int], full: bool = False) -> Optional[str]:
     :returns: a econfig string
     """
     if isinstance(element, int):
-        econ: Optional[str] = PERIODIC_TABLE_ELEMENTS.get(element, {}).get('econfig')  #type:ignore
+        econ: str | None = PERIODIC_TABLE_ELEMENTS.get(element, {}).get('econfig')  #type:ignore
     elif isinstance(element, str):
         element_num = ATOMIC_NAMES.get(element, None)
         if element_num is None:
@@ -38,7 +39,7 @@ def get_econfig(element: Union[str, int], full: bool = False) -> Optional[str]:
     return econ
 
 
-def get_coreconfig(element: Union[str, int], full: bool = False) -> Optional[str]:
+def get_coreconfig(element: str | int, full: bool = False) -> str | None:
     """
     returns the econfiguration as a string of an element.
 
@@ -50,7 +51,7 @@ def get_coreconfig(element: Union[str, int], full: bool = False) -> Optional[str
     return econ.split('|', maxsplit=1)[0].rstrip() if econ is not None else None
 
 
-def rek_econ(econfigstr: str) -> Optional[str]:
+def rek_econ(econfigstr: str) -> str | None:
     """
     recursive routine to return a full econfig
     '[Xe] 4f14 | 5d10 6s2 6p4' -> '1s 2s ... 4f14 | 5d10 6s2 6p4'

--- a/masci_tools/util/econfig.py
+++ b/masci_tools/util/econfig.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Functions for expanding/splitting or converting electron configuration strings
 """

--- a/masci_tools/util/fleur_calculate_expression.py
+++ b/masci_tools/util/fleur_calculate_expression.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/fleur_calculate_expression.py
+++ b/masci_tools/util/fleur_calculate_expression.py
@@ -27,7 +27,7 @@ class MissingConstant(Exception):
     pass
 
 
-def calculate_expression(expression: str | float | int, constants: dict[str, float] = None) -> float | int:
+def calculate_expression(expression: str | float | int, constants: dict[str, float] | None = None) -> float | int:
     """
     Recursively evaluates the given expression string with the given defined constants
 

--- a/masci_tools/util/fleur_calculate_expression.py
+++ b/masci_tools/util/fleur_calculate_expression.py
@@ -13,16 +13,21 @@
 This module contains the functions necessary to parse mathematical expressions
 with predefined constants given in the inp.xml file of Fleur
 """
-from typing import Callable, Dict, Union, Tuple
+from __future__ import annotations
+
+from typing import Callable
 import numpy as np
 from masci_tools.util.constants import FLEUR_DEFINED_CONSTANTS
 
 
 class MissingConstant(Exception):
+    """
+    Exception raised when a constant appearing in a expression is not defined
+    """
     pass
 
 
-def calculate_expression(expression: Union[str, float, int], constants: Dict[str, float] = None) -> float:
+def calculate_expression(expression: str | float | int, constants: dict[str, float] = None) -> float | int:
     """
     Recursively evaluates the given expression string with the given defined constants
 
@@ -35,9 +40,9 @@ def calculate_expression(expression: Union[str, float, int], constants: Dict[str
     return value
 
 
-def calculate_expression_partial(expression: Union[str, float, int],
-                                 constants: Dict[str, float] = None,
-                                 prevCommand: str = None) -> Tuple[float, str]:
+def calculate_expression_partial(expression: str | float | int,
+                                 constants: dict[str, float] | None = None,
+                                 prevCommand: str | None = None) -> tuple[float | int, str]:
     """
     Recursively evaluates the given expression string with the given defined constants
     and returns the unevaluated part of the expression
@@ -52,7 +57,7 @@ def calculate_expression_partial(expression: Union[str, float, int],
     """
 
     #Map the keywords recognized by fleur to the corresponding numpy function
-    functions_dict: Dict[str, Callable] = {
+    functions_dict: dict[str, Callable] = {
         'sin': np.sin,
         'cos': np.cos,
         'tan': np.tan,
@@ -172,7 +177,7 @@ def calculate_expression_partial(expression: Union[str, float, int],
     return value, expression
 
 
-def get_first_number(expression: str) -> Tuple[float, str]:
+def get_first_number(expression: str) -> tuple[float, str]:
     """
     Reads the number in the beginning of the expression string.
     This number can begin with a sign +-, a number or the decimal point
@@ -202,7 +207,7 @@ def get_first_number(expression: str) -> Tuple[float, str]:
     return float(numberstring), expression[len(numberstring):]
 
 
-def get_first_string(expression: str) -> Tuple[str, str]:
+def get_first_string(expression: str) -> tuple[str, str]:
     """
     Reads the letter string in the beginning of the expression string.
 
@@ -221,7 +226,7 @@ def get_first_string(expression: str) -> Tuple[str, str]:
     return found_string, expression[len(found_string):]
 
 
-def evaluate_bracket(expression: str, constants: Dict[str, float]) -> Tuple[Union[float, int], str]:
+def evaluate_bracket(expression: str, constants: dict[str, float]) -> tuple[float | int, str]:
     """
     Evaluates the bracket opened at the start of the expression
 

--- a/masci_tools/util/fleur_calculate_expression.py
+++ b/masci_tools/util/fleur_calculate_expression.py
@@ -24,7 +24,6 @@ class MissingConstant(Exception):
     """
     Exception raised when a constant appearing in a expression is not defined
     """
-    pass
 
 
 def calculate_expression(expression: str | float | int, constants: dict[str, float] | None = None) -> float | int:

--- a/masci_tools/util/kkr_rms_tracker.py
+++ b/masci_tools/util/kkr_rms_tracker.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #
@@ -11,14 +10,9 @@
 #                                                                             #
 ###############################################################################
 
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from numpy import array, sum, sqrt, log, abs, loadtxt, zeros_like, shape
 from matplotlib.pyplot import plot, figure, subplot, show, ion, title, suptitle, legend, gca, ioff, axvline, gcf
 import subprocess, sys, os, time
-from six.moves import range
-from builtins import str
 
 print()
 print('  ########  start script rms_tracker  ########')
@@ -323,7 +317,7 @@ while (True):
                 title('current iteration')
                 d_old = []
                 for i in range(j):
-                    d = loadtxt((path0 + 'dos.atom%i' % (i + 1)))
+                    d = loadtxt(path0 + 'dos.atom%i' % (i + 1))
                     lab = i
                     plot(d[:, 0], sum(d[:, 1:], axis=1), '-', label=lab)
                     d_old.append(d)

--- a/masci_tools/util/lockable_containers.py
+++ b/masci_tools/util/lockable_containers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/lockable_containers.py
+++ b/masci_tools/util/lockable_containers.py
@@ -100,7 +100,7 @@ class LockableDict(UserDict, Generic[S, T]):
         Freezes the object. This prevents further modifications
         """
         if self._recursive:
-            for key, val in self.items():
+            for val in self.values():
                 if isinstance(val, (LockableDict, LockableList)):
                     val.freeze()
 
@@ -109,7 +109,7 @@ class LockableDict(UserDict, Generic[S, T]):
     def _unfreeze(self) -> None:
 
         if self._recursive:
-            for key, val in self.items():
+            for val in self.values():
                 if isinstance(val, (LockableList, LockableDict)):
                     val._unfreeze()  #pylint: disable=protected-access
 

--- a/masci_tools/util/lockable_containers.py
+++ b/masci_tools/util/lockable_containers.py
@@ -13,19 +13,21 @@
 This module defines subclasses of UserDict and UserList to be able to prevent
 unintended modifications
 """
+from __future__ import annotations
+
 from collections import UserDict, UserList
 from contextlib import contextmanager
 
-from typing import Dict, Union, Any, Iterator, Iterable, cast, TypeVar, List, Generic
+from typing import Any, Iterator, Iterable, cast, TypeVar, Generic
 
 S = TypeVar('S')
-"""Generic Type"""
+""" Type variable for the key type of the dictionary """
 T = TypeVar('T')
-"""Generic Type"""
+""" Type variable for the value type of the dictionary """
 
 
 @contextmanager
-def LockContainer(lock_object: Union['LockableList[Any]', 'LockableDict[Any,Any]']) -> Iterator[None]:
+def LockContainer(lock_object: LockableList[Any] | LockableDict[Any, Any]) -> Iterator[None]:
     """
     Contextmanager for temporarily locking a lockable object. Object is unfrozen
     when exiting with block
@@ -64,7 +66,7 @@ class LockableDict(UserDict, Generic[S, T]):
 
     """
 
-    def __init__(self, *args: Dict[S, T], recursive: bool = True, **kwargs: T) -> None:
+    def __init__(self, *args: dict[S, T], recursive: bool = True, **kwargs: T) -> None:
         self._locked = False
         self._recursive = recursive
         super().__init__(*args, **kwargs)
@@ -84,7 +86,7 @@ class LockableDict(UserDict, Generic[S, T]):
         self.__check_lock()
         super().__delitem__(key)
 
-    def __setitem__(self, key: S, value: Union[T, 'LockableDict[S,T]', 'LockableList[T]']) -> None:
+    def __setitem__(self, key: S, value: T | LockableDict[S, T] | LockableList[T]) -> None:
         self.__check_lock()
         if isinstance(value, list):
             super().__setitem__(key, LockableList(value, recursive=self._recursive))
@@ -113,12 +115,12 @@ class LockableDict(UserDict, Generic[S, T]):
 
         self._locked = False
 
-    def get_unlocked(self) -> Dict[S, T]:
+    def get_unlocked(self) -> dict[S, T]:
         """
         Get copy of object with builtin lists and dicts
         """
         if self._recursive:
-            ret_dict: Dict[S, T] = {}
+            ret_dict: dict[S, T] = {}
             for key, value in self.items():
                 if isinstance(value, LockableDict):
                     ret_dict[key] = cast(T, value.get_unlocked())
@@ -171,11 +173,11 @@ class LockableList(UserList, Generic[T]):
         """
         return self._locked
 
-    def __delitem__(self, i: Union[int, slice]) -> None:
+    def __delitem__(self, i: int | slice) -> None:
         self.__check_lock()
         super().__delitem__(i)
 
-    def __setitem__(self, i: Union[int, slice], item: T) -> None:  #type:ignore
+    def __setitem__(self, i: int | slice, item: T) -> None:  #type:ignore
         self.__check_lock()
         if isinstance(item, list):
             super().__setitem__(i, LockableList(item, recursive=self._recursive))
@@ -184,15 +186,15 @@ class LockableList(UserList, Generic[T]):
         else:
             super().__setitem__(i, item)  # type: ignore
 
-    def __iadd__(self, other: Iterable[T]) -> 'LockableList[T]':
+    def __iadd__(self, other: Iterable[T]) -> LockableList[T]:
         self.__check_lock()
         return super().__iadd__(other)
 
-    def __add__(self, other: Iterable[T]) -> 'LockableList[T]':
+    def __add__(self, other: Iterable[T]) -> LockableList[T]:
         self.__check_lock()
         return super().__add__(other)
 
-    def __imul__(self, n: int) -> 'LockableList[T]':
+    def __imul__(self, n: int) -> LockableList[T]:
         self.__check_lock()
         return super().__imul__(n)
 
@@ -254,7 +256,7 @@ class LockableList(UserList, Generic[T]):
 
         self._locked = False
 
-    def get_unlocked(self) -> List[T]:
+    def get_unlocked(self) -> list[T]:
         """
         Get copy of object with builtin lists and dicts
         """

--- a/masci_tools/util/logging_util.py
+++ b/masci_tools/util/logging_util.py
@@ -11,8 +11,10 @@
 """
 This module defines useful utility for logging related functionality
 """
+from __future__ import annotations
+
 from logging import Handler, LoggerAdapter, LogRecord
-from typing import Dict, Tuple, Any, Union, cast, List
+from typing import Any, cast
 
 
 class DictHandler(Handler):
@@ -24,7 +26,7 @@ class DictHandler(Handler):
     Keyword arguments can be used to modify the keys for the different levels
     """
 
-    def __init__(self, log_dict: Dict[str, List[str]], ignore_unknown_levels: bool = False, **kwargs: Union[int, str]):
+    def __init__(self, log_dict: dict[str, list[str]], ignore_unknown_levels: bool = False, **kwargs: int | str):
         from logging import _levelToName
         import copy
 
@@ -33,7 +35,7 @@ class DictHandler(Handler):
         levels = copy.copy(list(_levelToName.values()))
         levels.remove('NOTSET')
 
-        self.level_names: Dict[str, str] = {name: cast(str, kwargs[name]) for name in levels if name in kwargs}
+        self.level_names: dict[str, str] = {name: cast(str, kwargs[name]) for name in levels if name in kwargs}
 
         if not ignore_unknown_levels:
             for name in levels:
@@ -71,5 +73,5 @@ class OutParserLogAdapter(LoggerAdapter):
     'iteration' key, whose value is prepended as [Iteration i] to the message
     """
 
-    def process(self, msg: str, kwargs: Any) -> Tuple[str, Dict]:
+    def process(self, msg: str, kwargs: Any) -> tuple[str, dict]:
         return f"[Iteration {self.extra['iteration']}] {msg}", kwargs

--- a/masci_tools/util/logging_util.py
+++ b/masci_tools/util/logging_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), 2018 Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.    #
 #                All rights reserved.                                         #

--- a/masci_tools/util/math_util.py
+++ b/masci_tools/util/math_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/modifypotential.py
+++ b/masci_tools/util/modifypotential.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), 2018 Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.    #
 #                All rights reserved.                                         #
@@ -13,14 +12,8 @@
 # edited by Philipp Ruessmann 2014
 # added averaging of spin up/down by Philipp Sep. 2015
 # pylint: skip-file
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from numpy import *
 from sys import argv, exit
-from six.moves import map
-from six.moves import range
-from six.moves import input
 
 mode = 'pot'
 if len(argv) == 2:
@@ -277,7 +270,7 @@ while 1:
         tempsave = order[row1]
         del order[row1]
     if mode1 == 4:
-        if type(tempsave) == type(1):
+        if type(tempsave) == int:
             if tempsave != -1:
                 row1 = int(eval(input('Paste before number:')))
                 order.insert(row1, tempsave)
@@ -306,7 +299,7 @@ while 1:
         for i in range(row1, row2 + 1):
             del order[row1]
     if mode1 == 8:
-        if type(tempsave) == type(1):
+        if type(tempsave) == int:
             if tempsave != -1:
                 row1 = int(eval(input('Paste before number:')))
                 row2 = int(eval(input('How many times?:')))

--- a/masci_tools/util/parse_tasks.py
+++ b/masci_tools/util/parse_tasks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/parse_tasks.py
+++ b/masci_tools/util/parse_tasks.py
@@ -13,6 +13,7 @@
 This module contains a class which organizes the known parsing tasks for outxml files
 and provides fuctionality for adding custom tasks easily
 """
+from __future__ import annotations
 
 from pprint import pprint
 import importlib.util
@@ -20,11 +21,11 @@ from importlib import import_module
 import copy
 import os
 from pathlib import Path
-from typing import Callable, Dict, Iterable, List, Set, Any, Union
+from typing import Callable, Dict, Iterable, Any, Union
 try:
-    from typing import Literal
+    from typing import Literal, TypeAlias  #type: ignore
 except ImportError:
-    from typing_extensions import Literal  #type:ignore
+    from typing_extensions import Literal, TypeAlias  #type:ignore
 import warnings
 from lxml import etree
 from logging import Logger, LoggerAdapter
@@ -36,10 +37,10 @@ import masci_tools
 PACKAGE_DIRECTORY = Path(masci_tools.__file__).parent.resolve()
 DEFAULT_TASK_FILE = PACKAGE_DIRECTORY / Path('io/parsers/fleur/default_parse_tasks.py')
 
-MIGRATION_DICT = Dict[str, Dict[str, Union[Literal['compatible'], Callable]]]
+MigrationDict: TypeAlias = "dict[str, dict[str, Literal['compatible'] | Callable]]"
 
 
-def find_migration(start: str, target: str, migrations: MIGRATION_DICT) -> Union[List[Callable], None]:
+def find_migration(start: str, target: str, migrations: MigrationDict) -> list[Callable] | None:
     """
     Tries to find a migration path from the start to the target version
     via the defined migration functions
@@ -62,7 +63,7 @@ def find_migration(start: str, target: str, migrations: MIGRATION_DICT) -> Union
             if migrations[start][target] == 'compatible':
                 return []
             return None
-        return [migrations[start][target]]  #type:ignore
+        return [migrations[start][target]]
 
     for possible_stop in migrations[start].keys():
         new_call_list = find_migration(possible_stop, target, migrations)
@@ -76,7 +77,7 @@ def find_migration(start: str, target: str, migrations: MIGRATION_DICT) -> Union
         else:
             call_list = [migrations[start][possible_stop]]
         call_list += new_call_list
-        return call_list  #type:ignore
+        return call_list
     return None
 
 
@@ -106,10 +107,10 @@ class ParseTasks:
     }
 
     _version = '0.2.0'
-    _migrations: MIGRATION_DICT = {}
-    _all_attribs_function: Set[str] = set()
-    _conversion_functions: Dict[str, Callable] = {}
-    _parse_functions: Dict[str, Callable] = {}
+    _migrations: MigrationDict = {}
+    _all_attribs_function: set[str] = set()
+    _conversion_functions: dict[str, Callable] = {}
+    _parse_functions: dict[str, Callable] = {}
 
     def __init__(self, version: str, task_file: os.PathLike = None, validate_defaults: bool = False) -> None:
         """
@@ -133,11 +134,11 @@ class ParseTasks:
         tasks = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(tasks)  #type:ignore
 
-        self._iteration_tasks: List[str] = []
-        self._general_tasks: List[str] = []
+        self._iteration_tasks: list[str] = []
+        self._general_tasks: list[str] = []
         self.version = convert_str_version_number(version)
 
-        tasks_dict: Dict[str, Dict[str, Any]] = copy.deepcopy(tasks.TASKS_DEFINITION)
+        tasks_dict: dict[str, dict[str, Any]] = copy.deepcopy(tasks.TASKS_DEFINITION)
         if validate_defaults:
             #Manually add each task to make sure that there are no typos/inconsitencies in the keys
             self.tasks = {}
@@ -146,7 +147,7 @@ class ParseTasks:
         else:
             self.tasks = tasks_dict
 
-        working: Set[str] = tasks.__working_out_versions__
+        working: set[str] = tasks.__working_out_versions__
         #Look if the base version is compatible if not look for a migration
         if version not in working:
 
@@ -170,35 +171,35 @@ class ParseTasks:
                     self.tasks = migration(self.tasks)
 
     @property
-    def iteration_tasks(self) -> List[str]:
+    def iteration_tasks(self) -> list[str]:
         """
         Tasks to perform for each iteration
         """
         return self._iteration_tasks
 
     @iteration_tasks.setter
-    def iteration_tasks(self, val: List[str]) -> None:
+    def iteration_tasks(self, val: list[str]) -> None:
         """
         Setter for iteration_tasks
         """
         self._iteration_tasks = val
 
     @property
-    def general_tasks(self) -> List[str]:
+    def general_tasks(self) -> list[str]:
         """
         Tasks to perform for the root node
         """
         return self._general_tasks
 
     @general_tasks.setter
-    def general_tasks(self, val: List[str]) -> None:
+    def general_tasks(self, val: list[str]) -> None:
         """
         Setter for general_tasks
         """
         self._general_tasks = val
 
     @property
-    def migrations(self) -> MIGRATION_DICT:
+    def migrations(self) -> MigrationDict:
         """
         Return the registered migrations
         """
@@ -207,7 +208,7 @@ class ParseTasks:
         return self._migrations
 
     @property
-    def conversion_functions(self) -> Dict[str, Callable]:
+    def conversion_functions(self) -> dict[str, Callable]:
         """
         Return the registered conversion functions
         """
@@ -216,7 +217,7 @@ class ParseTasks:
         return self._conversion_functions
 
     @property
-    def parse_functions(self) -> Dict[str, Callable]:
+    def parse_functions(self) -> dict[str, Callable]:
         """
         Return the registered parse functions
         """
@@ -225,7 +226,7 @@ class ParseTasks:
         return self._parse_functions
 
     @property
-    def all_attribs_function(self) -> Set[str]:
+    def all_attribs_function(self) -> set[str]:
         """
         Return the registered parse functions for parsing multipl attributes
         """
@@ -234,7 +235,7 @@ class ParseTasks:
         return self._all_attribs_function
 
     @property
-    def optional_tasks(self) -> Set[str]:
+    def optional_tasks(self) -> set[str]:
         """
         Return a set of the available optional defined tasks
         """
@@ -242,7 +243,7 @@ class ParseTasks:
 
     def add_task(self,
                  task_name: str,
-                 task_definition: Dict[str, Any],
+                 task_definition: dict[str, Any],
                  append: bool = False,
                  overwrite: bool = False) -> None:
         """
@@ -322,7 +323,7 @@ class ParseTasks:
             self.tasks[task_name] = task_definition
 
     def determine_tasks(self,
-                        fleurmodes: Dict[str, Any],
+                        fleurmodes: dict[str, Any],
                         optional_tasks: Iterable[str] = None,
                         minimal: bool = False) -> None:
         """
@@ -377,12 +378,12 @@ class ParseTasks:
 
     def perform_task(self,
                      task_name: str,
-                     node: Union[etree._Element, etree._ElementTree],
-                     out_dict: Dict,
-                     schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
-                     constants: Dict[str, float],
-                     logger: Union[Logger, LoggerAdapter] = None,
-                     use_lists: bool = True) -> Dict:
+                     node: etree._Element | etree._ElementTree,
+                     out_dict: dict,
+                     schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
+                     constants: dict[str, float],
+                     logger: Logger | LoggerAdapter | None = None,
+                     use_lists: bool = True) -> dict:
         """
         Evaluates the task given in the tasks_definition dict
 

--- a/masci_tools/util/parse_tasks.py
+++ b/masci_tools/util/parse_tasks.py
@@ -116,7 +116,7 @@ class ParseTasks:
     _conversion_functions: dict[str, Callable] = {}
     _parse_functions: dict[str, Callable] = {}
 
-    def __init__(self, version: str, task_file: os.PathLike = None, validate_defaults: bool = False) -> None:
+    def __init__(self, version: str, task_file: os.PathLike | None = None, validate_defaults: bool = False) -> None:
         """
         Initialize the default parse tasks
         Terminates if the version is not marked as working with the default tasks
@@ -328,7 +328,7 @@ class ParseTasks:
 
     def determine_tasks(self,
                         fleurmodes: dict[str, Any],
-                        optional_tasks: Iterable[str] = None,
+                        optional_tasks: Iterable[str] | None = None,
                         minimal: bool = False) -> None:
         """
         Determine, which tasks to perform based on the fleur_modes

--- a/masci_tools/util/parse_tasks.py
+++ b/masci_tools/util/parse_tasks.py
@@ -21,7 +21,7 @@ from importlib import import_module
 import copy
 import os
 from pathlib import Path
-from typing import Callable, Dict, Iterable, Any, Union
+from typing import Callable, Iterable, Any
 try:
     from typing import Literal, TypeAlias  #type: ignore
 except ImportError:
@@ -32,12 +32,16 @@ from logging import Logger, LoggerAdapter
 from masci_tools.io.parsers import fleur_schema
 
 from masci_tools.util.xml.converters import convert_str_version_number
+from masci_tools.util.typing import XMLLike
 import masci_tools
 
 PACKAGE_DIRECTORY = Path(masci_tools.__file__).parent.resolve()
 DEFAULT_TASK_FILE = PACKAGE_DIRECTORY / Path('io/parsers/fleur/default_parse_tasks.py')
 
 MigrationDict: TypeAlias = "dict[str, dict[str, Literal['compatible'] | Callable]]"
+"""
+Type describing the dictionary defining the migration pathways
+"""
 
 
 def find_migration(start: str, target: str, migrations: MigrationDict) -> list[Callable] | None:
@@ -378,7 +382,7 @@ class ParseTasks:
 
     def perform_task(self,
                      task_name: str,
-                     node: etree._Element | etree._ElementTree,
+                     node: XMLLike,
                      out_dict: dict,
                      schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                      constants: dict[str, float],

--- a/masci_tools/util/parse_tasks_decorators.py
+++ b/masci_tools/util/parse_tasks_decorators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/parse_tasks_decorators.py
+++ b/masci_tools/util/parse_tasks_decorators.py
@@ -26,7 +26,7 @@ from masci_tools.util.parse_tasks import ParseTasks
 from functools import wraps
 
 F = TypeVar('F', bound=Callable[..., Any])
-"""Generic Type variable for callable"""
+"""Generic Callable type"""
 
 
 def register_migration(base_version: str, target_version: Union[str, List[str]]) -> Callable[[F], F]:

--- a/masci_tools/util/plot_shapfun.py
+++ b/masci_tools/util/plot_shapfun.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), 2018 Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.    #
 #                All rights reserved.                                         #
@@ -18,9 +17,7 @@ Plotting utility to visualize the output of the voronoi code.
 Reads files 'vertices.dat' to extract the vertices of the shapefunctions and 'positions.dat' (done in 'read_shapefun' function)
 Then creates a simple matplotlib image to show the shapefunctions using the 'plot_shapefun' function.
 """
-from __future__ import print_function
 
-from __future__ import absolute_import
 from numpy import array, shape
 import sys
 from sys import argv

--- a/masci_tools/util/python_util.py
+++ b/masci_tools/util/python_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -16,6 +16,8 @@ schema_dicts defined for the Fleur input/output
 Also provides convienient functions to use just a attribute name for extracting the
 attribute from the right place in the given etree
 """
+from __future__ import annotations
+
 from masci_tools.io.parsers.fleur_schema import NoPathFound
 from masci_tools.util.parse_tasks_decorators import register_parsing_function
 from masci_tools.io.parsers import fleur_schema
@@ -181,9 +183,9 @@ def get_tag_info(schema_dict,
                                 parent=parent)
 
 
-def read_constants(root: Union[etree._Element, etree._ElementTree],
-                   schema_dict: 'fleur_schema.SchemaDict',
-                   logger: Logger = None) -> Dict[str, float]:
+def read_constants(root: etree._Element | etree._ElementTree,
+                   schema_dict: fleur_schema.SchemaDict,
+                   logger: Logger = None) -> dict[str, float]:
     """
     Reads in the constants defined in the inp.xml
     and returns them combined with the predefined constants from
@@ -226,10 +228,10 @@ def read_constants(root: Union[etree._Element, etree._ElementTree],
 
 
 @register_parsing_function('attrib')
-def evaluate_attribute(node: Union[etree._Element, etree._ElementTree],
-                       schema_dict: 'fleur_schema.SchemaDict',
+def evaluate_attribute(node: etree._Element | etree._ElementTree,
+                       schema_dict: fleur_schema.SchemaDict,
                        name: str,
-                       constants: Dict[str, float] = None,
+                       constants: dict[str, float] = None,
                        logger: Logger = None,
                        complex_xpath: XPathLike = None,
                        filters: FilterType = None,
@@ -279,7 +281,7 @@ def evaluate_attribute(node: Union[etree._Element, etree._ElementTree],
             complex_xpath.add_filter(key, val)
     check_complex_xpath(node, attrib_xpath, complex_xpath)
 
-    stringattribute: List[str] = eval_xpath(node, complex_xpath, logger=logger, list_return=True)  #type:ignore
+    stringattribute: list[str] = eval_xpath(node, complex_xpath, logger=logger, list_return=True)  #type:ignore
 
     if len(stringattribute) == 0:
         if logger is None:
@@ -308,10 +310,10 @@ def evaluate_attribute(node: Union[etree._Element, etree._ElementTree],
 
 
 @register_parsing_function('text')
-def evaluate_text(node: Union[etree._Element, etree._ElementTree],
-                  schema_dict: 'fleur_schema.SchemaDict',
+def evaluate_text(node: etree._Element | etree._ElementTree,
+                  schema_dict: fleur_schema.SchemaDict,
                   name: str,
-                  constants: Dict[str, float] = None,
+                  constants: dict[str, float] = None,
                   logger: Logger = None,
                   complex_xpath: XPathLike = None,
                   iteration_path: bool = False,
@@ -358,7 +360,7 @@ def evaluate_text(node: Union[etree._Element, etree._ElementTree],
 
     check_complex_xpath(node, tag_xpath, complex_xpath)
 
-    stringtext: List[str] = eval_xpath(node, add_tag(complex_xpath, 'text()'), logger=logger,
+    stringtext: list[str] = eval_xpath(node, add_tag(complex_xpath, 'text()'), logger=logger,
                                        list_return=True)  #type:ignore
 
     for text in stringtext.copy():
@@ -392,10 +394,10 @@ def evaluate_text(node: Union[etree._Element, etree._ElementTree],
 
 
 @register_parsing_function('allAttribs', all_attribs_keys=True)
-def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
-                 schema_dict: 'fleur_schema.SchemaDict',
+def evaluate_tag(node: etree._Element | etree._ElementTree,
+                 schema_dict: fleur_schema.SchemaDict,
                  name: str,
-                 constants: Dict[str, float] = None,
+                 constants: dict[str, float] = None,
                  logger: Logger = None,
                  subtags: bool = False,
                  text: bool = True,
@@ -491,11 +493,11 @@ def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
             'exist or it has no attributes', name)
     attrib_list = sorted(list(attribs.original_case.values()))
 
-    out_dict: Dict[str, Any] = {}
+    out_dict: dict[str, Any] = {}
 
     for attrib in attrib_list:
 
-        stringattribute: List[str] = eval_xpath(node,
+        stringattribute: list[str] = eval_xpath(node,
                                                 add_tag(complex_xpath, f'@{attrib}'),
                                                 logger=logger,
                                                 list_return=True)  #type:ignore
@@ -527,7 +529,7 @@ def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
     if parse_text:
 
         _, name = split_off_tag(tag_xpath)
-        stringtext: List[str] = eval_xpath(node, add_tag(complex_xpath, 'text()'), logger=logger,
+        stringtext: list[str] = eval_xpath(node, add_tag(complex_xpath, 'text()'), logger=logger,
                                            list_return=True)  #type:ignore
 
         for textval in stringtext.copy():
@@ -561,7 +563,7 @@ def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
                 logger.error('Conflicting key %s: ' 'Key is already in the output dictionary', tag)
             out_dict[tag] = []
 
-        sub_nodes: List[etree._Element] = eval_xpath(node, complex_xpath, logger=logger, list_return=True)  #type:ignore
+        sub_nodes: list[etree._Element] = eval_xpath(node, complex_xpath, logger=logger, list_return=True)  #type:ignore
         for sub_node in sub_nodes:
             for tag in tags:
                 if tag_exists(sub_node, schema_dict, tag):
@@ -595,10 +597,10 @@ def evaluate_tag(node: Union[etree._Element, etree._ElementTree],
 
 
 @register_parsing_function('singleValue', all_attribs_keys=True)
-def evaluate_single_value_tag(node: Union[etree._Element, etree._ElementTree],
-                              schema_dict: 'fleur_schema.SchemaDict',
+def evaluate_single_value_tag(node: etree._Element | etree._ElementTree,
+                              schema_dict: fleur_schema.SchemaDict,
                               name: str,
-                              constants: Dict[str, float] = None,
+                              constants: dict[str, float] = None,
                               logger: Logger = None,
                               complex_xpath: XPathLike = None,
                               **kwargs: Any) -> Any:
@@ -653,10 +655,10 @@ def evaluate_single_value_tag(node: Union[etree._Element, etree._ElementTree],
 
 
 @register_parsing_function('parentAttribs', all_attribs_keys=True)
-def evaluate_parent_tag(node: Union[etree._Element, etree._ElementTree],
-                        schema_dict: 'fleur_schema.SchemaDict',
+def evaluate_parent_tag(node: etree._Element | etree._ElementTree,
+                        schema_dict: fleur_schema.SchemaDict,
                         name: str,
-                        constants: Dict[str, float] = None,
+                        constants: dict[str, float] = None,
                         logger: Logger = None,
                         complex_xpath: XPathLike = None,
                         iteration_path: bool = False,
@@ -741,9 +743,9 @@ def evaluate_parent_tag(node: Union[etree._Element, etree._ElementTree],
             'exist or it has no attributes', name)
     attrib_list = sorted(list(attribs.original_case.values()))
 
-    elems: List[etree._Element] = eval_xpath(node, complex_xpath, logger=logger, list_return=True)  #type:ignore
+    elems: list[etree._Element] = eval_xpath(node, complex_xpath, logger=logger, list_return=True)  #type:ignore
 
-    out_dict: Dict[str, Any] = {}
+    out_dict: dict[str, Any] = {}
     for attrib in attrib_list:
         out_dict[attrib] = []
 
@@ -792,8 +794,8 @@ def evaluate_parent_tag(node: Union[etree._Element, etree._ElementTree],
 
 
 @register_parsing_function('attrib_exists')
-def attrib_exists(node: Union[etree._Element, etree._ElementTree],
-                  schema_dict: 'fleur_schema.SchemaDict',
+def attrib_exists(node: etree._Element | etree._ElementTree,
+                  schema_dict: fleur_schema.SchemaDict,
                   name: str,
                   logger: Logger = None,
                   iteration_path: bool = False,
@@ -827,13 +829,13 @@ def attrib_exists(node: Union[etree._Element, etree._ElementTree],
     tag_xpath, attrib_name = split_off_attrib(attrib_xpath)
     tag_xpath_builder = XPathBuilder(tag_xpath, filters=filters, strict=True)
 
-    tags: List[etree._Element] = eval_xpath(node, tag_xpath_builder, logger=logger, list_return=True)  #type:ignore
+    tags: list[etree._Element] = eval_xpath(node, tag_xpath_builder, logger=logger, list_return=True)  #type:ignore
     return any(attrib_name in tag.attrib for tag in tags)
 
 
 @register_parsing_function('exists')
-def tag_exists(node: Union[etree._Element, etree._ElementTree],
-               schema_dict: 'fleur_schema.SchemaDict',
+def tag_exists(node: etree._Element | etree._ElementTree,
+               schema_dict: fleur_schema.SchemaDict,
                name: str,
                logger: Logger = None,
                **kwargs: Any) -> bool:
@@ -860,8 +862,8 @@ def tag_exists(node: Union[etree._Element, etree._ElementTree],
 
 
 @register_parsing_function('numberNodes')
-def get_number_of_nodes(node: Union[etree._Element, etree._ElementTree],
-                        schema_dict: 'fleur_schema.SchemaDict',
+def get_number_of_nodes(node: etree._Element | etree._ElementTree,
+                        schema_dict: fleur_schema.SchemaDict,
                         name: str,
                         logger: Logger = None,
                         **kwargs: Any) -> int:
@@ -891,37 +893,37 @@ def get_number_of_nodes(node: Union[etree._Element, etree._ElementTree],
 
 
 @overload
-def eval_simple_xpath(node: Union[etree._Element, etree._ElementTree],
-                      schema_dict: 'fleur_schema.SchemaDict',
+def eval_simple_xpath(node: etree._Element | etree._ElementTree,
+                      schema_dict: fleur_schema.SchemaDict,
                       name: str,
                       logger: Logger = None,
                       iteration_path: bool = False,
                       filters: FilterType = None,
                       list_return: Literal[True] = ...,
-                      **kwargs: Any) -> 'List[etree._Element]':
+                      **kwargs: Any) -> list[etree._Element]:
     ...
 
 
 @overload
-def eval_simple_xpath(node: Union[etree._Element, etree._ElementTree],
-                      schema_dict: 'fleur_schema.SchemaDict',
+def eval_simple_xpath(node: etree._Element | etree._ElementTree,
+                      schema_dict: fleur_schema.SchemaDict,
                       name: str,
                       logger: Logger = None,
                       iteration_path: bool = False,
                       filters: FilterType = None,
                       list_return: Literal[False] = ...,
-                      **kwargs: Any) -> 'Union[etree._Element, List[etree._Element]]':
+                      **kwargs: Any) -> etree._Element | list[etree._Element]:
     ...
 
 
-def eval_simple_xpath(node: Union[etree._Element, etree._ElementTree],
-                      schema_dict: 'fleur_schema.SchemaDict',
+def eval_simple_xpath(node: etree._Element | etree._ElementTree,
+                      schema_dict: fleur_schema.SchemaDict,
                       name: str,
                       logger: Logger = None,
                       iteration_path: bool = False,
                       filters: FilterType = None,
                       list_return: bool = False,
-                      **kwargs: Any) -> 'Union[etree._Element, List[etree._Element]]':
+                      **kwargs: Any) -> etree._Element | list[etree._Element]:
     """
     Evaluates a simple xpath expression of the tag in the xmltree based on the given name
     and additional further specifications with the available type information
@@ -950,8 +952,8 @@ def eval_simple_xpath(node: Union[etree._Element, etree._ElementTree],
     return eval_xpath(node, tag_xpath_builder, logger=logger, list_return=list_return)  #type: ignore[return-value]
 
 
-def _select_tag_xpath(node: Union[etree._Element, etree._ElementTree],
-                      schema_dict: 'fleur_schema.SchemaDict',
+def _select_tag_xpath(node: etree._Element | etree._ElementTree,
+                      schema_dict: fleur_schema.SchemaDict,
                       name: str,
                       iteration_path: bool = False,
                       **kwargs: Any) -> str:
@@ -983,7 +985,7 @@ def _select_tag_xpath(node: Union[etree._Element, etree._ElementTree],
         if not isinstance(schema_dict, fleur_schema.OutputSchemaDict):
             raise ValueError('iteration_path=True can only be used with OutputSchemaDict')
 
-    root_tags: Tuple[str, ...] = (schema_dict['root_tag'],)
+    root_tags: tuple[str, ...] = (schema_dict['root_tag'],)
     if isinstance(schema_dict, fleur_schema.OutputSchemaDict):
         root_tags += tuple(schema_dict['iteration_tags'])
 
@@ -1004,8 +1006,8 @@ def _select_tag_xpath(node: Union[etree._Element, etree._ElementTree],
     return xpath
 
 
-def _select_attrib_xpath(node: Union[etree._Element, etree._ElementTree],
-                         schema_dict: 'fleur_schema.SchemaDict',
+def _select_attrib_xpath(node: etree._Element | etree._ElementTree,
+                         schema_dict: fleur_schema.SchemaDict,
                          name: str,
                          iteration_path: bool = False,
                          **kwargs: Any) -> str:
@@ -1040,7 +1042,7 @@ def _select_attrib_xpath(node: Union[etree._Element, etree._ElementTree],
         if not isinstance(schema_dict, fleur_schema.OutputSchemaDict):
             raise ValueError('iteration_path=True can only be used with OutputSchemaDict')
 
-    root_tags: Tuple[str, ...] = (schema_dict['root_tag'],)
+    root_tags: tuple[str, ...] = (schema_dict['root_tag'],)
     if isinstance(schema_dict, fleur_schema.OutputSchemaDict):
         root_tags += tuple(schema_dict['iteration_tags'])
 
@@ -1061,12 +1063,12 @@ def _select_attrib_xpath(node: Union[etree._Element, etree._ElementTree],
     return xpath
 
 
-def _select_tag_info(node: Union[etree._Element, etree._ElementTree],
-                     schema_dict: 'fleur_schema.SchemaDict',
+def _select_tag_info(node: etree._Element | etree._ElementTree,
+                     schema_dict: fleur_schema.SchemaDict,
                      name: str,
                      iteration_path: bool = False,
                      iteration_tag: str = 'iteration',
-                     contains: Union[str, Iterable[str]] = None,
+                     contains: str | Iterable[str] | None = None,
                      **kwargs: Any) -> fleur_schema.schema_dict.TagInfo:
     """
     Get the tag information used for the evaluation function in this module
@@ -1099,7 +1101,7 @@ def _select_tag_info(node: Union[etree._Element, etree._ElementTree],
         if not isinstance(schema_dict, fleur_schema.OutputSchemaDict):
             raise ValueError('iteration_path=True can only be used with OutputSchemaDict')
 
-    root_tags: Tuple[str, ...] = (schema_dict['root_tag'],)
+    root_tags: tuple[str, ...] = (schema_dict['root_tag'],)
     if isinstance(schema_dict, fleur_schema.OutputSchemaDict):
         root_tags += tuple(schema_dict['iteration_tags'])
 

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -28,8 +28,8 @@ from lxml import etree
 from logging import Logger
 import warnings
 import copy
-from typing import Iterable, Any, overload
 import os
+from typing import Iterable, Any, overload
 try:
     from typing import Literal
 except ImportError:
@@ -198,7 +198,6 @@ def read_constants(root: XMLLike, schema_dict: fleur_schema.SchemaDict, logger: 
     :return: a python dictionary with all defined constants
     """
     from masci_tools.util.constants import FLEUR_DEFINED_CONSTANTS
-    import copy
 
     defined_constants = copy.deepcopy(FLEUR_DEFINED_CONSTANTS)
 

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -630,7 +630,7 @@ def evaluate_single_value_tag(node: XMLLike,
     """
 
     only_required = kwargs.get('only_required', False)
-    ignore = kwargs.get('ignore', [])
+    ignore = kwargs.pop('ignore', ['comment'])
 
     value_dict = evaluate_tag(node,
                               schema_dict,
@@ -638,6 +638,7 @@ def evaluate_single_value_tag(node: XMLLike,
                               constants=constants,
                               logger=logger,
                               complex_xpath=complex_xpath,
+                              ignore=ignore,
                               **kwargs)
 
     if value_dict.get('value') is None:

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -185,7 +185,9 @@ def get_tag_info(schema_dict,
                                 parent=parent)
 
 
-def read_constants(root: XMLLike, schema_dict: fleur_schema.SchemaDict, logger: Logger = None) -> dict[str, float]:
+def read_constants(root: XMLLike,
+                   schema_dict: fleur_schema.SchemaDict,
+                   logger: Logger | None = None) -> dict[str, float]:
     """
     Reads in the constants defined in the inp.xml
     and returns them combined with the predefined constants from
@@ -230,10 +232,10 @@ def read_constants(root: XMLLike, schema_dict: fleur_schema.SchemaDict, logger: 
 def evaluate_attribute(node: XMLLike,
                        schema_dict: fleur_schema.SchemaDict,
                        name: str,
-                       constants: dict[str, float] = None,
-                       logger: Logger = None,
-                       complex_xpath: XPathLike = None,
-                       filters: FilterType = None,
+                       constants: dict[str, float] | None = None,
+                       logger: Logger | None = None,
+                       complex_xpath: XPathLike | None = None,
+                       filters: FilterType | None = None,
                        iteration_path: bool = False,
                        **kwargs: Any) -> Any:
     """
@@ -312,11 +314,11 @@ def evaluate_attribute(node: XMLLike,
 def evaluate_text(node: XMLLike,
                   schema_dict: fleur_schema.SchemaDict,
                   name: str,
-                  constants: dict[str, float] = None,
-                  logger: Logger = None,
-                  complex_xpath: XPathLike = None,
+                  constants: dict[str, float] | None = None,
+                  logger: Logger | None = None,
+                  complex_xpath: XPathLike | None = None,
                   iteration_path: bool = False,
-                  filters: FilterType = None,
+                  filters: FilterType | None = None,
                   **kwargs: Any) -> Any:
     """
     Evaluates the text of the tag based on the given name
@@ -396,13 +398,13 @@ def evaluate_text(node: XMLLike,
 def evaluate_tag(node: XMLLike,
                  schema_dict: fleur_schema.SchemaDict,
                  name: str,
-                 constants: dict[str, float] = None,
-                 logger: Logger = None,
+                 constants: dict[str, float] | None = None,
+                 logger: Logger | None = None,
                  subtags: bool = False,
                  text: bool = True,
-                 complex_xpath: XPathLike = None,
+                 complex_xpath: XPathLike | None = None,
                  iteration_path: bool = False,
-                 filters: FilterType = None,
+                 filters: FilterType | None = None,
                  **kwargs: Any) -> Any:
     """
     Evaluates all attributes of the tag based on the given name
@@ -599,9 +601,9 @@ def evaluate_tag(node: XMLLike,
 def evaluate_single_value_tag(node: XMLLike,
                               schema_dict: fleur_schema.SchemaDict,
                               name: str,
-                              constants: dict[str, float] = None,
-                              logger: Logger = None,
-                              complex_xpath: XPathLike = None,
+                              constants: dict[str, float] | None = None,
+                              logger: Logger | None = None,
+                              complex_xpath: XPathLike | None = None,
                               **kwargs: Any) -> Any:
     """
     Evaluates the value and unit attribute of the tag based on the given name
@@ -658,11 +660,11 @@ def evaluate_single_value_tag(node: XMLLike,
 def evaluate_parent_tag(node: XMLLike,
                         schema_dict: fleur_schema.SchemaDict,
                         name: str,
-                        constants: dict[str, float] = None,
-                        logger: Logger = None,
-                        complex_xpath: XPathLike = None,
+                        constants: dict[str, float] | None = None,
+                        logger: Logger | None = None,
+                        complex_xpath: XPathLike | None = None,
                         iteration_path: bool = False,
-                        filters: FilterType = None,
+                        filters: FilterType | None = None,
                         **kwargs: Any) -> Any:
     """
     Evaluates all attributes of the parent tag based on the given name
@@ -797,9 +799,9 @@ def evaluate_parent_tag(node: XMLLike,
 def attrib_exists(node: XMLLike,
                   schema_dict: fleur_schema.SchemaDict,
                   name: str,
-                  logger: Logger = None,
+                  logger: Logger | None = None,
                   iteration_path: bool = False,
-                  filters: FilterType = None,
+                  filters: FilterType | None = None,
                   **kwargs: Any) -> bool:
     """
     Evaluates whether the attribute exists in the xmltree based on the given name
@@ -837,7 +839,7 @@ def attrib_exists(node: XMLLike,
 def tag_exists(node: XMLLike,
                schema_dict: fleur_schema.SchemaDict,
                name: str,
-               logger: Logger = None,
+               logger: Logger | None = None,
                **kwargs: Any) -> bool:
     """
     Evaluates whether the tag exists in the xmltree based on the given name
@@ -865,7 +867,7 @@ def tag_exists(node: XMLLike,
 def get_number_of_nodes(node: XMLLike,
                         schema_dict: fleur_schema.SchemaDict,
                         name: str,
-                        logger: Logger = None,
+                        logger: Logger | None = None,
                         **kwargs: Any) -> int:
     """
     Evaluates the number of occurences of the tag in the xmltree based on the given name
@@ -896,9 +898,9 @@ def get_number_of_nodes(node: XMLLike,
 def eval_simple_xpath(node: XMLLike,
                       schema_dict: fleur_schema.SchemaDict,
                       name: str,
-                      logger: Logger = None,
+                      logger: Logger | None = None,
                       iteration_path: bool = False,
-                      filters: FilterType = None,
+                      filters: FilterType | None = None,
                       list_return: Literal[True] = ...,
                       **kwargs: Any) -> list[etree._Element]:
     ...
@@ -908,9 +910,9 @@ def eval_simple_xpath(node: XMLLike,
 def eval_simple_xpath(node: XMLLike,
                       schema_dict: fleur_schema.SchemaDict,
                       name: str,
-                      logger: Logger = None,
+                      logger: Logger | None = None,
                       iteration_path: bool = False,
-                      filters: FilterType = None,
+                      filters: FilterType | None = None,
                       list_return: Literal[False] = ...,
                       **kwargs: Any) -> etree._Element | list[etree._Element]:
     ...
@@ -919,9 +921,9 @@ def eval_simple_xpath(node: XMLLike,
 def eval_simple_xpath(node: XMLLike,
                       schema_dict: fleur_schema.SchemaDict,
                       name: str,
-                      logger: Logger = None,
+                      logger: Logger | None = None,
                       iteration_path: bool = False,
-                      filters: FilterType = None,
+                      filters: FilterType | None = None,
                       list_return: bool = False,
                       **kwargs: Any) -> etree._Element | list[etree._Element]:
     """

--- a/masci_tools/util/typing.py
+++ b/masci_tools/util/typing.py
@@ -1,18 +1,42 @@
 """
 This module defines some aliases used in typing
 """
-from typing import TypeVar, Union
+from __future__ import annotations
+
+from typing import TypeVar, Any, IO
 try:
     from typing import TypeAlias  #type: ignore[attr-defined]
 except ImportError:
     from typing_extensions import TypeAlias
 from lxml import etree
+from pathlib import Path
+import os
 
 #Type for xml setters/getters for xpath objects that can be used in `eval_xpath`
 from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
-XPathLike: TypeAlias = Union[str, bytes, etree.XPath, XPathBuilder]
+XPathLike: TypeAlias = 'str | bytes | etree.XPath | XPathBuilder'
+"""
+Type for xpath expressions
+"""
+
 TXPathLike = TypeVar('TXPathLike', str, etree.XPath, XPathBuilder)
 """
 Type for xpath expressions
+"""
+
+FileLike: TypeAlias = 'str | bytes | Path | os.PathLike[Any] | IO'
+"""
+Type used for functions accepting file-like objects, i.e. handles or file paths
+"""
+
+XMLFileLike: TypeAlias = 'etree._ElementTree | etree._Element | FileLike'
+"""
+Type used for functions accepting xml-file-like objects, i.e. handles or file paths
+or already parsed xml objects
+"""
+
+XMLLike: TypeAlias = 'etree._Element | etree._ElementTree'
+"""
+Type used for functions accepting xml objects from lxml
 """

--- a/masci_tools/util/typing.py
+++ b/masci_tools/util/typing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module defines some aliases used in typing
 """

--- a/masci_tools/util/xml/collect_xml_setters.py
+++ b/masci_tools/util/xml/collect_xml_setters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Collect all functions that should be exposed to the :py:class:`~masci_tools.io.io_fleurxmlmodifier.FleurXMLModifier`
 and classify them according to their interface. This makes extending functionality for the Modifier relatively easy

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -174,9 +174,9 @@ def validate_xml(xmltree: etree._ElementTree,
 
 def eval_xpath(node: XMLLike | etree._XPathEvaluatorBase,
                xpath: XPathLike,
-               logger: logging.Logger = None,
+               logger: logging.Logger | None = None,
                list_return: bool = False,
-               namespaces: etree._DictAnyStr = None,
+               namespaces: etree._DictAnyStr | None = None,
                **variables: etree._XPathObject) -> etree._XPathObject:
     """
     Tries to evaluate an xpath expression. If it fails it logs it.
@@ -238,7 +238,7 @@ def eval_xpath(node: XMLLike | etree._XPathEvaluatorBase,
     return return_value
 
 
-def get_xml_attribute(node: etree._Element, attributename: str, logger: logging.Logger = None) -> str | None:
+def get_xml_attribute(node: etree._Element, attributename: str, logger: logging.Logger | None = None) -> str | None:
     """
     Get an attribute value from a node.
 

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -14,15 +14,11 @@ Common functions for parsing input/output files or XMLschemas from FLEUR
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable
-from masci_tools.util.typing import XPathLike, TXPathLike
+from masci_tools.util.typing import XMLLike, XPathLike, TXPathLike
 from lxml import etree
 import warnings
-import os
 import copy
-from logging import Logger
-if TYPE_CHECKING:
-    from masci_tools.io.parsers import fleur_schema
+import logging
 
 from .xpathbuilder import XPathBuilder
 
@@ -106,9 +102,10 @@ def clear_xml(tree: etree._ElementTree) -> tuple[etree._ElementTree, set[str]]:
     return cleared_tree, all_included_tags
 
 
-def reverse_xinclude(xmltree: etree._ElementTree, schema_dict: fleur_schema.SchemaDict, included_tags: Iterable[str],
-                     **kwargs: os.PathLike) -> tuple[etree._ElementTree, dict[os.PathLike | str, etree._ElementTree]]:
+def reverse_xinclude(xmltree, schema_dict, included_tags, **kwargs):
     """
+    DEPRECATED ALIAS: Moved to masci_tools.util.schema_dict_util
+
     Split the xmltree back up according to the given included tags.
     The original xmltree will be returned with the corresponding xinclude tags
     and the included trees are returned in a dict mapping the inserted filename
@@ -134,70 +131,9 @@ def reverse_xinclude(xmltree: etree._ElementTree, schema_dict: fleur_schema.Sche
 
     :raises ValueError: if the tag can not be found in teh given xmltree
     """
-
-    INCLUDE_NSMAP = {'xi': 'http://www.w3.org/2001/XInclude'}
-    INCLUDE_TAG = etree.QName(INCLUDE_NSMAP['xi'], 'include')
-    FALLBACK_TAG = etree.QName(INCLUDE_NSMAP['xi'], 'fallback')
-
-    excluded_tree = copy.deepcopy(xmltree)
-
-    include_file_names: dict[str, os.PathLike | str] = {
-        'relaxation': 'relax.xml',
-        'kPointLists': 'kpts.xml',
-        'symmetryOperations': 'sym.xml',
-        'atomSpecies': 'species.xml',
-        'atomGroups': 'atoms.xml'
-    }
-
-    include_file_names = {**include_file_names, **kwargs}
-
-    unknown_file_names = 0
-    included_trees = {}
-    root = excluded_tree.getroot()
-
-    if not all(isinstance(tag, str) for tag in included_tags):
-        raise ValueError(f'included_tags is not made up of strings: {included_tags}')
-
-    for tag in included_tags:
-        if tag in include_file_names:
-            file_name = include_file_names[tag]
-        else:
-            warnings.warn(f'No filename known for tag {tag}')
-            unknown_file_names += 1
-            file_name = f'unknown-{unknown_file_names}.xml'
-
-        try:
-            tag_xpath = schema_dict.tag_xpath(tag)
-        except Exception as err:
-            raise ValueError(f'Cannot determine place of included tag {tag}') from err
-        included_tag_res: list[etree._Element] = eval_xpath(root, tag_xpath, list_return=True)  #type:ignore
-
-        if len(included_tag_res) != 1:
-            raise ValueError(f'Cannot determine place of included tag {tag}')
-        included_tag = included_tag_res[0]
-
-        included_trees[file_name] = etree.ElementTree(included_tag)
-
-        parent = included_tag.getparent()
-        if parent is None:
-            raise ValueError('Could not find parent of included tag')
-
-        xinclude_elem = etree.Element(INCLUDE_TAG, href=os.fspath(file_name), nsmap=INCLUDE_NSMAP)  #type:ignore
-        xinclude_elem.append(etree.Element(FALLBACK_TAG))  #type:ignore
-
-        parent.replace(included_tag, xinclude_elem)
-
-    if 'relax.xml' not in included_trees:
-        #The relax.xml include should always be there
-        xinclude_elem = etree.Element(INCLUDE_TAG, href='relax.xml', nsmap=INCLUDE_NSMAP)  #type:ignore
-        xinclude_elem.append(etree.Element(FALLBACK_TAG))  #type:ignore
-        root.append(xinclude_elem)
-
-    etree.indent(excluded_tree)
-    for tree in included_trees.values():
-        etree.indent(tree)
-
-    return excluded_tree, included_trees
+    from masci_tools.util.schema_dict_util import reverse_xinclude
+    warnings.warn('DEPRECATED: reverse_xinclude moved to masci_tools.util.schema_dict_util', DeprecationWarning)
+    return reverse_xinclude(xmltree, schema_dict, included_tags, **kwargs)
 
 
 def validate_xml(xmltree: etree._ElementTree,
@@ -236,9 +172,9 @@ def validate_xml(xmltree: etree._ElementTree,
         raise etree.DocumentInvalid(errmsg) from exc
 
 
-def eval_xpath(node: etree._Element | etree._ElementTree | etree._XPathEvaluatorBase,
+def eval_xpath(node: XMLLike | etree._XPathEvaluatorBase,
                xpath: XPathLike,
-               logger: Logger = None,
+               logger: logging.Logger = None,
                list_return: bool = False,
                namespaces: etree._DictAnyStr = None,
                **variables: etree._XPathObject) -> etree._XPathObject:
@@ -286,7 +222,7 @@ def eval_xpath(node: etree._Element | etree._ElementTree | etree._XPathEvaluator
         elif isinstance(node, etree._XPathEvaluatorBase):  #pylint: disable=protected-access
             return_value = node(xpath, **variables)
         else:
-            return_value = node.xpath(xpath, namespaces=namespaces, **variables)  #type:ignore
+            return_value = node.xpath(xpath, namespaces=namespaces, **variables)
     except etree.XPathEvalError as err:
         if logger is not None:
             logger.exception(
@@ -302,7 +238,7 @@ def eval_xpath(node: etree._Element | etree._ElementTree | etree._XPathEvaluator
     return return_value
 
 
-def get_xml_attribute(node: etree._Element, attributename: str, logger: Logger = None) -> str | None:
+def get_xml_attribute(node: etree._Element, attributename: str, logger: logging.Logger = None) -> str | None:
     """
     Get an attribute value from a node.
 
@@ -426,8 +362,7 @@ def split_off_attrib(xpath: TXPathLike) -> tuple[TXPathLike, str]:
     return xpath, attrib
 
 
-def check_complex_xpath(node: etree._Element | etree._ElementTree, base_xpath: XPathLike,
-                        complex_xpath: XPathLike) -> None:
+def check_complex_xpath(node: XMLLike, base_xpath: XPathLike, complex_xpath: XPathLike) -> None:
     """
     Check that the given complex xpath produces a subset of the results
     for the simple xpath

--- a/masci_tools/util/xml/converters.py
+++ b/masci_tools/util/xml/converters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/xml/converters.py
+++ b/masci_tools/util/xml/converters.py
@@ -31,7 +31,7 @@ def convert_to_xml(value: Any | list[Any],
                    schema_dict: fleur_schema.SchemaDict,
                    name: str,
                    text: bool = False,
-                   logger: logging.Logger = None,
+                   logger: logging.Logger | None = None,
                    list_return: bool = False) -> tuple[str | list[str], bool]:
     """
     Tries to converts a given string to the types specified in the schema_dict.
@@ -75,8 +75,8 @@ def convert_from_xml(
     schema_dict: fleur_schema.SchemaDict,
     name: str,
     text: bool = False,
-    constants: dict[str, float] = None,
-    logger: logging.Logger = None,
+    constants: dict[str, float] | None = None,
+    logger: logging.Logger | None = None,
     list_return: bool = False
 ) -> tuple[ConvertedType | list[ConvertedType] | list[ConvertedType | list[ConvertedType]], bool]:
     """
@@ -121,8 +121,8 @@ def convert_from_xml(
 def convert_from_xml_explicit(
     xmlstring: str | list[str],
     definitions: list[fleur_schema.AttributeType],
-    constants: dict[str, float] = None,
-    logger: logging.Logger = None,
+    constants: dict[str, float] | None = None,
+    logger: logging.Logger | None = None,
     list_return: bool = False
 ) -> tuple[ConvertedType | list[ConvertedType] | list[ConvertedType | list[ConvertedType]], bool]:
     """
@@ -198,7 +198,7 @@ def convert_from_xml_explicit(
 
 def convert_to_xml_explicit(value: Any | Iterable[Any],
                             definitions: list[fleur_schema.AttributeType],
-                            logger: logging.Logger = None,
+                            logger: logging.Logger | None = None,
                             float_format: str = '.10',
                             list_return: bool = False) -> tuple[str | list[str], bool]:
     """
@@ -269,8 +269,8 @@ def convert_to_xml_explicit(value: Any | Iterable[Any],
 
 def convert_from_xml_single_values(xmlstring: str | list[str],
                                    possible_types: tuple[BaseType, ...],
-                                   constants: dict[str, float] = None,
-                                   logger: logging.Logger = None) -> tuple[list[ConvertedType], bool]:
+                                   constants: dict[str, float] | None = None,
+                                   logger: logging.Logger | None = None) -> tuple[list[ConvertedType], bool]:
     """
     Tries to converts a given string attribute to the types given in possible_types.
     First succeeded conversion will be returned
@@ -358,7 +358,7 @@ def convert_from_xml_single_values(xmlstring: str | list[str],
 
 def convert_to_xml_single_values(value: Any | Iterable[Any],
                                  possible_types: tuple[BaseType, ...],
-                                 logger: logging.Logger = None,
+                                 logger: logging.Logger | None = None,
                                  float_format: str = '.10') -> tuple[list[str], bool]:
     """
     Tries to converts a given attributevalue to a string for a xml file according

--- a/masci_tools/util/xml/converters.py
+++ b/masci_tools/util/xml/converters.py
@@ -12,6 +12,7 @@
 """
 Common functions for converting types to and from XML files
 """
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable, List, Tuple, Union, Dict, Any, cast
 try:
@@ -27,12 +28,12 @@ BASE_TYPES = Union[Literal['int'], Literal['switch'], Literal['string'], Literal
 CONVERTED_TYPES = Union[int, float, bool, str]
 
 
-def convert_to_xml(value: Union[Any, List[Any]],
-                   schema_dict: 'fleur_schema.SchemaDict',
+def convert_to_xml(value: Any | list[Any],
+                   schema_dict: fleur_schema.SchemaDict,
                    name: str,
                    text: bool = False,
                    logger: Logger = None,
-                   list_return: bool = False) -> Tuple[Union[str, List[str]], bool]:
+                   list_return: bool = False) -> tuple[str | list[str], bool]:
     """
     Tries to converts a given string to the types specified in the schema_dict.
     First succeeded conversion will be returned
@@ -71,14 +72,14 @@ def convert_to_xml(value: Union[Any, List[Any]],
 
 
 def convert_from_xml(
-    xmlstring: Union[str, List[str]],
-    schema_dict: 'fleur_schema.SchemaDict',
+    xmlstring: str | list[str],
+    schema_dict: fleur_schema.SchemaDict,
     name: str,
     text: bool = False,
-    constants: Dict[str, float] = None,
+    constants: dict[str, float] = None,
     logger: Logger = None,
     list_return: bool = False
-) -> Tuple[Union[CONVERTED_TYPES, List[CONVERTED_TYPES], List[Union[CONVERTED_TYPES, List[CONVERTED_TYPES]]]], bool]:
+) -> tuple[CONVERTED_TYPES | list[CONVERTED_TYPES] | list[CONVERTED_TYPES | list[CONVERTED_TYPES]], bool]:
     """
     Tries to converts a given string to the types specified in the schema_dict.
     First succeeded conversion will be returned
@@ -119,12 +120,12 @@ def convert_from_xml(
 
 
 def convert_from_xml_explicit(
-    xmlstring: Union[str, List[str]],
-    definitions: List['fleur_schema.AttributeType'],
-    constants: Dict[str, float] = None,
+    xmlstring: str | list[str],
+    definitions: list[fleur_schema.AttributeType],
+    constants: dict[str, float] = None,
     logger: Logger = None,
     list_return: bool = False
-) -> Tuple[Union[CONVERTED_TYPES, List[CONVERTED_TYPES], List[Union[CONVERTED_TYPES, List[CONVERTED_TYPES]]]], bool]:
+) -> tuple[CONVERTED_TYPES | list[CONVERTED_TYPES] | list[CONVERTED_TYPES | list[CONVERTED_TYPES]], bool]:
     """
     Tries to converts a given string to the types given in definitions.
     First succeeded conversion will be returned
@@ -145,7 +146,7 @@ def convert_from_xml_explicit(
     if not isinstance(xmlstring, list):
         xmlstring = [xmlstring]
 
-    converted_list: List[Union[CONVERTED_TYPES, List[CONVERTED_TYPES]]] = []
+    converted_list: list[CONVERTED_TYPES | list[CONVERTED_TYPES]] = []
     all_success = True
     for text in xmlstring:
 
@@ -171,7 +172,7 @@ def convert_from_xml_explicit(
             all_success = False
             continue
 
-        types: Tuple[BASE_TYPES, ...] = tuple(definition.base_type for definition in text_definitions)  #type:ignore
+        types: tuple[BASE_TYPES, ...] = tuple(definition.base_type for definition in text_definitions)  #type:ignore
         lengths = {definition.length for definition in text_definitions}
 
         if len(text_definitions) == 1:
@@ -196,11 +197,11 @@ def convert_from_xml_explicit(
     return ret_value, all_success
 
 
-def convert_to_xml_explicit(value: Union[Any, Iterable[Any]],
-                            definitions: List['fleur_schema.AttributeType'],
+def convert_to_xml_explicit(value: Any | Iterable[Any],
+                            definitions: list[fleur_schema.AttributeType],
                             logger: Logger = None,
                             float_format: str = '.10',
-                            list_return: bool = False) -> Tuple[Union[str, List[str]], bool]:
+                            list_return: bool = False) -> tuple[str | list[str], bool]:
     """
     Tries to convert a given list of values to str for a xml file based on the definitions (length and type).
     First succeeded conversion will be returned
@@ -253,7 +254,7 @@ def convert_to_xml_explicit(value: Union[Any, Iterable[Any]],
             all_success = False
             continue
 
-        types: Tuple[BASE_TYPES, ...] = tuple(definition.base_type for definition in text_definitions)  #type:ignore
+        types: tuple[BASE_TYPES, ...] = tuple(definition.base_type for definition in text_definitions)  #type:ignore
 
         converted_text, suc = convert_to_xml_single_values(val, types, logger=logger, float_format=float_format)
         all_success = all_success and suc
@@ -267,10 +268,10 @@ def convert_to_xml_explicit(value: Union[Any, Iterable[Any]],
     return ret_value, all_success
 
 
-def convert_from_xml_single_values(xmlstring: Union[str, List[str]],
-                                   possible_types: Tuple[BASE_TYPES, ...],
-                                   constants: Dict[str, float] = None,
-                                   logger: Logger = None) -> Tuple[List[CONVERTED_TYPES], bool]:
+def convert_from_xml_single_values(xmlstring: str | list[str],
+                                   possible_types: tuple[BASE_TYPES, ...],
+                                   constants: dict[str, float] = None,
+                                   logger: Logger = None) -> tuple[list[CONVERTED_TYPES], bool]:
     """
     Tries to converts a given string attribute to the types given in possible_types.
     First succeeded conversion will be returned
@@ -297,7 +298,7 @@ def convert_from_xml_single_values(xmlstring: Union[str, List[str]],
     all_success = True
     for text in xmlstring:
 
-        exceptions: List[Exception] = []
+        exceptions: list[Exception] = []
         for value_type in possible_types:
             if value_type == 'float':
                 try:
@@ -356,10 +357,10 @@ def convert_from_xml_single_values(xmlstring: Union[str, List[str]],
     return converted_list, all_success
 
 
-def convert_to_xml_single_values(value: Union[Any, Iterable[Any]],
-                                 possible_types: Tuple[BASE_TYPES, ...],
+def convert_to_xml_single_values(value: Any | Iterable[Any],
+                                 possible_types: tuple[BASE_TYPES, ...],
                                  logger: Logger = None,
-                                 float_format: str = '.10') -> Tuple[List[str], bool]:
+                                 float_format: str = '.10') -> tuple[list[str], bool]:
     """
     Tries to converts a given attributevalue to a string for a xml file according
     to the types given in possible_types.
@@ -384,7 +385,7 @@ def convert_to_xml_single_values(value: Union[Any, Iterable[Any]],
 
     converted_value: str
     converted_list = []
-    exceptions: List[Exception] = []
+    exceptions: list[Exception] = []
     all_success = True
     for val in value:
 
@@ -425,7 +426,7 @@ def convert_to_xml_single_values(value: Union[Any, Iterable[Any]],
     return converted_list, all_success
 
 
-def convert_from_fortran_bool(stringbool: Union[str, bool]) -> bool:
+def convert_from_fortran_bool(stringbool: str | bool) -> bool:
     """
     Converts a string in this case ('T', 'F', or 't', 'f') to True or False
 
@@ -449,7 +450,7 @@ def convert_from_fortran_bool(stringbool: Union[str, bool]) -> bool:
     raise TypeError(f"Could not convert: '{stringbool}' to boolean, " 'only accepts str or boolean')
 
 
-def convert_to_fortran_bool(boolean: Union[bool, str]) -> Literal['T', 'F']:
+def convert_to_fortran_bool(boolean: bool | str) -> Literal['T', 'F']:
     """
     Converts a Boolean as string to the format defined in the input
 
@@ -473,7 +474,7 @@ def convert_to_fortran_bool(boolean: Union[bool, str]) -> Literal['T', 'F']:
     raise TypeError('convert_to_fortran_bool accepts only a string or ' f'bool as argument, given {boolean} ')
 
 
-def convert_fleur_lo(loelements: List[etree._Element]) -> str:
+def convert_fleur_lo(loelements: list[etree._Element]) -> str:
     """
     Converts lo xml elements from the inp.xml file into a lo string for the inpgen
     """
@@ -522,7 +523,7 @@ def convert_fleur_electronconfig(econfig_element: etree._Element) -> str:
     return f'{core_config_str} | {valence_config_str}'
 
 
-def convert_str_version_number(version_str: str) -> Tuple[int, int]:
+def convert_str_version_number(version_str: str) -> tuple[int, int]:
     """
     Convert the version number as a integer for easy comparisons
 

--- a/masci_tools/util/xml/converters.py
+++ b/masci_tools/util/xml/converters.py
@@ -14,25 +14,24 @@ Common functions for converting types to and from XML files
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, List, Tuple, Union, Dict, Any, cast
+from typing import Iterable, Any, cast
 try:
-    from typing import Literal
+    from typing import Literal, TypeAlias  #type:ignore
 except ImportError:
-    from typing_extensions import Literal  #type:ignore
+    from typing_extensions import Literal, TypeAlias  #type:ignore
 from lxml import etree
-from logging import Logger
-if TYPE_CHECKING:
-    from masci_tools.io.parsers import fleur_schema
+import logging
+from masci_tools.io.parsers import fleur_schema
 
-BASE_TYPES = Union[Literal['int'], Literal['switch'], Literal['string'], Literal['float'], Literal['float_expression']]
-CONVERTED_TYPES = Union[int, float, bool, str]
+BaseType: TypeAlias = Literal['int', 'switch', 'string', 'float', 'float_expression']
+ConvertedType: TypeAlias = 'int | float | bool | str'
 
 
 def convert_to_xml(value: Any | list[Any],
                    schema_dict: fleur_schema.SchemaDict,
                    name: str,
                    text: bool = False,
-                   logger: Logger = None,
+                   logger: logging.Logger = None,
                    list_return: bool = False) -> tuple[str | list[str], bool]:
     """
     Tries to converts a given string to the types specified in the schema_dict.
@@ -77,9 +76,9 @@ def convert_from_xml(
     name: str,
     text: bool = False,
     constants: dict[str, float] = None,
-    logger: Logger = None,
+    logger: logging.Logger = None,
     list_return: bool = False
-) -> tuple[CONVERTED_TYPES | list[CONVERTED_TYPES] | list[CONVERTED_TYPES | list[CONVERTED_TYPES]], bool]:
+) -> tuple[ConvertedType | list[ConvertedType] | list[ConvertedType | list[ConvertedType]], bool]:
     """
     Tries to converts a given string to the types specified in the schema_dict.
     First succeeded conversion will be returned
@@ -123,9 +122,9 @@ def convert_from_xml_explicit(
     xmlstring: str | list[str],
     definitions: list[fleur_schema.AttributeType],
     constants: dict[str, float] = None,
-    logger: Logger = None,
+    logger: logging.Logger = None,
     list_return: bool = False
-) -> tuple[CONVERTED_TYPES | list[CONVERTED_TYPES] | list[CONVERTED_TYPES | list[CONVERTED_TYPES]], bool]:
+) -> tuple[ConvertedType | list[ConvertedType] | list[ConvertedType | list[ConvertedType]], bool]:
     """
     Tries to converts a given string to the types given in definitions.
     First succeeded conversion will be returned
@@ -146,7 +145,7 @@ def convert_from_xml_explicit(
     if not isinstance(xmlstring, list):
         xmlstring = [xmlstring]
 
-    converted_list: list[CONVERTED_TYPES | list[CONVERTED_TYPES]] = []
+    converted_list: list[ConvertedType | list[ConvertedType]] = []
     all_success = True
     for text in xmlstring:
 
@@ -172,7 +171,7 @@ def convert_from_xml_explicit(
             all_success = False
             continue
 
-        types: tuple[BASE_TYPES, ...] = tuple(definition.base_type for definition in text_definitions)  #type:ignore
+        types: tuple[BaseType, ...] = tuple(definition.base_type for definition in text_definitions)
         lengths = {definition.length for definition in text_definitions}
 
         if len(text_definitions) == 1:
@@ -184,7 +183,7 @@ def convert_from_xml_explicit(
         all_success = all_success and suc
 
         if len(converted_text) == 1 and 'unbounded' not in lengths:
-            converted_text = converted_text[0]  #type:ignore
+            converted_text = converted_text[0]
         elif len(converted_text) == 0 and 'unbounded' not in lengths:
             converted_text = ''  #type:ignore
 
@@ -192,14 +191,14 @@ def convert_from_xml_explicit(
 
     ret_value = converted_list
     if len(converted_list) == 1 and not list_return:
-        ret_value = converted_list[0]  #type:ignore
+        ret_value = converted_list[0]
 
     return ret_value, all_success
 
 
 def convert_to_xml_explicit(value: Any | Iterable[Any],
                             definitions: list[fleur_schema.AttributeType],
-                            logger: Logger = None,
+                            logger: logging.Logger = None,
                             float_format: str = '.10',
                             list_return: bool = False) -> tuple[str | list[str], bool]:
     """
@@ -254,7 +253,7 @@ def convert_to_xml_explicit(value: Any | Iterable[Any],
             all_success = False
             continue
 
-        types: tuple[BASE_TYPES, ...] = tuple(definition.base_type for definition in text_definitions)  #type:ignore
+        types: tuple[BaseType, ...] = tuple(definition.base_type for definition in text_definitions)
 
         converted_text, suc = convert_to_xml_single_values(val, types, logger=logger, float_format=float_format)
         all_success = all_success and suc
@@ -269,9 +268,9 @@ def convert_to_xml_explicit(value: Any | Iterable[Any],
 
 
 def convert_from_xml_single_values(xmlstring: str | list[str],
-                                   possible_types: tuple[BASE_TYPES, ...],
+                                   possible_types: tuple[BaseType, ...],
                                    constants: dict[str, float] = None,
-                                   logger: Logger = None) -> tuple[list[CONVERTED_TYPES], bool]:
+                                   logger: logging.Logger = None) -> tuple[list[ConvertedType], bool]:
     """
     Tries to converts a given string attribute to the types given in possible_types.
     First succeeded conversion will be returned
@@ -293,7 +292,7 @@ def convert_from_xml_single_values(xmlstring: str | list[str],
     if not isinstance(xmlstring, list):
         xmlstring = [xmlstring]
 
-    converted_value: CONVERTED_TYPES
+    converted_value: ConvertedType
     converted_list = []
     all_success = True
     for text in xmlstring:
@@ -358,8 +357,8 @@ def convert_from_xml_single_values(xmlstring: str | list[str],
 
 
 def convert_to_xml_single_values(value: Any | Iterable[Any],
-                                 possible_types: tuple[BASE_TYPES, ...],
-                                 logger: Logger = None,
+                                 possible_types: tuple[BaseType, ...],
+                                 logger: logging.Logger = None,
                                  float_format: str = '.10') -> tuple[list[str], bool]:
     """
     Tries to converts a given attributevalue to a string for a xml file according

--- a/masci_tools/util/xml/xml_getters.py
+++ b/masci_tools/util/xml/xml_getters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/xml/xml_getters.py
+++ b/masci_tools/util/xml/xml_getters.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from masci_tools.io.parsers.fleur_schema import schema_dict_version_dispatch
 from masci_tools.io.common_functions import AtomSiteProperties
+from masci_tools.util.typing import XMLLike
 from lxml import etree
 import warnings
 import numpy as np
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
     from masci_tools.io.parsers import fleur_schema
 
 
-def get_fleur_modes(xmltree: etree._Element | etree._ElementTree,
+def get_fleur_modes(xmltree: XMLLike,
                     schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                     logger: Logger = None) -> dict[str, Any]:
     """
@@ -168,7 +169,7 @@ def get_fleur_modes(xmltree: etree._Element | etree._ElementTree,
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def get_nkpts(xmltree: etree._Element | etree._ElementTree,
+def get_nkpts(xmltree: XMLLike,
               schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
               logger: Logger = None) -> int:
     """
@@ -225,7 +226,7 @@ def get_nkpts(xmltree: etree._Element | etree._ElementTree,
 
 
 @get_nkpts.register(max_version='0.31')
-def get_nkpts_max4(xmltree: etree._Element | etree._ElementTree,
+def get_nkpts_max4(xmltree: XMLLike,
                    schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                    logger: Logger = None) -> int:
     """
@@ -302,7 +303,7 @@ def get_nkpts_max4(xmltree: etree._Element | etree._ElementTree,
     return nkpts
 
 
-def get_cell(xmltree: etree._Element | etree._ElementTree,
+def get_cell(xmltree: XMLLike,
              schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
              logger: Logger = None,
              convert_to_angstroem: bool = True) -> tuple[np.ndarray, tuple[bool, bool, bool]]:
@@ -388,7 +389,7 @@ def get_cell(xmltree: etree._Element | etree._ElementTree,
     return cell, pbc
 
 
-def _get_species_info(xmltree: etree._Element | etree._ElementTree,
+def _get_species_info(xmltree: XMLLike,
                       schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                       logger: Logger = None) -> dict[str, dict[str, str]]:
     """
@@ -460,7 +461,7 @@ def _get_species_info(xmltree: etree._Element | etree._ElementTree,
     return species_info
 
 
-def get_parameter_data(xmltree: etree._Element | etree._ElementTree,
+def get_parameter_data(xmltree: XMLLike,
                        schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                        inpgen_ready: bool = True,
                        write_ids: bool = True,
@@ -655,7 +656,7 @@ def get_parameter_data(xmltree: etree._Element | etree._ElementTree,
     return parameters
 
 
-def get_structure_data(xmltree: etree._Element | etree._ElementTree,
+def get_structure_data(xmltree: XMLLike,
                        schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                        include_relaxations: bool = True,
                        site_namedtuple: bool = True,
@@ -851,7 +852,7 @@ def get_structure_data(xmltree: etree._Element | etree._ElementTree,
 
 @schema_dict_version_dispatch(output_schema=False)
 def get_kpoints_data(
-    xmltree: etree._Element | etree._ElementTree,
+    xmltree: XMLLike,
     schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
     name: str = None,
     index: int = None,
@@ -969,7 +970,7 @@ def get_kpoints_data(
 
 @get_kpoints_data.register(max_version='0.31')
 def get_kpoints_data_max4(
-        xmltree: etree._Element | etree._ElementTree,
+        xmltree: XMLLike,
         schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
         logger: Logger = None,
         convert_to_angstroem: bool = True,
@@ -1049,7 +1050,7 @@ def get_kpoints_data_max4(
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def get_relaxation_information(xmltree: etree._Element | etree._ElementTree,
+def get_relaxation_information(xmltree: XMLLike,
                                schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                                logger: Logger = None) -> dict[str, Any]:
     """
@@ -1106,7 +1107,7 @@ def get_relaxation_information(xmltree: etree._Element | etree._ElementTree,
 
 
 @get_relaxation_information.register(max_version='0.28')
-def get_relaxation_information_pre029(xmltree: etree._Element | etree._ElementTree,
+def get_relaxation_information_pre029(xmltree: XMLLike,
                                       schema_dict: (fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict),
                                       logger: Logger = None) -> None:
     """
@@ -1126,7 +1127,7 @@ def get_relaxation_information_pre029(xmltree: etree._Element | etree._ElementTr
         f"'get_relaxation_information' is not implemented for inputs of version '{schema_dict['inp_version']}'")
 
 
-def get_symmetry_information(xmltree: etree._Element | etree._ElementTree,
+def get_symmetry_information(xmltree: XMLLike,
                              schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                              logger: Logger = None) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """

--- a/masci_tools/util/xml/xml_getters.py
+++ b/masci_tools/util/xml/xml_getters.py
@@ -22,10 +22,8 @@ from lxml import etree
 import warnings
 import numpy as np
 from logging import Logger
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from masci_tools.io.parsers import fleur_schema
+from typing import Any
+from masci_tools.io.parsers import fleur_schema
 
 
 def get_fleur_modes(xmltree: XMLLike,

--- a/masci_tools/util/xml/xml_getters.py
+++ b/masci_tools/util/xml/xml_getters.py
@@ -18,12 +18,13 @@ from __future__ import annotations
 from masci_tools.io.parsers.fleur_schema import schema_dict_version_dispatch
 from masci_tools.io.common_functions import AtomSiteProperties
 from masci_tools.util.typing import XMLLike
+from masci_tools.io.parsers import fleur_schema
+
 from lxml import etree
 import warnings
 import numpy as np
 from logging import Logger
 from typing import Any
-from masci_tools.io.parsers import fleur_schema
 
 
 def get_fleur_modes(xmltree: XMLLike,

--- a/masci_tools/util/xml/xml_getters.py
+++ b/masci_tools/util/xml/xml_getters.py
@@ -28,7 +28,7 @@ from masci_tools.io.parsers import fleur_schema
 
 def get_fleur_modes(xmltree: XMLLike,
                     schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-                    logger: Logger = None) -> dict[str, Any]:
+                    logger: Logger | None = None) -> dict[str, Any]:
     """
     Determine the calculation modes of fleur for the given xml file. Calculation modes
     are things that change the produced files or output in the out.xml files
@@ -169,7 +169,7 @@ def get_fleur_modes(xmltree: XMLLike,
 @schema_dict_version_dispatch(output_schema=False)
 def get_nkpts(xmltree: XMLLike,
               schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-              logger: Logger = None) -> int:
+              logger: Logger | None = None) -> int:
     """
     Get the number of kpoints that will be used in the calculation specified in the given
     fleur XMl file.
@@ -226,7 +226,7 @@ def get_nkpts(xmltree: XMLLike,
 @get_nkpts.register(max_version='0.31')
 def get_nkpts_max4(xmltree: XMLLike,
                    schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-                   logger: Logger = None) -> int:
+                   logger: Logger | None = None) -> int:
     """
     Get the number of kpoints that will be used in the calculation specified in the given
     fleur XMl file. Version specific for Max4 versions or older
@@ -303,7 +303,7 @@ def get_nkpts_max4(xmltree: XMLLike,
 
 def get_cell(xmltree: XMLLike,
              schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-             logger: Logger = None,
+             logger: Logger | None = None,
              convert_to_angstroem: bool = True) -> tuple[np.ndarray, tuple[bool, bool, bool]]:
     """
     Get the Bravais matrix from the given fleur xml file. In addition a list
@@ -389,7 +389,7 @@ def get_cell(xmltree: XMLLike,
 
 def _get_species_info(xmltree: XMLLike,
                       schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-                      logger: Logger = None) -> dict[str, dict[str, str]]:
+                      logger: Logger | None = None) -> dict[str, dict[str, str]]:
     """
     Gets the species identifiers and information.
     Used to keep species information consistent between
@@ -464,7 +464,7 @@ def get_parameter_data(xmltree: XMLLike,
                        inpgen_ready: bool = True,
                        write_ids: bool = True,
                        extract_econfig: bool = False,
-                       logger: Logger = None) -> dict[str, Any]:
+                       logger: Logger | None = None) -> dict[str, Any]:
     """
     This routine returns an python dictionary produced from the inp.xml
     file, which contains all the parameters needed to setup a new inp.xml from a inpgen
@@ -654,13 +654,14 @@ def get_parameter_data(xmltree: XMLLike,
     return parameters
 
 
-def get_structure_data(xmltree: XMLLike,
-                       schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-                       include_relaxations: bool = True,
-                       site_namedtuple: bool = True,
-                       convert_to_angstroem: bool = True,
-                       normalize_kind_name: bool = True,
-                       logger: Logger = None) -> tuple[list[AtomSiteProperties], np.ndarray, tuple[bool, bool, bool]]:
+def get_structure_data(
+        xmltree: XMLLike,
+        schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
+        include_relaxations: bool = True,
+        site_namedtuple: bool = True,
+        convert_to_angstroem: bool = True,
+        normalize_kind_name: bool = True,
+        logger: Logger | None = None) -> tuple[list[AtomSiteProperties], np.ndarray, tuple[bool, bool, bool]]:
     """
     Get the structure defined in the given fleur xml file.
 
@@ -852,10 +853,10 @@ def get_structure_data(xmltree: XMLLike,
 def get_kpoints_data(
     xmltree: XMLLike,
     schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-    name: str = None,
-    index: int = None,
+    name: str | None = None,
+    index: int | None = None,
     only_used: bool = False,
-    logger: Logger = None,
+    logger: Logger | None = None,
     convert_to_angstroem: bool = True
 ) -> tuple[list[list[float]] | dict[str, list[list[float]]], list[float] | dict[str, list[float]], np.ndarray, tuple[
         bool, bool, bool]]:
@@ -970,7 +971,7 @@ def get_kpoints_data(
 def get_kpoints_data_max4(
         xmltree: XMLLike,
         schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-        logger: Logger = None,
+        logger: Logger | None = None,
         convert_to_angstroem: bool = True,
         only_used: bool = False) -> tuple[list[list[float]], list[float], np.ndarray, tuple[bool, bool, bool]]:
     """
@@ -1050,7 +1051,7 @@ def get_kpoints_data_max4(
 @schema_dict_version_dispatch(output_schema=False)
 def get_relaxation_information(xmltree: XMLLike,
                                schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-                               logger: Logger = None) -> dict[str, Any]:
+                               logger: Logger | None = None) -> dict[str, Any]:
     """
     Get the relaxation information from the given fleur XML file. This includes the current
     displacements, energy and posforce evolution
@@ -1107,7 +1108,7 @@ def get_relaxation_information(xmltree: XMLLike,
 @get_relaxation_information.register(max_version='0.28')
 def get_relaxation_information_pre029(xmltree: XMLLike,
                                       schema_dict: (fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict),
-                                      logger: Logger = None) -> None:
+                                      logger: Logger | None = None) -> None:
     """
     Get the relaxation information from the given fleur XML file. This includes the current
     displacements, energy and posforce evolution
@@ -1127,7 +1128,7 @@ def get_relaxation_information_pre029(xmltree: XMLLike,
 
 def get_symmetry_information(xmltree: XMLLike,
                              schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
-                             logger: Logger = None) -> tuple[list[np.ndarray], list[np.ndarray]]:
+                             logger: Logger | None = None) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """
     Get the symmetry information from the given fleur XML file. This includes the
     rotation matrices and shifts defined in the ``symmetryOperations`` tag.

--- a/masci_tools/util/xml/xml_getters.py
+++ b/masci_tools/util/xml/xml_getters.py
@@ -13,21 +13,23 @@
 This module provides functions to extract distinct parts of the fleur xml files
 for easy versioning and reuse
 """
+from __future__ import annotations
+
 from masci_tools.io.parsers.fleur_schema import schema_dict_version_dispatch
 from masci_tools.io.common_functions import AtomSiteProperties
 from lxml import etree
 import warnings
 import numpy as np
 from logging import Logger
-from typing import TYPE_CHECKING, Iterable, List, Tuple, Union, Dict, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from masci_tools.io.parsers import fleur_schema
 
 
-def get_fleur_modes(xmltree: Union[etree._Element, etree._ElementTree],
-                    schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
-                    logger: Logger = None) -> Dict[str, Any]:
+def get_fleur_modes(xmltree: etree._Element | etree._ElementTree,
+                    schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
+                    logger: Logger = None) -> dict[str, Any]:
     """
     Determine the calculation modes of fleur for the given xml file. Calculation modes
     are things that change the produced files or output in the out.xml files
@@ -166,8 +168,8 @@ def get_fleur_modes(xmltree: Union[etree._Element, etree._ElementTree],
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def get_nkpts(xmltree: Union[etree._Element, etree._ElementTree],
-              schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
+def get_nkpts(xmltree: etree._Element | etree._ElementTree,
+              schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
               logger: Logger = None) -> int:
     """
     Get the number of kpoints that will be used in the calculation specified in the given
@@ -223,8 +225,8 @@ def get_nkpts(xmltree: Union[etree._Element, etree._ElementTree],
 
 
 @get_nkpts.register(max_version='0.31')
-def get_nkpts_max4(xmltree: Union[etree._Element, etree._ElementTree],
-                   schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
+def get_nkpts_max4(xmltree: etree._Element | etree._ElementTree,
+                   schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                    logger: Logger = None) -> int:
     """
     Get the number of kpoints that will be used in the calculation specified in the given
@@ -262,7 +264,7 @@ def get_nkpts_max4(xmltree: Union[etree._Element, etree._ElementTree],
                 alt_kpt_set = kpt_set
                 break
 
-    kpt_tag: List[etree._Element] = []
+    kpt_tag: list[etree._Element] = []
     if alt_kpt_set is not None:
         kpt_tag = eval_simple_xpath(alt_kpt_set, schema_dict, 'kPointList', list_return=True, logger=logger)
         if len(kpt_tag) == 0:
@@ -300,10 +302,10 @@ def get_nkpts_max4(xmltree: Union[etree._Element, etree._ElementTree],
     return nkpts
 
 
-def get_cell(xmltree: Union[etree._Element, etree._ElementTree],
-             schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
+def get_cell(xmltree: etree._Element | etree._ElementTree,
+             schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
              logger: Logger = None,
-             convert_to_angstroem: bool = True) -> Tuple[np.ndarray, Tuple[bool, bool, bool]]:
+             convert_to_angstroem: bool = True) -> tuple[np.ndarray, tuple[bool, bool, bool]]:
     """
     Get the Bravais matrix from the given fleur xml file. In addition a list
     determining in, which directions there are periodic boundary conditions
@@ -334,8 +336,8 @@ def get_cell(xmltree: Union[etree._Element, etree._ElementTree],
         root = xmltree
     constants = read_constants(root, schema_dict, logger=logger)
 
-    cell: Optional[np.ndarray] = None
-    lattice_tag: Optional[etree._Element] = None
+    cell: np.ndarray | None = None
+    lattice_tag: etree._Element | None = None
     if tag_exists(root, schema_dict, 'bulkLattice', logger=logger):
         lattice_tag = eval_simple_xpath(root, schema_dict, 'bulkLattice', logger=logger)  #type: ignore
         pbc = (True, True, True)
@@ -386,9 +388,9 @@ def get_cell(xmltree: Union[etree._Element, etree._ElementTree],
     return cell, pbc
 
 
-def _get_species_info(xmltree: Union[etree._Element, etree._ElementTree],
-                      schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
-                      logger: Logger = None) -> Dict[str, Dict[str, str]]:
+def _get_species_info(xmltree: etree._Element | etree._ElementTree,
+                      schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
+                      logger: Logger = None) -> dict[str, dict[str, str]]:
     """
     Gets the species identifiers and information.
     Used to keep species information consistent between
@@ -432,7 +434,7 @@ def _get_species_info(xmltree: Union[etree._Element, etree._ElementTree],
         raise ValueError(
             f'Failed to read in species names and elements. Got {len(names)} names and {len(elements)} elements')
 
-    species_info: Dict[str, Dict[str, str]] = {}
+    species_info: dict[str, dict[str, str]] = {}
     for name, element in zip(names, elements):
         #Check if the species name has a numerical id at the end (separated by - or .)
         #And add all of them first
@@ -458,12 +460,12 @@ def _get_species_info(xmltree: Union[etree._Element, etree._ElementTree],
     return species_info
 
 
-def get_parameter_data(xmltree: Union[etree._Element, etree._ElementTree],
-                       schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
+def get_parameter_data(xmltree: etree._Element | etree._ElementTree,
+                       schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                        inpgen_ready: bool = True,
                        write_ids: bool = True,
                        extract_econfig: bool = False,
-                       logger: Logger = None) -> Dict[str, Any]:
+                       logger: Logger = None) -> dict[str, Any]:
     """
     This routine returns an python dictionary produced from the inp.xml
     file, which contains all the parameters needed to setup a new inp.xml from a inpgen
@@ -653,13 +655,13 @@ def get_parameter_data(xmltree: Union[etree._Element, etree._ElementTree],
     return parameters
 
 
-def get_structure_data(xmltree: Union[etree._Element, etree._ElementTree],
-                       schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
+def get_structure_data(xmltree: etree._Element | etree._ElementTree,
+                       schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
                        include_relaxations: bool = True,
                        site_namedtuple: bool = True,
                        convert_to_angstroem: bool = True,
                        normalize_kind_name: bool = True,
-                       logger: Logger = None) -> Tuple[List[AtomSiteProperties], np.ndarray, Tuple[bool, bool, bool]]:
+                       logger: Logger = None) -> tuple[list[AtomSiteProperties], np.ndarray, tuple[bool, bool, bool]]:
     """
     Get the structure defined in the given fleur xml file.
 
@@ -722,7 +724,7 @@ def get_structure_data(xmltree: Union[etree._Element, etree._ElementTree],
 
     species_info = _get_species_info(xmltree, schema_dict, logger=None)
 
-    atom_data: List[AtomSiteProperties] = []
+    atom_data: list[AtomSiteProperties] = []
     atom_groups = eval_simple_xpath(root, schema_dict, 'atomGroup', list_return=True, logger=logger)
 
     #Read relaxation information if available
@@ -745,7 +747,7 @@ def get_structure_data(xmltree: Union[etree._Element, etree._ElementTree],
 
     for indx, group in enumerate(atom_groups):
 
-        atom_positions: List[List[float]] = []
+        atom_positions: list[list[float]] = []
 
         absolute_positions = evaluate_text(group,
                                            schema_dict,
@@ -849,15 +851,15 @@ def get_structure_data(xmltree: Union[etree._Element, etree._ElementTree],
 
 @schema_dict_version_dispatch(output_schema=False)
 def get_kpoints_data(
-    xmltree: Union[etree._Element, etree._ElementTree],
-    schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
+    xmltree: etree._Element | etree._ElementTree,
+    schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
     name: str = None,
     index: int = None,
     only_used: bool = False,
     logger: Logger = None,
     convert_to_angstroem: bool = True
-) -> Tuple[Union[List[List[float]], Dict[str, List[List[float]]]], Union[List[float], Dict[str, List[float]]],
-           np.ndarray, Tuple[bool, bool, bool]]:
+) -> tuple[list[list[float]] | dict[str, list[list[float]]], list[float] | dict[str, list[float]], np.ndarray, tuple[
+        bool, bool, bool]]:
     """
     Get the kpoint sets defined in the given fleur xml file.
 
@@ -967,11 +969,11 @@ def get_kpoints_data(
 
 @get_kpoints_data.register(max_version='0.31')
 def get_kpoints_data_max4(
-        xmltree: Union[etree._Element, etree._ElementTree],
-        schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
+        xmltree: etree._Element | etree._ElementTree,
+        schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
         logger: Logger = None,
         convert_to_angstroem: bool = True,
-        only_used: bool = False) -> Tuple[List[List[float]], List[float], np.ndarray, Tuple[bool, bool, bool]]:
+        only_used: bool = False) -> tuple[list[list[float]], list[float], np.ndarray, tuple[bool, bool, bool]]:
     """
     Get the kpoint sets defined in the given fleur xml file.
 
@@ -1047,9 +1049,9 @@ def get_kpoints_data_max4(
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def get_relaxation_information(xmltree: Union[etree._Element, etree._ElementTree],
-                               schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
-                               logger: Logger = None) -> Dict[str, Any]:
+def get_relaxation_information(xmltree: etree._Element | etree._ElementTree,
+                               schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
+                               logger: Logger = None) -> dict[str, Any]:
     """
     Get the relaxation information from the given fleur XML file. This includes the current
     displacements, energy and posforce evolution
@@ -1104,9 +1106,8 @@ def get_relaxation_information(xmltree: Union[etree._Element, etree._ElementTree
 
 
 @get_relaxation_information.register(max_version='0.28')
-def get_relaxation_information_pre029(xmltree: Union[etree._Element, etree._ElementTree],
-                                      schema_dict: Union['fleur_schema.InputSchemaDict',
-                                                         'fleur_schema.OutputSchemaDict'],
+def get_relaxation_information_pre029(xmltree: etree._Element | etree._ElementTree,
+                                      schema_dict: (fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict),
                                       logger: Logger = None) -> None:
     """
     Get the relaxation information from the given fleur XML file. This includes the current
@@ -1125,9 +1126,9 @@ def get_relaxation_information_pre029(xmltree: Union[etree._Element, etree._Elem
         f"'get_relaxation_information' is not implemented for inputs of version '{schema_dict['inp_version']}'")
 
 
-def get_symmetry_information(xmltree: Union[etree._Element, etree._ElementTree],
-                             schema_dict: Union['fleur_schema.InputSchemaDict', 'fleur_schema.OutputSchemaDict'],
-                             logger: Logger = None) -> Tuple[List[np.ndarray], List[np.ndarray]]:
+def get_symmetry_information(xmltree: etree._Element | etree._ElementTree,
+                             schema_dict: fleur_schema.InputSchemaDict | fleur_schema.OutputSchemaDict,
+                             logger: Logger = None) -> tuple[list[np.ndarray], list[np.ndarray]]:
     """
     Get the symmetry information from the given fleur XML file. This includes the
     rotation matrices and shifts defined in the ``symmetryOperations`` tag.

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -118,9 +118,7 @@ def xml_delete_att(xmltree: XMLLike,
     return xmltree
 
 
-def xml_delete_tag(xmltree: XMLLike,
-                   xpath: XPathLike,
-                   occurrences: int | Iterable[int] | None = None) -> XMLLike:
+def xml_delete_tag(xmltree: XMLLike, xpath: XPathLike, occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Deletes a xml tag in an xmletree.
 
@@ -329,12 +327,11 @@ def xml_create_tag(xmltree: XMLLike,
     return xmltree
 
 
-def xml_set_attrib_value_no_create(
-        xmltree: XMLLike,
-        xpath: XPathLike,
-        attributename: str,
-        attribv: Any,
-        occurrences: int | Iterable[int] | None = None) -> XMLLike:
+def xml_set_attrib_value_no_create(xmltree: XMLLike,
+                                   xpath: XPathLike,
+                                   attributename: str,
+                                   attribv: Any,
+                                   occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Sets an attribute in a xmltree to a given value. By default the attribute will be set
     on all nodes returned for the specified xpath.

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -29,7 +29,7 @@ from masci_tools.util.xml.xpathbuilder import XPathBuilder
 def xml_replace_tag(xmltree: XMLLike,
                     xpath: XPathLike,
                     newelement: etree._Element,
-                    occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
+                    occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     replaces xml tags by another tag on an xmletree in place
 
@@ -78,7 +78,7 @@ def xml_replace_tag(xmltree: XMLLike,
 def xml_delete_att(xmltree: XMLLike,
                    xpath: XPathLike,
                    attrib: str,
-                   occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
+                   occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Deletes an xml attribute in an xmletree.
 
@@ -120,7 +120,7 @@ def xml_delete_att(xmltree: XMLLike,
 
 def xml_delete_tag(xmltree: XMLLike,
                    xpath: XPathLike,
-                   occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
+                   occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Deletes a xml tag in an xmletree.
 
@@ -204,7 +204,7 @@ def xml_create_tag(xmltree: XMLLike,
                    tag_order: list[str] | None = None,
                    occurrences: int | Iterable[int] | None = None,
                    correct_order: bool = True,
-                   several: bool = True) -> etree._Element | etree._ElementTree:
+                   several: bool = True) -> XMLLike:
     """
     This method evaluates an xpath expression and creates a tag in a xmltree under the
     returned nodes.
@@ -334,7 +334,7 @@ def xml_set_attrib_value_no_create(
         xpath: XPathLike,
         attributename: str,
         attribv: Any,
-        occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
+        occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Sets an attribute in a xmltree to a given value. By default the attribute will be set
     on all nodes returned for the specified xpath.
@@ -389,7 +389,7 @@ def xml_set_attrib_value_no_create(
 def xml_set_text_no_create(xmltree: XMLLike,
                            xpath: XPathLike,
                            text: Any,
-                           occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
+                           occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Sets the text of a tag in a xmltree to a given value.
     By default the text will be set on all nodes returned for the specified xpath.

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -329,11 +329,12 @@ def xml_create_tag(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def xml_set_attrib_value_no_create(xmltree: etree._Element | etree._ElementTree,
-                                   xpath: XPathLike,
-                                   attributename: str,
-                                   attribv: Any,
-                                   occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
+def xml_set_attrib_value_no_create(
+        xmltree: etree._Element | etree._ElementTree,
+        xpath: XPathLike,
+        attributename: str,
+        attribv: Any,
+        occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
     """
     Sets an attribute in a xmltree to a given value. By default the attribute will be set
     on all nodes returned for the specified xpath.

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -15,7 +15,9 @@ have the ability to create missing tags on the fly. This functionality is added 
 in :py:mod:`~masci_tools.util.xml.xml_setters_xpaths` since we need the schema dictionary
 to do these operations robustly
 """
-from typing import Iterable, Union, List, Any, cast
+from __future__ import annotations
+
+from typing import Iterable, Any, cast
 from lxml import etree
 import warnings
 
@@ -24,10 +26,10 @@ from masci_tools.util.xml.common_functions import eval_xpath
 from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
 
-def xml_replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
+def xml_replace_tag(xmltree: etree._Element | etree._ElementTree,
                     xpath: XPathLike,
                     newelement: etree._Element,
-                    occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
+                    occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
     """
     replaces xml tags by another tag on an xmletree in place
 
@@ -47,7 +49,7 @@ def xml_replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
     else:
         root = xmltree
 
-    nodes: List[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
 
     if len(nodes) == 0:
         warnings.warn(
@@ -73,10 +75,10 @@ def xml_replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def xml_delete_att(xmltree: Union[etree._Element, etree._ElementTree],
+def xml_delete_att(xmltree: etree._Element | etree._ElementTree,
                    xpath: XPathLike,
                    attrib: str,
-                   occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
+                   occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
     """
     Deletes an xml attribute in an xmletree.
 
@@ -95,7 +97,7 @@ def xml_delete_att(xmltree: Union[etree._Element, etree._ElementTree],
     else:
         root = xmltree
 
-    nodes: List[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
 
     if len(nodes) == 0:
         warnings.warn(
@@ -116,9 +118,9 @@ def xml_delete_att(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def xml_delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
+def xml_delete_tag(xmltree: etree._Element | etree._ElementTree,
                    xpath: XPathLike,
-                   occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
+                   occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
     """
     Deletes a xml tag in an xmletree.
 
@@ -136,7 +138,7 @@ def xml_delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
     else:
         root = xmltree
 
-    nodes: List[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
 
     if len(nodes) == 0:
         warnings.warn(
@@ -160,7 +162,7 @@ def xml_delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def _reorder_tags(node: etree._Element, tag_order: List[str]) -> etree._Element:
+def _reorder_tags(node: etree._Element, tag_order: list[str]) -> etree._Element:
     """
     Order the children of the given node into the given order
 
@@ -195,14 +197,14 @@ def _reorder_tags(node: etree._Element, tag_order: List[str]) -> etree._Element:
     return ordered_node
 
 
-def xml_create_tag(xmltree: Union[etree._Element, etree._ElementTree],
+def xml_create_tag(xmltree: etree._Element | etree._ElementTree,
                    xpath: XPathLike,
-                   element: Union[str, etree._Element],
+                   element: str | etree._Element,
                    place_index: int = None,
-                   tag_order: List[str] = None,
-                   occurrences: Union[int, Iterable[int]] = None,
+                   tag_order: list[str] = None,
+                   occurrences: int | Iterable[int] | None = None,
                    correct_order: bool = True,
-                   several: bool = True) -> Union[etree._Element, etree._ElementTree]:
+                   several: bool = True) -> etree._Element | etree._ElementTree:
     """
     This method evaluates an xpath expression and creates a tag in a xmltree under the
     returned nodes.
@@ -240,7 +242,7 @@ def xml_create_tag(xmltree: Union[etree._Element, etree._ElementTree],
     else:
         element_name = element.tag  #type:ignore
 
-    parent_nodes: List[etree._Element] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+    parent_nodes: list[etree._Element] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
 
     if len(parent_nodes) == 0:
         raise ValueError(f"Could not create tag '{element_name}' because atleast one subtag is missing. "
@@ -327,12 +329,11 @@ def xml_create_tag(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def xml_set_attrib_value_no_create(
-        xmltree: Union[etree._Element, etree._ElementTree],
-        xpath: XPathLike,
-        attributename: str,
-        attribv: Any,
-        occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
+def xml_set_attrib_value_no_create(xmltree: etree._Element | etree._ElementTree,
+                                   xpath: XPathLike,
+                                   attributename: str,
+                                   attribv: Any,
+                                   occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
     """
     Sets an attribute in a xmltree to a given value. By default the attribute will be set
     on all nodes returned for the specified xpath.
@@ -354,7 +355,7 @@ def xml_set_attrib_value_no_create(
     else:
         root = xmltree
 
-    nodes: List[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
 
     if len(nodes) == 0:
         warnings.warn(
@@ -384,10 +385,10 @@ def xml_set_attrib_value_no_create(
     return xmltree
 
 
-def xml_set_text_no_create(xmltree: Union[etree._Element, etree._ElementTree],
+def xml_set_text_no_create(xmltree: etree._Element | etree._ElementTree,
                            xpath: XPathLike,
                            text: Any,
-                           occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
+                           occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
     """
     Sets the text of a tag in a xmltree to a given value.
     By default the text will be set on all nodes returned for the specified xpath.
@@ -408,7 +409,7 @@ def xml_set_text_no_create(xmltree: Union[etree._Element, etree._ElementTree],
     else:
         root = xmltree
 
-    nodes: List[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
 
     if len(nodes) == 0:
         warnings.warn(

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -200,8 +200,8 @@ def _reorder_tags(node: etree._Element, tag_order: list[str]) -> etree._Element:
 def xml_create_tag(xmltree: XMLLike,
                    xpath: XPathLike,
                    element: str | etree._Element,
-                   place_index: int = None,
-                   tag_order: list[str] = None,
+                   place_index: int | None = None,
+                   tag_order: list[str] | None = None,
                    occurrences: int | Iterable[int] | None = None,
                    correct_order: bool = True,
                    several: bool = True) -> etree._Element | etree._ElementTree:

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -21,12 +21,12 @@ from typing import Iterable, Any, cast
 from lxml import etree
 import warnings
 
-from masci_tools.util.typing import XPathLike
+from masci_tools.util.typing import XPathLike, XMLLike
 from masci_tools.util.xml.common_functions import eval_xpath
 from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
 
-def xml_replace_tag(xmltree: etree._Element | etree._ElementTree,
+def xml_replace_tag(xmltree: XMLLike,
                     xpath: XPathLike,
                     newelement: etree._Element,
                     occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
@@ -45,7 +45,7 @@ def xml_replace_tag(xmltree: etree._Element | etree._ElementTree,
     from masci_tools.io.common_functions import is_sequence
 
     if not etree.iselement(xmltree):
-        root = xmltree.getroot()  #type:ignore
+        root = xmltree.getroot()
     else:
         root = xmltree
 
@@ -75,7 +75,7 @@ def xml_replace_tag(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def xml_delete_att(xmltree: etree._Element | etree._ElementTree,
+def xml_delete_att(xmltree: XMLLike,
                    xpath: XPathLike,
                    attrib: str,
                    occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
@@ -93,7 +93,7 @@ def xml_delete_att(xmltree: etree._Element | etree._ElementTree,
     from masci_tools.io.common_functions import is_sequence
 
     if not etree.iselement(xmltree):
-        root = xmltree.getroot()  #type:ignore
+        root = xmltree.getroot()
     else:
         root = xmltree
 
@@ -118,7 +118,7 @@ def xml_delete_att(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def xml_delete_tag(xmltree: etree._Element | etree._ElementTree,
+def xml_delete_tag(xmltree: XMLLike,
                    xpath: XPathLike,
                    occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
     """
@@ -134,7 +134,7 @@ def xml_delete_tag(xmltree: etree._Element | etree._ElementTree,
     from masci_tools.io.common_functions import is_sequence
 
     if not etree.iselement(xmltree):
-        root = xmltree.getroot()  #type:ignore
+        root = xmltree.getroot()
     else:
         root = xmltree
 
@@ -197,7 +197,7 @@ def _reorder_tags(node: etree._Element, tag_order: list[str]) -> etree._Element:
     return ordered_node
 
 
-def xml_create_tag(xmltree: etree._Element | etree._ElementTree,
+def xml_create_tag(xmltree: XMLLike,
                    xpath: XPathLike,
                    element: str | etree._Element,
                    place_index: int = None,
@@ -330,7 +330,7 @@ def xml_create_tag(xmltree: etree._Element | etree._ElementTree,
 
 
 def xml_set_attrib_value_no_create(
-        xmltree: etree._Element | etree._ElementTree,
+        xmltree: XMLLike,
         xpath: XPathLike,
         attributename: str,
         attribv: Any,
@@ -352,7 +352,7 @@ def xml_set_attrib_value_no_create(
     from masci_tools.io.common_functions import is_sequence
 
     if not etree.iselement(xmltree):
-        root = xmltree.getroot()  #type:ignore
+        root = xmltree.getroot()
     else:
         root = xmltree
 
@@ -386,7 +386,7 @@ def xml_set_attrib_value_no_create(
     return xmltree
 
 
-def xml_set_text_no_create(xmltree: etree._Element | etree._ElementTree,
+def xml_set_text_no_create(xmltree: XMLLike,
                            xpath: XPathLike,
                            text: Any,
                            occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
@@ -406,7 +406,7 @@ def xml_set_text_no_create(xmltree: etree._Element | etree._ElementTree,
     from masci_tools.io.common_functions import is_sequence
 
     if not etree.iselement(xmltree):
-        root = xmltree.getroot()  #type:ignore
+        root = xmltree.getroot()
     else:
         root = xmltree
 

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -13,8 +13,10 @@
 Functions for modifying the xml input file of Fleur utilizing the schema dict
 and as little knowledge of the concrete xpaths as possible
 """
+from __future__ import annotations
+
 import warnings
-from typing import Any, Iterable, List, Union, Dict, Tuple
+from typing import Any, Iterable
 try:
     from typing import Literal
 except ImportError:
@@ -28,14 +30,14 @@ from masci_tools.io.parsers import fleur_schema
 from lxml import etree
 
 
-def create_tag(xmltree: Union[etree._Element, etree._ElementTree],
-               schema_dict: 'fleur_schema.SchemaDict',
-               tag: Union[str, etree._Element],
+def create_tag(xmltree: etree._Element | etree._ElementTree,
+               schema_dict: fleur_schema.SchemaDict,
+               tag: str | etree._Element,
                complex_xpath: XPathLike = None,
                filters: FilterType = None,
                create_parents: bool = False,
-               occurrences: Union[int, Iterable[int]] = None,
-               **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+               occurrences: int | Iterable[int] | None = None,
+               **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     This method creates a tag with a uniquely identified xpath under the nodes of its parent.
     If there are no nodes evaluated the subtags can be created with `create_parents=True`
@@ -91,13 +93,13 @@ def create_tag(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
-               schema_dict: 'fleur_schema.SchemaDict',
+def delete_tag(xmltree: etree._Element | etree._ElementTree,
+               schema_dict: fleur_schema.SchemaDict,
                tag_name: str,
                complex_xpath: XPathLike = None,
                filters: FilterType = None,
-               occurrences: Union[int, Iterable[int]] = None,
-               **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+               occurrences: int | Iterable[int] | None = None,
+               **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     This method deletes a tag with a uniquely identified xpath.
 
@@ -134,13 +136,13 @@ def delete_tag(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_delete_tag(xmltree, complex_xpath, occurrences=occurrences)
 
 
-def delete_att(xmltree: Union[etree._Element, etree._ElementTree],
-               schema_dict: 'fleur_schema.SchemaDict',
+def delete_att(xmltree: etree._Element | etree._ElementTree,
+               schema_dict: fleur_schema.SchemaDict,
                attrib_name: str,
                complex_xpath: XPathLike = None,
                filters: FilterType = None,
-               occurrences: Union[int, Iterable[int]] = None,
-               **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+               occurrences: int | Iterable[int] | None = None,
+               **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     This method deletes a attribute with a uniquely identified xpath.
 
@@ -181,14 +183,14 @@ def delete_att(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_delete_att(xmltree, complex_xpath, attrib_name, occurrences=occurrences)
 
 
-def replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
-                schema_dict: 'fleur_schema.SchemaDict',
+def replace_tag(xmltree: etree._Element | etree._ElementTree,
+                schema_dict: fleur_schema.SchemaDict,
                 tag_name: str,
                 newelement: etree._Element,
                 complex_xpath: XPathLike = None,
                 filters: FilterType = None,
-                occurrences: Union[int, Iterable[int]] = None,
-                **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+                occurrences: int | Iterable[int] | None = None,
+                **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     This method deletes a tag with a uniquely identified xpath.
 
@@ -226,15 +228,15 @@ def replace_tag(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_replace_tag(xmltree, complex_xpath, newelement, occurrences=occurrences)
 
 
-def add_number_to_attrib(xmltree: Union[etree._Element, etree._ElementTree],
-                         schema_dict: 'fleur_schema.SchemaDict',
+def add_number_to_attrib(xmltree: etree._Element | etree._ElementTree,
+                         schema_dict: fleur_schema.SchemaDict,
                          attributename: str,
                          add_number: Any,
                          complex_xpath: XPathLike = None,
                          filters: FilterType = None,
                          mode: Literal['abs', 'rel'] = 'abs',
-                         occurrences: Union[int, Iterable[int]] = None,
-                         **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+                         occurrences: int | Iterable[int] | None = None,
+                         **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     Adds a given number to the attribute value in a xmltree specified by the name of the attribute
     and optional further specification
@@ -286,14 +288,14 @@ def add_number_to_attrib(xmltree: Union[etree._Element, etree._ElementTree],
                                     occurrences=occurrences)
 
 
-def add_number_to_first_attrib(xmltree: Union[etree._Element, etree._ElementTree],
-                               schema_dict: 'fleur_schema.SchemaDict',
+def add_number_to_first_attrib(xmltree: etree._Element | etree._ElementTree,
+                               schema_dict: fleur_schema.SchemaDict,
                                attributename: str,
                                add_number: Any,
                                complex_xpath: XPathLike = None,
                                filters: FilterType = None,
                                mode: Literal['abs', 'rel'] = 'abs',
-                               **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+                               **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     Adds a given number to the first occurrence of an attribute value in a xmltree specified by the name of the attribute
     and optional further specification
@@ -328,15 +330,15 @@ def add_number_to_first_attrib(xmltree: Union[etree._Element, etree._ElementTree
                                 **kwargs)
 
 
-def set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
-                     schema_dict: 'fleur_schema.SchemaDict',
+def set_attrib_value(xmltree: etree._Element | etree._ElementTree,
+                     schema_dict: fleur_schema.SchemaDict,
                      attributename: str,
                      attribv: Any,
                      complex_xpath: XPathLike = None,
                      filters: FilterType = None,
-                     occurrences: Union[int, Iterable[int]] = None,
+                     occurrences: int | Iterable[int]  | None = None,
                      create: bool = False,
-                     **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+                     **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     Sets an attribute in a xmltree to a given value, specified by its name and further
     specifications.
@@ -395,14 +397,14 @@ def set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
                                 create=create)
 
 
-def set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
-                           schema_dict: 'fleur_schema.SchemaDict',
+def set_first_attrib_value(xmltree: etree._Element | etree._ElementTree,
+                           schema_dict: fleur_schema.SchemaDict,
                            attributename: str,
                            attribv: Any,
                            complex_xpath: XPathLike = None,
                            filters: FilterType = None,
                            create: bool = False,
-                           **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+                           **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     Sets the first occurrence of an attribute in a xmltree to a given value, specified by its name and further
     specifications.
@@ -440,15 +442,15 @@ def set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
                             **kwargs)
 
 
-def set_text(xmltree: Union[etree._Element, etree._ElementTree],
-             schema_dict: 'fleur_schema.SchemaDict',
+def set_text(xmltree: etree._Element | etree._ElementTree,
+             schema_dict: fleur_schema.SchemaDict,
              tag_name: str,
              text: Any,
              complex_xpath: XPathLike = None,
              filters: FilterType = None,
-             occurrences: Union[int, Iterable[int]] = None,
+             occurrences: int | Iterable[int] | None = None,
              create: bool = False,
-             **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+             **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     Sets the text on tags in a xmltree to a given value, specified by the name of the tag and
     further specifications. By default the text will be set on all nodes returned for the specified xpath.
@@ -489,14 +491,14 @@ def set_text(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_set_text(xmltree, schema_dict, complex_xpath, base_xpath, text, occurrences=occurrences, create=create)
 
 
-def set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
-                   schema_dict: 'fleur_schema.SchemaDict',
+def set_first_text(xmltree: etree._Element | etree._ElementTree,
+                   schema_dict: fleur_schema.SchemaDict,
                    attributename: str,
                    attribv: Any,
                    complex_xpath: XPathLike = None,
                    filters: FilterType = None,
                    create: bool = False,
-                   **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+                   **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     Sets the text the first occurrence of a tag in a xmltree to a given value, specified by the name of the tag and
     further specifications. By default the text will be set on all nodes returned for the specified xpath.
@@ -531,14 +533,14 @@ def set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
                     **kwargs)
 
 
-def set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
-                   schema_dict: 'fleur_schema.SchemaDict',
+def set_simple_tag(xmltree: etree._Element | etree._ElementTree,
+                   schema_dict: fleur_schema.SchemaDict,
                    tag_name: str,
-                   changes: Union[List[Dict[str, Any]], Dict[str, Any]],
+                   changes: list[dict[str, Any]] | dict[str, Any],
                    complex_xpath: XPathLike = None,
                    filters: FilterType = None,
                    create_parents: bool = False,
-                   **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+                   **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     Sets one or multiple `simple` tag(s) in an xmltree. A simple tag can only hold attributes and has no
     subtags. The tag is specified by its name and further specification
@@ -592,14 +594,14 @@ def set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
                               create_parents=create_parents)
 
 
-def set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
-                    schema_dict: 'fleur_schema.SchemaDict',
+def set_complex_tag(xmltree: etree._Element | etree._ElementTree,
+                    schema_dict: fleur_schema.SchemaDict,
                     tag_name: str,
-                    changes: Dict[str, Any],
+                    changes: dict[str, Any],
                     complex_xpath: XPathLike = None,
                     filters: FilterType = None,
                     create: bool = False,
-                    **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+                    **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     Function to correctly set tags/attributes for a given tag.
     Goes through the attributedict and decides based on the schema_dict, how the corresponding
@@ -646,11 +648,11 @@ def set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_set_complex_tag(xmltree, schema_dict, complex_xpath, base_xpath, changes, create=create)
 
 
-def set_species_label(xmltree: Union[etree._Element, etree._ElementTree],
-                      schema_dict: 'fleur_schema.SchemaDict',
+def set_species_label(xmltree: etree._Element | etree._ElementTree,
+                      schema_dict: fleur_schema.SchemaDict,
                       atom_label: str,
-                      attributedict: Dict[str, Any],
-                      create: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                      attributedict: dict[str, Any],
+                      create: bool = False) -> etree._Element | etree._ElementTree:
     """
     This method calls :func:`~masci_tools.util.xml.xml_setters_names.set_species()`
     method for a certain atom species that corresponds to an atom with a given label
@@ -688,12 +690,12 @@ def set_species_label(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def set_species(xmltree: Union[etree._Element, etree._ElementTree],
-                schema_dict: 'fleur_schema.SchemaDict',
+def set_species(xmltree: etree._Element | etree._ElementTree,
+                schema_dict: fleur_schema.SchemaDict,
                 species_name: str,
-                attributedict: Dict[str, Any],
+                attributedict: dict[str, Any],
                 filters: FilterType = None,
-                create: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                create: bool = False) -> etree._Element | etree._ElementTree:
     """
     Method to set parameters of a species tag of the fleur inp.xml file.
 
@@ -742,11 +744,11 @@ def set_species(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_set_complex_tag(xmltree, schema_dict, xpath_species, base_xpath_species, attributedict, create=create)
 
 
-def clone_species(xmltree: Union[etree._Element, etree._ElementTree],
-                  schema_dict: 'fleur_schema.SchemaDict',
+def clone_species(xmltree: etree._Element | etree._ElementTree,
+                  schema_dict: fleur_schema.SchemaDict,
                   species_name: str,
                   new_name: str,
-                  changes: Dict[str, Any] = None) -> Union[etree._Element, etree._ElementTree]:
+                  changes: dict[str, Any] = None) -> etree._Element | etree._ElementTree:
     """
     Method to create a new species from an existing one with evtl. modifications
 
@@ -793,13 +795,13 @@ def clone_species(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def shift_value_species_label(xmltree: Union[etree._Element, etree._ElementTree],
-                              schema_dict: 'fleur_schema.SchemaDict',
+def shift_value_species_label(xmltree: etree._Element | etree._ElementTree,
+                              schema_dict: fleur_schema.SchemaDict,
                               atom_label: str,
                               attributename: str,
                               value_given: Any,
                               mode: Literal['abs', 'rel'] = 'abs',
-                              **kwargs: Any) -> Union[etree._Element, etree._ElementTree]:
+                              **kwargs: Any) -> etree._Element | etree._ElementTree:
     """
     Shifts the value of an attribute on a species by label
     if atom_label contains 'all' then applies to all species
@@ -855,11 +857,11 @@ def shift_value_species_label(xmltree: Union[etree._Element, etree._ElementTree]
     return xmltree
 
 
-def set_atomgroup_label(xmltree: Union[etree._Element, etree._ElementTree],
-                        schema_dict: 'fleur_schema.SchemaDict',
+def set_atomgroup_label(xmltree: etree._Element | etree._ElementTree,
+                        schema_dict: fleur_schema.SchemaDict,
                         atom_label: str,
-                        attributedict: Dict[str, Any],
-                        create: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                        attributedict: dict[str, Any],
+                        create: bool = False) -> etree._Element | etree._ElementTree:
     """
     This method calls :func:`~masci_tools.util.xml.xml_setters_names.set_atomgroup()`
     method for a certain atom species that corresponds to an atom with a given label.
@@ -881,7 +883,7 @@ def set_atomgroup_label(xmltree: Union[etree._Element, etree._ElementTree],
     """
     from masci_tools.util.schema_dict_util import tag_exists
     if atom_label == 'all':
-        return set_atomgroup(xmltree, schema_dict, attributedict, position=None, species='all')
+        return set_atomgroup(xmltree, schema_dict, attributedict, species='all')
     film = tag_exists(xmltree, schema_dict, 'filmPos')
     label_path = f"/{'filmPos' if film else 'relPos'}/@label"
 
@@ -895,13 +897,13 @@ def set_atomgroup_label(xmltree: Union[etree._Element, etree._ElementTree],
                          }})
 
 
-def set_atomgroup(xmltree: Union[etree._Element, etree._ElementTree],
-                  schema_dict: 'fleur_schema.SchemaDict',
-                  attributedict: Dict[str, Any],
-                  position: Union[int, Literal['all']] = None,
-                  species: str = None,
-                  filters: FilterType = None,
-                  create: bool = False) -> Union[etree._Element, etree._ElementTree]:
+def set_atomgroup(xmltree: etree._Element | etree._ElementTree,
+                  schema_dict: fleur_schema.SchemaDict,
+                  attributedict: dict[str, Any],
+                  position: int | Literal['all'] | None = None,
+                  species: str | None = None,
+                  filters: FilterType | None = None,
+                  create: bool = False) -> etree._Element | etree._ElementTree:
     """
     Method to set parameters of an atom group of the fleur inp.xml file.
 
@@ -954,12 +956,12 @@ def set_atomgroup(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def switch_species_label(xmltree: Union[etree._Element, etree._ElementTree],
-                         schema_dict: 'fleur_schema.SchemaDict',
+def switch_species_label(xmltree: etree._Element | etree._ElementTree,
+                         schema_dict: fleur_schema.SchemaDict,
                          atom_label: str,
                          new_species_name: str,
                          clone: bool = False,
-                         changes: Dict[str, Any] = None) -> Union[etree._Element, etree._ElementTree]:
+                         changes: dict[str, Any] = None) -> etree._Element | etree._ElementTree:
     """
     Method to switch the species of an atom group of the fleur inp.xml file based on a label
     of a contained atom
@@ -994,14 +996,14 @@ def switch_species_label(xmltree: Union[etree._Element, etree._ElementTree],
                           }})
 
 
-def switch_species(xmltree: Union[etree._Element, etree._ElementTree],
-                   schema_dict: 'fleur_schema.SchemaDict',
+def switch_species(xmltree: etree._Element | etree._ElementTree,
+                   schema_dict: fleur_schema.SchemaDict,
                    new_species_name: str,
-                   position: Union[int, Literal['all']] = None,
-                   species: str = None,
-                   filters: FilterType = None,
+                   position: int | Literal['all'] | None = None,
+                   species: str | None = None,
+                   filters: FilterType | None = None,
                    clone: bool = False,
-                   changes: Dict[str, Any] = None) -> Union[etree._Element, etree._ElementTree]:
+                   changes: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
     """
     Method to switch the species of an atom group of the fleur inp.xml file.
 
@@ -1060,11 +1062,11 @@ def switch_species(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_set_attrib_value(xmltree, schema_dict, atomgroup_xpath, atomgroup_base_path, 'species', new_species_name)
 
 
-def shift_value(xmltree: Union[etree._Element, etree._ElementTree],
-                schema_dict: 'fleur_schema.SchemaDict',
-                change_dict: Dict[str, Any],
+def shift_value(xmltree: etree._Element | etree._ElementTree,
+                schema_dict: fleur_schema.SchemaDict,
+                change_dict: dict[str, Any],
                 mode: Literal['abs', 'rel'] = 'abs',
-                path_spec: Dict[str, Any] = None) -> Union[etree._Element, etree._ElementTree]:
+                path_spec: dict[str, Any] = None) -> etree._Element | etree._ElementTree:
     """
     Shifts numerical values of attributes directly in the inp.xml file.
 
@@ -1098,10 +1100,10 @@ def shift_value(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def set_inpchanges(xmltree: Union[etree._Element, etree._ElementTree],
-                   schema_dict: 'fleur_schema.SchemaDict',
-                   change_dict: Dict[str, Any],
-                   path_spec: Dict[str, Any] = None) -> Union[etree._Element, etree._ElementTree]:
+def set_inpchanges(xmltree: etree._Element | etree._ElementTree,
+                   schema_dict: fleur_schema.SchemaDict,
+                   change_dict: dict[str, Any],
+                   path_spec: dict[str, Any] = None) -> etree._Element | etree._ElementTree:
     """
     This method sets all the attribute and texts provided in the change_dict.
 
@@ -1155,15 +1157,15 @@ def set_inpchanges(xmltree: Union[etree._Element, etree._ElementTree],
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def set_kpointlist(xmltree: Union[etree._Element, etree._ElementTree],
-                   schema_dict: 'fleur_schema.SchemaDict',
+def set_kpointlist(xmltree: etree._Element | etree._ElementTree,
+                   schema_dict: fleur_schema.SchemaDict,
                    kpoints: Iterable[Iterable[float]],
                    weights: Iterable[float],
                    name: str = None,
                    kpoint_type: Literal['path', 'mesh', 'tria', 'tria-bulk', 'spex-mesh'] = 'path',
-                   special_labels: Dict[int, str] = None,
+                   special_labels: dict[int, str] = None,
                    switch: bool = False,
-                   overwrite: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                   overwrite: bool = False) -> etree._Element | etree._ElementTree:
     """
     Explicitely create a kPointList from the given kpoints and weights. This routine will add the
     specified kPointList with the given name.
@@ -1220,7 +1222,7 @@ def set_kpointlist(xmltree: Union[etree._Element, etree._ElementTree],
             new_k = etree.Element('kPoint', weight=weight, label=special_labels[indx])
         else:
             new_k = etree.Element('kPoint', weight=weight)
-        res: Tuple[str, bool] = convert_to_xml(kpoint, schema_dict, 'kpoint', text=True)  #type:ignore
+        res: tuple[str, bool] = convert_to_xml(kpoint, schema_dict, 'kpoint', text=True)  #type:ignore
         text, _ = res
         new_k.text = text
         new_kpo.append(new_k)
@@ -1234,9 +1236,9 @@ def set_kpointlist(xmltree: Union[etree._Element, etree._ElementTree],
 
 
 @set_kpointlist.register(max_version='0.31')
-def set_kpointlist_max4(xmltree: Union[etree._Element, etree._ElementTree], schema_dict: 'fleur_schema.SchemaDict',
+def set_kpointlist_max4(xmltree: etree._Element | etree._ElementTree, schema_dict: fleur_schema.SchemaDict,
                         kpoints: Iterable[Iterable[float]],
-                        weights: Iterable[float]) -> Union[etree._Element, etree._ElementTree]:
+                        weights: Iterable[float]) -> etree._Element | etree._ElementTree:
     """
     Explicitely create a kPointList from the given kpoints and weights. This
     routine is specific to input versions Max4 and before and will replace any
@@ -1271,7 +1273,7 @@ def set_kpointlist_max4(xmltree: Union[etree._Element, etree._ElementTree], sche
     for kpoint, weight in zip(kpoints, weights):
         weight, _ = convert_to_xml(weight, schema_dict, 'weight')
         new_k = etree.Element('kPoint', weight=weight)
-        res: Tuple[str, bool] = convert_to_xml(kpoint, schema_dict, 'kpoint', text=True)  #type:ignore
+        res: tuple[str, bool] = convert_to_xml(kpoint, schema_dict, 'kpoint', text=True)  #type:ignore
         text, _ = res
         new_k.text = text
         new_kpo.append(new_k)
@@ -1282,8 +1284,8 @@ def set_kpointlist_max4(xmltree: Union[etree._Element, etree._ElementTree], sche
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def switch_kpointset(xmltree: Union[etree._Element, etree._ElementTree], schema_dict: 'fleur_schema.SchemaDict',
-                     list_name: str) -> Union[etree._Element, etree._ElementTree]:
+def switch_kpointset(xmltree: etree._Element | etree._ElementTree, schema_dict: fleur_schema.SchemaDict,
+                     list_name: str) -> etree._Element | etree._ElementTree:
     """
     Switch the used k-point set
 
@@ -1308,8 +1310,8 @@ def switch_kpointset(xmltree: Union[etree._Element, etree._ElementTree], schema_
 
 
 @switch_kpointset.register(max_version='0.31')
-def switch_kpointset_max4(xmltree: Union[etree._Element, etree._ElementTree], schema_dict: 'fleur_schema.SchemaDict',
-                          list_name: str) -> Union[etree._Element, etree._ElementTree]:
+def switch_kpointset_max4(xmltree: etree._Element | etree._ElementTree, schema_dict: fleur_schema.SchemaDict,
+                          list_name: str) -> etree._Element | etree._ElementTree:
     """
     Sets a k-point mesh directly into inp.xml specific for inputs of version Max4
 
@@ -1327,10 +1329,10 @@ def switch_kpointset_max4(xmltree: Union[etree._Element, etree._ElementTree], sc
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def set_nkpts(xmltree: Union[etree._Element, etree._ElementTree],
-              schema_dict: 'fleur_schema.SchemaDict',
+def set_nkpts(xmltree: etree._Element | etree._ElementTree,
+              schema_dict: fleur_schema.SchemaDict,
               count: int,
-              gamma: bool = False) -> Union[etree._Element, etree._ElementTree]:
+              gamma: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets a k-point mesh directly into inp.xml
 
@@ -1350,10 +1352,10 @@ def set_nkpts(xmltree: Union[etree._Element, etree._ElementTree],
 
 
 @set_nkpts.register(max_version='0.31')
-def set_nkpts_max4(xmltree: Union[etree._Element, etree._ElementTree],
-                   schema_dict: 'fleur_schema.SchemaDict',
+def set_nkpts_max4(xmltree: etree._Element | etree._ElementTree,
+                   schema_dict: fleur_schema.SchemaDict,
                    count: int,
-                   gamma: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                   gamma: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets a k-point mesh directly into inp.xml specific for inputs of version Max4
 
@@ -1383,11 +1385,11 @@ def set_nkpts_max4(xmltree: Union[etree._Element, etree._ElementTree],
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def set_kpath(xmltree: Union[etree._Element, etree._ElementTree],
-              schema_dict: 'fleur_schema.SchemaDict',
-              kpath: Dict[str, Iterable[float]],
+def set_kpath(xmltree: etree._Element | etree._ElementTree,
+              schema_dict: fleur_schema.SchemaDict,
+              kpath: dict[str, Iterable[float]],
               count: int,
-              gamma: bool = False) -> Union[etree._Element, etree._ElementTree]:
+              gamma: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets a k-path directly into inp.xml  as a alternative kpoint set with purpose 'bands'
 
@@ -1410,11 +1412,11 @@ def set_kpath(xmltree: Union[etree._Element, etree._ElementTree],
 
 
 @set_kpath.register(max_version='0.31')
-def set_kpath_max4(xmltree: Union[etree._Element, etree._ElementTree],
-                   schema_dict: 'fleur_schema.SchemaDict',
-                   kpath: Dict[str, Iterable[float]],
+def set_kpath_max4(xmltree: etree._Element | etree._ElementTree,
+                   schema_dict: fleur_schema.SchemaDict,
+                   kpath: dict[str, Iterable[float]],
                    count: int,
-                   gamma: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                   gamma: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets a k-path directly into inp.xml as a alternative kpoint set with purpose 'bands'
 
@@ -1440,7 +1442,7 @@ def set_kpath_max4(xmltree: Union[etree._Element, etree._ElementTree],
     new_kpo = etree.Element('kPointCount', count=f'{count}', gamma=f'{convert_to_fortran_bool(gamma)}')
     for label, coord in kpath.items():
         new_k = etree.Element('specialPoint', name=f'{label}')
-        res: Tuple[str, bool] = convert_to_xml(coord, schema_dict, 'kpoint', text=True)  #type:ignore
+        res: tuple[str, bool] = convert_to_xml(coord, schema_dict, 'kpoint', text=True)  #type:ignore
         text, _ = res
         new_k.text = text
         new_kpo.append(new_k)

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -37,7 +37,7 @@ def create_tag(xmltree: XMLLike,
                filters: FilterType = None,
                create_parents: bool = False,
                occurrences: int | Iterable[int] | None = None,
-               **kwargs: Any) -> etree._Element | etree._ElementTree:
+               **kwargs: Any) -> XMLLike:
     """
     This method creates a tag with a uniquely identified xpath under the nodes of its parent.
     If there are no nodes evaluated the subtags can be created with `create_parents=True`
@@ -99,7 +99,7 @@ def delete_tag(xmltree: XMLLike,
                complex_xpath: XPathLike = None,
                filters: FilterType = None,
                occurrences: int | Iterable[int] | None = None,
-               **kwargs: Any) -> etree._Element | etree._ElementTree:
+               **kwargs: Any) -> XMLLike:
     """
     This method deletes a tag with a uniquely identified xpath.
 
@@ -142,7 +142,7 @@ def delete_att(xmltree: XMLLike,
                complex_xpath: XPathLike = None,
                filters: FilterType = None,
                occurrences: int | Iterable[int] | None = None,
-               **kwargs: Any) -> etree._Element | etree._ElementTree:
+               **kwargs: Any) -> XMLLike:
     """
     This method deletes a attribute with a uniquely identified xpath.
 
@@ -190,7 +190,7 @@ def replace_tag(xmltree: XMLLike,
                 complex_xpath: XPathLike = None,
                 filters: FilterType = None,
                 occurrences: int | Iterable[int] | None = None,
-                **kwargs: Any) -> etree._Element | etree._ElementTree:
+                **kwargs: Any) -> XMLLike:
     """
     This method deletes a tag with a uniquely identified xpath.
 
@@ -236,7 +236,7 @@ def add_number_to_attrib(xmltree: XMLLike,
                          filters: FilterType = None,
                          mode: Literal['abs', 'rel'] = 'abs',
                          occurrences: int | Iterable[int] | None = None,
-                         **kwargs: Any) -> etree._Element | etree._ElementTree:
+                         **kwargs: Any) -> XMLLike:
     """
     Adds a given number to the attribute value in a xmltree specified by the name of the attribute
     and optional further specification
@@ -295,7 +295,7 @@ def add_number_to_first_attrib(xmltree: XMLLike,
                                complex_xpath: XPathLike = None,
                                filters: FilterType = None,
                                mode: Literal['abs', 'rel'] = 'abs',
-                               **kwargs: Any) -> etree._Element | etree._ElementTree:
+                               **kwargs: Any) -> XMLLike:
     """
     Adds a given number to the first occurrence of an attribute value in a xmltree specified by the name of the attribute
     and optional further specification
@@ -338,7 +338,7 @@ def set_attrib_value(xmltree: XMLLike,
                      filters: FilterType = None,
                      occurrences: int | Iterable[int] | None = None,
                      create: bool = False,
-                     **kwargs: Any) -> etree._Element | etree._ElementTree:
+                     **kwargs: Any) -> XMLLike:
     """
     Sets an attribute in a xmltree to a given value, specified by its name and further
     specifications.
@@ -404,7 +404,7 @@ def set_first_attrib_value(xmltree: XMLLike,
                            complex_xpath: XPathLike = None,
                            filters: FilterType = None,
                            create: bool = False,
-                           **kwargs: Any) -> etree._Element | etree._ElementTree:
+                           **kwargs: Any) -> XMLLike:
     """
     Sets the first occurrence of an attribute in a xmltree to a given value, specified by its name and further
     specifications.
@@ -450,7 +450,7 @@ def set_text(xmltree: XMLLike,
              filters: FilterType = None,
              occurrences: int | Iterable[int] | None = None,
              create: bool = False,
-             **kwargs: Any) -> etree._Element | etree._ElementTree:
+             **kwargs: Any) -> XMLLike:
     """
     Sets the text on tags in a xmltree to a given value, specified by the name of the tag and
     further specifications. By default the text will be set on all nodes returned for the specified xpath.
@@ -498,7 +498,7 @@ def set_first_text(xmltree: XMLLike,
                    complex_xpath: XPathLike = None,
                    filters: FilterType = None,
                    create: bool = False,
-                   **kwargs: Any) -> etree._Element | etree._ElementTree:
+                   **kwargs: Any) -> XMLLike:
     """
     Sets the text the first occurrence of a tag in a xmltree to a given value, specified by the name of the tag and
     further specifications. By default the text will be set on all nodes returned for the specified xpath.
@@ -540,7 +540,7 @@ def set_simple_tag(xmltree: XMLLike,
                    complex_xpath: XPathLike = None,
                    filters: FilterType = None,
                    create_parents: bool = False,
-                   **kwargs: Any) -> etree._Element | etree._ElementTree:
+                   **kwargs: Any) -> XMLLike:
     """
     Sets one or multiple `simple` tag(s) in an xmltree. A simple tag can only hold attributes and has no
     subtags. The tag is specified by its name and further specification
@@ -601,7 +601,7 @@ def set_complex_tag(xmltree: XMLLike,
                     complex_xpath: XPathLike = None,
                     filters: FilterType = None,
                     create: bool = False,
-                    **kwargs: Any) -> etree._Element | etree._ElementTree:
+                    **kwargs: Any) -> XMLLike:
     """
     Function to correctly set tags/attributes for a given tag.
     Goes through the attributedict and decides based on the schema_dict, how the corresponding
@@ -652,7 +652,7 @@ def set_species_label(xmltree: XMLLike,
                       schema_dict: fleur_schema.SchemaDict,
                       atom_label: str,
                       attributedict: dict[str, Any],
-                      create: bool = False) -> etree._Element | etree._ElementTree:
+                      create: bool = False) -> XMLLike:
     """
     This method calls :func:`~masci_tools.util.xml.xml_setters_names.set_species()`
     method for a certain atom species that corresponds to an atom with a given label
@@ -695,7 +695,7 @@ def set_species(xmltree: XMLLike,
                 species_name: str,
                 attributedict: dict[str, Any],
                 filters: FilterType = None,
-                create: bool = False) -> etree._Element | etree._ElementTree:
+                create: bool = False) -> XMLLike:
     """
     Method to set parameters of a species tag of the fleur inp.xml file.
 
@@ -748,7 +748,7 @@ def clone_species(xmltree: XMLLike,
                   schema_dict: fleur_schema.SchemaDict,
                   species_name: str,
                   new_name: str,
-                  changes: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
+                  changes: dict[str, Any] | None = None) -> XMLLike:
     """
     Method to create a new species from an existing one with evtl. modifications
 
@@ -801,7 +801,7 @@ def shift_value_species_label(xmltree: XMLLike,
                               attributename: str,
                               value_given: Any,
                               mode: Literal['abs', 'rel'] = 'abs',
-                              **kwargs: Any) -> etree._Element | etree._ElementTree:
+                              **kwargs: Any) -> XMLLike:
     """
     Shifts the value of an attribute on a species by label
     if atom_label contains 'all' then applies to all species
@@ -861,7 +861,7 @@ def set_atomgroup_label(xmltree: XMLLike,
                         schema_dict: fleur_schema.SchemaDict,
                         atom_label: str,
                         attributedict: dict[str, Any],
-                        create: bool = False) -> etree._Element | etree._ElementTree:
+                        create: bool = False) -> XMLLike:
     """
     This method calls :func:`~masci_tools.util.xml.xml_setters_names.set_atomgroup()`
     method for a certain atom species that corresponds to an atom with a given label.
@@ -903,7 +903,7 @@ def set_atomgroup(xmltree: XMLLike,
                   position: int | Literal['all'] | None = None,
                   species: str | None = None,
                   filters: FilterType | None = None,
-                  create: bool = False) -> etree._Element | etree._ElementTree:
+                  create: bool = False) -> XMLLike:
     """
     Method to set parameters of an atom group of the fleur inp.xml file.
 
@@ -961,7 +961,7 @@ def switch_species_label(xmltree: XMLLike,
                          atom_label: str,
                          new_species_name: str,
                          clone: bool = False,
-                         changes: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
+                         changes: dict[str, Any] | None = None) -> XMLLike:
     """
     Method to switch the species of an atom group of the fleur inp.xml file based on a label
     of a contained atom
@@ -1003,7 +1003,7 @@ def switch_species(xmltree: XMLLike,
                    species: str | None = None,
                    filters: FilterType | None = None,
                    clone: bool = False,
-                   changes: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
+                   changes: dict[str, Any] | None = None) -> XMLLike:
     """
     Method to switch the species of an atom group of the fleur inp.xml file.
 
@@ -1066,7 +1066,7 @@ def shift_value(xmltree: XMLLike,
                 schema_dict: fleur_schema.SchemaDict,
                 change_dict: dict[str, Any],
                 mode: Literal['abs', 'rel'] = 'abs',
-                path_spec: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
+                path_spec: dict[str, Any] | None = None) -> XMLLike:
     """
     Shifts numerical values of attributes directly in the inp.xml file.
 
@@ -1103,7 +1103,7 @@ def shift_value(xmltree: XMLLike,
 def set_inpchanges(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    change_dict: dict[str, Any],
-                   path_spec: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
+                   path_spec: dict[str, Any] | None = None) -> XMLLike:
     """
     This method sets all the attribute and texts provided in the change_dict.
 
@@ -1165,7 +1165,7 @@ def set_kpointlist(xmltree: XMLLike,
                    kpoint_type: Literal['path', 'mesh', 'tria', 'tria-bulk', 'spex-mesh'] = 'path',
                    special_labels: dict[int, str] | None = None,
                    switch: bool = False,
-                   overwrite: bool = False) -> etree._Element | etree._ElementTree:
+                   overwrite: bool = False) -> XMLLike:
     """
     Explicitely create a kPointList from the given kpoints and weights. This routine will add the
     specified kPointList with the given name.
@@ -1237,7 +1237,7 @@ def set_kpointlist(xmltree: XMLLike,
 
 @set_kpointlist.register(max_version='0.31')
 def set_kpointlist_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict, kpoints: Iterable[Iterable[float]],
-                        weights: Iterable[float]) -> etree._Element | etree._ElementTree:
+                        weights: Iterable[float]) -> XMLLike:
     """
     Explicitely create a kPointList from the given kpoints and weights. This
     routine is specific to input versions Max4 and before and will replace any
@@ -1284,7 +1284,7 @@ def set_kpointlist_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict, 
 
 @schema_dict_version_dispatch(output_schema=False)
 def switch_kpointset(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict,
-                     list_name: str) -> etree._Element | etree._ElementTree:
+                     list_name: str) -> XMLLike:
     """
     Switch the used k-point set
 
@@ -1310,7 +1310,7 @@ def switch_kpointset(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict,
 
 @switch_kpointset.register(max_version='0.31')
 def switch_kpointset_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict,
-                          list_name: str) -> etree._Element | etree._ElementTree:
+                          list_name: str) -> XMLLike:
     """
     Sets a k-point mesh directly into inp.xml specific for inputs of version Max4
 
@@ -1331,7 +1331,7 @@ def switch_kpointset_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict
 def set_nkpts(xmltree: XMLLike,
               schema_dict: fleur_schema.SchemaDict,
               count: int,
-              gamma: bool = False) -> etree._Element | etree._ElementTree:
+              gamma: bool = False) -> XMLLike:
     """
     Sets a k-point mesh directly into inp.xml
 
@@ -1354,7 +1354,7 @@ def set_nkpts(xmltree: XMLLike,
 def set_nkpts_max4(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    count: int,
-                   gamma: bool = False) -> etree._Element | etree._ElementTree:
+                   gamma: bool = False) -> XMLLike:
     """
     Sets a k-point mesh directly into inp.xml specific for inputs of version Max4
 
@@ -1388,7 +1388,7 @@ def set_kpath(xmltree: XMLLike,
               schema_dict: fleur_schema.SchemaDict,
               kpath: dict[str, Iterable[float]],
               count: int,
-              gamma: bool = False) -> etree._Element | etree._ElementTree:
+              gamma: bool = False) -> XMLLike:
     """
     Sets a k-path directly into inp.xml  as a alternative kpoint set with purpose 'bands'
 
@@ -1415,7 +1415,7 @@ def set_kpath_max4(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    kpath: dict[str, Iterable[float]],
                    count: int,
-                   gamma: bool = False) -> etree._Element | etree._ElementTree:
+                   gamma: bool = False) -> XMLLike:
     """
     Sets a k-path directly into inp.xml as a alternative kpoint set with purpose 'bands'
 

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -1283,8 +1283,7 @@ def set_kpointlist_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict, 
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def switch_kpointset(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict,
-                     list_name: str) -> XMLLike:
+def switch_kpointset(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict, list_name: str) -> XMLLike:
     """
     Switch the used k-point set
 
@@ -1309,8 +1308,7 @@ def switch_kpointset(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict,
 
 
 @switch_kpointset.register(max_version='0.31')
-def switch_kpointset_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict,
-                          list_name: str) -> XMLLike:
+def switch_kpointset_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict, list_name: str) -> XMLLike:
     """
     Sets a k-point mesh directly into inp.xml specific for inputs of version Max4
 
@@ -1328,10 +1326,7 @@ def switch_kpointset_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def set_nkpts(xmltree: XMLLike,
-              schema_dict: fleur_schema.SchemaDict,
-              count: int,
-              gamma: bool = False) -> XMLLike:
+def set_nkpts(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict, count: int, gamma: bool = False) -> XMLLike:
     """
     Sets a k-point mesh directly into inp.xml
 
@@ -1351,10 +1346,7 @@ def set_nkpts(xmltree: XMLLike,
 
 
 @set_nkpts.register(max_version='0.31')
-def set_nkpts_max4(xmltree: XMLLike,
-                   schema_dict: fleur_schema.SchemaDict,
-                   count: int,
-                   gamma: bool = False) -> XMLLike:
+def set_nkpts_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict, count: int, gamma: bool = False) -> XMLLike:
     """
     Sets a k-point mesh directly into inp.xml specific for inputs of version Max4
 

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -748,7 +748,7 @@ def clone_species(xmltree: XMLLike,
                   schema_dict: fleur_schema.SchemaDict,
                   species_name: str,
                   new_name: str,
-                  changes: dict[str, Any] = None) -> etree._Element | etree._ElementTree:
+                  changes: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
     """
     Method to create a new species from an existing one with evtl. modifications
 
@@ -961,7 +961,7 @@ def switch_species_label(xmltree: XMLLike,
                          atom_label: str,
                          new_species_name: str,
                          clone: bool = False,
-                         changes: dict[str, Any] = None) -> etree._Element | etree._ElementTree:
+                         changes: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
     """
     Method to switch the species of an atom group of the fleur inp.xml file based on a label
     of a contained atom
@@ -1066,7 +1066,7 @@ def shift_value(xmltree: XMLLike,
                 schema_dict: fleur_schema.SchemaDict,
                 change_dict: dict[str, Any],
                 mode: Literal['abs', 'rel'] = 'abs',
-                path_spec: dict[str, Any] = None) -> etree._Element | etree._ElementTree:
+                path_spec: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
     """
     Shifts numerical values of attributes directly in the inp.xml file.
 
@@ -1103,7 +1103,7 @@ def shift_value(xmltree: XMLLike,
 def set_inpchanges(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    change_dict: dict[str, Any],
-                   path_spec: dict[str, Any] = None) -> etree._Element | etree._ElementTree:
+                   path_spec: dict[str, Any] | None = None) -> etree._Element | etree._ElementTree:
     """
     This method sets all the attribute and texts provided in the change_dict.
 
@@ -1161,9 +1161,9 @@ def set_kpointlist(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    kpoints: Iterable[Iterable[float]],
                    weights: Iterable[float],
-                   name: str = None,
+                   name: str | None = None,
                    kpoint_type: Literal['path', 'mesh', 'tria', 'tria-bulk', 'spex-mesh'] = 'path',
-                   special_labels: dict[int, str] = None,
+                   special_labels: dict[int, str] | None = None,
                    switch: bool = False,
                    overwrite: bool = False) -> etree._Element | etree._ElementTree:
     """

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -336,7 +336,7 @@ def set_attrib_value(xmltree: etree._Element | etree._ElementTree,
                      attribv: Any,
                      complex_xpath: XPathLike = None,
                      filters: FilterType = None,
-                     occurrences: int | Iterable[int]  | None = None,
+                     occurrences: int | Iterable[int] | None = None,
                      create: bool = False,
                      **kwargs: Any) -> etree._Element | etree._ElementTree:
     """

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     from typing_extensions import Literal  #type:ignore
 
-from masci_tools.util.typing import XPathLike
+from masci_tools.util.typing import XPathLike, XMLLike
 from masci_tools.util.xml.xpathbuilder import XPathBuilder, FilterType
 from masci_tools.io.parsers.fleur_schema import schema_dict_version_dispatch
 from masci_tools.io.parsers import fleur_schema
@@ -30,7 +30,7 @@ from masci_tools.io.parsers import fleur_schema
 from lxml import etree
 
 
-def create_tag(xmltree: etree._Element | etree._ElementTree,
+def create_tag(xmltree: XMLLike,
                schema_dict: fleur_schema.SchemaDict,
                tag: str | etree._Element,
                complex_xpath: XPathLike = None,
@@ -93,7 +93,7 @@ def create_tag(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def delete_tag(xmltree: etree._Element | etree._ElementTree,
+def delete_tag(xmltree: XMLLike,
                schema_dict: fleur_schema.SchemaDict,
                tag_name: str,
                complex_xpath: XPathLike = None,
@@ -136,7 +136,7 @@ def delete_tag(xmltree: etree._Element | etree._ElementTree,
     return xml_delete_tag(xmltree, complex_xpath, occurrences=occurrences)
 
 
-def delete_att(xmltree: etree._Element | etree._ElementTree,
+def delete_att(xmltree: XMLLike,
                schema_dict: fleur_schema.SchemaDict,
                attrib_name: str,
                complex_xpath: XPathLike = None,
@@ -183,7 +183,7 @@ def delete_att(xmltree: etree._Element | etree._ElementTree,
     return xml_delete_att(xmltree, complex_xpath, attrib_name, occurrences=occurrences)
 
 
-def replace_tag(xmltree: etree._Element | etree._ElementTree,
+def replace_tag(xmltree: XMLLike,
                 schema_dict: fleur_schema.SchemaDict,
                 tag_name: str,
                 newelement: etree._Element,
@@ -228,7 +228,7 @@ def replace_tag(xmltree: etree._Element | etree._ElementTree,
     return xml_replace_tag(xmltree, complex_xpath, newelement, occurrences=occurrences)
 
 
-def add_number_to_attrib(xmltree: etree._Element | etree._ElementTree,
+def add_number_to_attrib(xmltree: XMLLike,
                          schema_dict: fleur_schema.SchemaDict,
                          attributename: str,
                          add_number: Any,
@@ -288,7 +288,7 @@ def add_number_to_attrib(xmltree: etree._Element | etree._ElementTree,
                                     occurrences=occurrences)
 
 
-def add_number_to_first_attrib(xmltree: etree._Element | etree._ElementTree,
+def add_number_to_first_attrib(xmltree: XMLLike,
                                schema_dict: fleur_schema.SchemaDict,
                                attributename: str,
                                add_number: Any,
@@ -330,7 +330,7 @@ def add_number_to_first_attrib(xmltree: etree._Element | etree._ElementTree,
                                 **kwargs)
 
 
-def set_attrib_value(xmltree: etree._Element | etree._ElementTree,
+def set_attrib_value(xmltree: XMLLike,
                      schema_dict: fleur_schema.SchemaDict,
                      attributename: str,
                      attribv: Any,
@@ -397,7 +397,7 @@ def set_attrib_value(xmltree: etree._Element | etree._ElementTree,
                                 create=create)
 
 
-def set_first_attrib_value(xmltree: etree._Element | etree._ElementTree,
+def set_first_attrib_value(xmltree: XMLLike,
                            schema_dict: fleur_schema.SchemaDict,
                            attributename: str,
                            attribv: Any,
@@ -442,7 +442,7 @@ def set_first_attrib_value(xmltree: etree._Element | etree._ElementTree,
                             **kwargs)
 
 
-def set_text(xmltree: etree._Element | etree._ElementTree,
+def set_text(xmltree: XMLLike,
              schema_dict: fleur_schema.SchemaDict,
              tag_name: str,
              text: Any,
@@ -491,7 +491,7 @@ def set_text(xmltree: etree._Element | etree._ElementTree,
     return xml_set_text(xmltree, schema_dict, complex_xpath, base_xpath, text, occurrences=occurrences, create=create)
 
 
-def set_first_text(xmltree: etree._Element | etree._ElementTree,
+def set_first_text(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    attributename: str,
                    attribv: Any,
@@ -533,7 +533,7 @@ def set_first_text(xmltree: etree._Element | etree._ElementTree,
                     **kwargs)
 
 
-def set_simple_tag(xmltree: etree._Element | etree._ElementTree,
+def set_simple_tag(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    tag_name: str,
                    changes: list[dict[str, Any]] | dict[str, Any],
@@ -594,7 +594,7 @@ def set_simple_tag(xmltree: etree._Element | etree._ElementTree,
                               create_parents=create_parents)
 
 
-def set_complex_tag(xmltree: etree._Element | etree._ElementTree,
+def set_complex_tag(xmltree: XMLLike,
                     schema_dict: fleur_schema.SchemaDict,
                     tag_name: str,
                     changes: dict[str, Any],
@@ -648,7 +648,7 @@ def set_complex_tag(xmltree: etree._Element | etree._ElementTree,
     return xml_set_complex_tag(xmltree, schema_dict, complex_xpath, base_xpath, changes, create=create)
 
 
-def set_species_label(xmltree: etree._Element | etree._ElementTree,
+def set_species_label(xmltree: XMLLike,
                       schema_dict: fleur_schema.SchemaDict,
                       atom_label: str,
                       attributedict: dict[str, Any],
@@ -690,7 +690,7 @@ def set_species_label(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def set_species(xmltree: etree._Element | etree._ElementTree,
+def set_species(xmltree: XMLLike,
                 schema_dict: fleur_schema.SchemaDict,
                 species_name: str,
                 attributedict: dict[str, Any],
@@ -744,7 +744,7 @@ def set_species(xmltree: etree._Element | etree._ElementTree,
     return xml_set_complex_tag(xmltree, schema_dict, xpath_species, base_xpath_species, attributedict, create=create)
 
 
-def clone_species(xmltree: etree._Element | etree._ElementTree,
+def clone_species(xmltree: XMLLike,
                   schema_dict: fleur_schema.SchemaDict,
                   species_name: str,
                   new_name: str,
@@ -795,7 +795,7 @@ def clone_species(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def shift_value_species_label(xmltree: etree._Element | etree._ElementTree,
+def shift_value_species_label(xmltree: XMLLike,
                               schema_dict: fleur_schema.SchemaDict,
                               atom_label: str,
                               attributename: str,
@@ -857,7 +857,7 @@ def shift_value_species_label(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def set_atomgroup_label(xmltree: etree._Element | etree._ElementTree,
+def set_atomgroup_label(xmltree: XMLLike,
                         schema_dict: fleur_schema.SchemaDict,
                         atom_label: str,
                         attributedict: dict[str, Any],
@@ -897,7 +897,7 @@ def set_atomgroup_label(xmltree: etree._Element | etree._ElementTree,
                          }})
 
 
-def set_atomgroup(xmltree: etree._Element | etree._ElementTree,
+def set_atomgroup(xmltree: XMLLike,
                   schema_dict: fleur_schema.SchemaDict,
                   attributedict: dict[str, Any],
                   position: int | Literal['all'] | None = None,
@@ -956,7 +956,7 @@ def set_atomgroup(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def switch_species_label(xmltree: etree._Element | etree._ElementTree,
+def switch_species_label(xmltree: XMLLike,
                          schema_dict: fleur_schema.SchemaDict,
                          atom_label: str,
                          new_species_name: str,
@@ -996,7 +996,7 @@ def switch_species_label(xmltree: etree._Element | etree._ElementTree,
                           }})
 
 
-def switch_species(xmltree: etree._Element | etree._ElementTree,
+def switch_species(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    new_species_name: str,
                    position: int | Literal['all'] | None = None,
@@ -1062,7 +1062,7 @@ def switch_species(xmltree: etree._Element | etree._ElementTree,
     return xml_set_attrib_value(xmltree, schema_dict, atomgroup_xpath, atomgroup_base_path, 'species', new_species_name)
 
 
-def shift_value(xmltree: etree._Element | etree._ElementTree,
+def shift_value(xmltree: XMLLike,
                 schema_dict: fleur_schema.SchemaDict,
                 change_dict: dict[str, Any],
                 mode: Literal['abs', 'rel'] = 'abs',
@@ -1100,7 +1100,7 @@ def shift_value(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def set_inpchanges(xmltree: etree._Element | etree._ElementTree,
+def set_inpchanges(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    change_dict: dict[str, Any],
                    path_spec: dict[str, Any] = None) -> etree._Element | etree._ElementTree:
@@ -1157,7 +1157,7 @@ def set_inpchanges(xmltree: etree._Element | etree._ElementTree,
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def set_kpointlist(xmltree: etree._Element | etree._ElementTree,
+def set_kpointlist(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    kpoints: Iterable[Iterable[float]],
                    weights: Iterable[float],
@@ -1236,8 +1236,7 @@ def set_kpointlist(xmltree: etree._Element | etree._ElementTree,
 
 
 @set_kpointlist.register(max_version='0.31')
-def set_kpointlist_max4(xmltree: etree._Element | etree._ElementTree, schema_dict: fleur_schema.SchemaDict,
-                        kpoints: Iterable[Iterable[float]],
+def set_kpointlist_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict, kpoints: Iterable[Iterable[float]],
                         weights: Iterable[float]) -> etree._Element | etree._ElementTree:
     """
     Explicitely create a kPointList from the given kpoints and weights. This
@@ -1284,7 +1283,7 @@ def set_kpointlist_max4(xmltree: etree._Element | etree._ElementTree, schema_dic
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def switch_kpointset(xmltree: etree._Element | etree._ElementTree, schema_dict: fleur_schema.SchemaDict,
+def switch_kpointset(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict,
                      list_name: str) -> etree._Element | etree._ElementTree:
     """
     Switch the used k-point set
@@ -1310,7 +1309,7 @@ def switch_kpointset(xmltree: etree._Element | etree._ElementTree, schema_dict: 
 
 
 @switch_kpointset.register(max_version='0.31')
-def switch_kpointset_max4(xmltree: etree._Element | etree._ElementTree, schema_dict: fleur_schema.SchemaDict,
+def switch_kpointset_max4(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict,
                           list_name: str) -> etree._Element | etree._ElementTree:
     """
     Sets a k-point mesh directly into inp.xml specific for inputs of version Max4
@@ -1329,7 +1328,7 @@ def switch_kpointset_max4(xmltree: etree._Element | etree._ElementTree, schema_d
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def set_nkpts(xmltree: etree._Element | etree._ElementTree,
+def set_nkpts(xmltree: XMLLike,
               schema_dict: fleur_schema.SchemaDict,
               count: int,
               gamma: bool = False) -> etree._Element | etree._ElementTree:
@@ -1352,7 +1351,7 @@ def set_nkpts(xmltree: etree._Element | etree._ElementTree,
 
 
 @set_nkpts.register(max_version='0.31')
-def set_nkpts_max4(xmltree: etree._Element | etree._ElementTree,
+def set_nkpts_max4(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    count: int,
                    gamma: bool = False) -> etree._Element | etree._ElementTree:
@@ -1385,7 +1384,7 @@ def set_nkpts_max4(xmltree: etree._Element | etree._ElementTree,
 
 
 @schema_dict_version_dispatch(output_schema=False)
-def set_kpath(xmltree: etree._Element | etree._ElementTree,
+def set_kpath(xmltree: XMLLike,
               schema_dict: fleur_schema.SchemaDict,
               kpath: dict[str, Iterable[float]],
               count: int,
@@ -1412,7 +1411,7 @@ def set_kpath(xmltree: etree._Element | etree._ElementTree,
 
 
 @set_kpath.register(max_version='0.31')
-def set_kpath_max4(xmltree: etree._Element | etree._ElementTree,
+def set_kpath_max4(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
                    kpath: dict[str, Iterable[float]],
                    count: int,

--- a/masci_tools/util/xml/xml_setters_nmmpmat.py
+++ b/masci_tools/util/xml/xml_setters_nmmpmat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/xml/xml_setters_nmmpmat.py
+++ b/masci_tools/util/xml/xml_setters_nmmpmat.py
@@ -19,9 +19,10 @@ import numpy as np
 from lxml import etree
 from masci_tools.io.parsers import fleur_schema
 from masci_tools.util.xml.xpathbuilder import XPathBuilder, FilterType
+from masci_tools.util.typing import XMLLike
 
 
-def set_nmmpmat(xmltree: etree._Element | etree._ElementTree,
+def set_nmmpmat(xmltree: XMLLike,
                 nmmplines: list[str],
                 schema_dict: fleur_schema.SchemaDict,
                 species_name: str,
@@ -136,7 +137,7 @@ def set_nmmpmat(xmltree: etree._Element | etree._ElementTree,
     return nmmplines
 
 
-def rotate_nmmpmat(xmltree: etree._Element | etree._ElementTree,
+def rotate_nmmpmat(xmltree: XMLLike,
                    nmmplines: list[str],
                    schema_dict: fleur_schema.SchemaDict,
                    species_name: str,
@@ -228,8 +229,7 @@ def rotate_nmmpmat(xmltree: etree._Element | etree._ElementTree,
     return nmmplines
 
 
-def validate_nmmpmat(xmltree: etree._Element | etree._ElementTree, nmmplines: list[str] | None,
-                     schema_dict: fleur_schema.SchemaDict) -> None:
+def validate_nmmpmat(xmltree: XMLLike, nmmplines: list[str] | None, schema_dict: fleur_schema.SchemaDict) -> None:
     """
     Checks that the given nmmp_lines is valid with the given xmltree
 

--- a/masci_tools/util/xml/xml_setters_nmmpmat.py
+++ b/masci_tools/util/xml/xml_setters_nmmpmat.py
@@ -28,12 +28,12 @@ def set_nmmpmat(xmltree: XMLLike,
                 species_name: str,
                 orbital: int,
                 spin: int,
-                state_occupations: list[float] = None,
-                orbital_occupations: list[float] = None,
-                denmat: np.ndarray = None,
-                phi: float = None,
-                theta: float = None,
-                filters: FilterType = None) -> list[str]:
+                state_occupations: list[float] | None = None,
+                orbital_occupations: list[float] | None = None,
+                denmat: np.ndarray | None = None,
+                phi: float | None = None,
+                theta: float | None = None,
+                filters: FilterType | None = None) -> list[str]:
     """Routine sets the block in the n_mmp_mat file specified by species_name, orbital and spin
     to the desired density matrix
 

--- a/masci_tools/util/xml/xml_setters_nmmpmat.py
+++ b/masci_tools/util/xml/xml_setters_nmmpmat.py
@@ -13,25 +13,26 @@
 This module contains useful methods for initializing or modifying a n_mmp_mat file
 for LDA+U
 """
-from typing import Union, List, Optional
+from __future__ import annotations
+
 import numpy as np
 from lxml import etree
 from masci_tools.io.parsers import fleur_schema
 from masci_tools.util.xml.xpathbuilder import XPathBuilder, FilterType
 
 
-def set_nmmpmat(xmltree: Union[etree._Element, etree._ElementTree],
-                nmmplines: List[str],
-                schema_dict: 'fleur_schema.SchemaDict',
+def set_nmmpmat(xmltree: etree._Element | etree._ElementTree,
+                nmmplines: list[str],
+                schema_dict: fleur_schema.SchemaDict,
                 species_name: str,
                 orbital: int,
                 spin: int,
-                state_occupations: List[float] = None,
-                orbital_occupations: List[float] = None,
+                state_occupations: list[float] = None,
+                orbital_occupations: list[float] = None,
                 denmat: np.ndarray = None,
                 phi: float = None,
                 theta: float = None,
-                filters: FilterType = None) -> List[str]:
+                filters: FilterType = None) -> list[str]:
     """Routine sets the block in the n_mmp_mat file specified by species_name, orbital and spin
     to the desired density matrix
 
@@ -67,7 +68,7 @@ def set_nmmpmat(xmltree: Union[etree._Element, etree._ElementTree],
     elif species_name != 'all':
         species_xpath.add_filter('species', {'name': species_name})
 
-    all_species: List[etree._Element] = eval_xpath(xmltree, species_xpath, list_return=True)  #type:ignore
+    all_species: list[etree._Element] = eval_xpath(xmltree, species_xpath, list_return=True)  #type:ignore
 
     nspins = evaluate_attribute(xmltree, schema_dict, 'jspins')
     if 'l_mtnocoPot' in schema_dict['attrib_types']:
@@ -135,14 +136,14 @@ def set_nmmpmat(xmltree: Union[etree._Element, etree._ElementTree],
     return nmmplines
 
 
-def rotate_nmmpmat(xmltree: Union[etree._Element, etree._ElementTree],
-                   nmmplines: List[str],
-                   schema_dict: 'fleur_schema.SchemaDict',
+def rotate_nmmpmat(xmltree: etree._Element | etree._ElementTree,
+                   nmmplines: list[str],
+                   schema_dict: fleur_schema.SchemaDict,
                    species_name: str,
                    orbital: int,
                    phi: float,
                    theta: float,
-                   filters: FilterType = None) -> List[str]:
+                   filters: FilterType = None) -> list[str]:
     """
     Rotate the density matrix with the given angles phi and theta
 
@@ -173,7 +174,7 @@ def rotate_nmmpmat(xmltree: Union[etree._Element, etree._ElementTree],
     elif species_name != 'all':
         species_xpath.add_filter('species', {'name': species_name})
 
-    all_species: List[etree._Element] = eval_xpath(xmltree, species_xpath, list_return=True)  #type:ignore
+    all_species: list[etree._Element] = eval_xpath(xmltree, species_xpath, list_return=True)  #type:ignore
 
     nspins = evaluate_attribute(xmltree, schema_dict, 'jspins')
     if 'l_mtnocoPot' in schema_dict['attrib_types']:
@@ -227,8 +228,8 @@ def rotate_nmmpmat(xmltree: Union[etree._Element, etree._ElementTree],
     return nmmplines
 
 
-def validate_nmmpmat(xmltree: Union[etree._Element, etree._ElementTree], nmmplines: Optional[List[str]],
-                     schema_dict: 'fleur_schema.SchemaDict') -> None:
+def validate_nmmpmat(xmltree: etree._Element | etree._ElementTree, nmmplines: list[str] | None,
+                     schema_dict: fleur_schema.SchemaDict) -> None:
     """
     Checks that the given nmmp_lines is valid with the given xmltree
 

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -13,7 +13,9 @@
 Functions for modifying the xml input file of Fleur with explicit xpath arguments
 These can still use the schema dict for finding information about the xpath
 """
-from typing import Any, Iterable, List, Union, Dict, cast, Tuple
+from __future__ import annotations
+
+from typing import Any, Iterable, cast
 try:
     from typing import Literal
 except ImportError:
@@ -27,15 +29,14 @@ from masci_tools.io.parsers import fleur_schema
 from lxml import etree
 
 
-def xml_create_tag_schema_dict(
-        xmltree: Union[etree._Element, etree._ElementTree],
-        schema_dict: 'fleur_schema.SchemaDict',
-        xpath: XPathLike,
-        base_xpath: str,
-        element: Union[str, etree._Element],
-        create_parents: bool = False,
-        number_nodes: int = 1,
-        occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
+def xml_create_tag_schema_dict(xmltree: etree._Element | etree._ElementTree,
+                               schema_dict: fleur_schema.SchemaDict,
+                               xpath: XPathLike,
+                               base_xpath: str,
+                               element: str | etree._Element,
+                               create_parents: bool = False,
+                               number_nodes: int = 1,
+                               occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
     """
     This method evaluates an xpath expression and creates a tag in a xmltree under the
     returned nodes.
@@ -85,7 +86,7 @@ def xml_create_tag_schema_dict(
     if not several_tags and number_nodes > 1:
         raise ValueError(f'Can not create {number_nodes} nodes of tag {element_name}: Tag only allowed once')
 
-    parent_nodes: List[etree._Element] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+    parent_nodes: list[etree._Element] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
 
     if len(parent_nodes) == 0:
         if create_parents:
@@ -106,14 +107,14 @@ def xml_create_tag_schema_dict(
     return xmltree
 
 
-def eval_xpath_create(xmltree: Union[etree._Element, etree._ElementTree],
-                      schema_dict: 'fleur_schema.SchemaDict',
+def eval_xpath_create(xmltree: etree._Element | etree._ElementTree,
+                      schema_dict: fleur_schema.SchemaDict,
                       xpath: XPathLike,
                       base_xpath: str,
                       create_parents: bool = False,
-                      occurrences: Union[int, Iterable[int]] = None,
+                      occurrences: int | Iterable[int] | None = None,
                       number_nodes: int = 1,
-                      list_return: bool = False) -> List[etree._Element]:
+                      list_return: bool = False) -> list[etree._Element]:
     """
     Evaluates and xpath and creates tag if the result is empty
 
@@ -134,7 +135,7 @@ def eval_xpath_create(xmltree: Union[etree._Element, etree._ElementTree],
 
     check_complex_xpath(xmltree, base_xpath, xpath)
 
-    nodes: List[etree._Element] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+    nodes: list[etree._Element] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
 
     if len(nodes) == 0:
         parent_xpath, tag_name = split_off_tag(base_xpath)
@@ -155,14 +156,14 @@ def eval_xpath_create(xmltree: Union[etree._Element, etree._ElementTree],
     return nodes
 
 
-def xml_set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
-                         schema_dict: 'fleur_schema.SchemaDict',
+def xml_set_attrib_value(xmltree: etree._Element | etree._ElementTree,
+                         schema_dict: fleur_schema.SchemaDict,
                          xpath: XPathLike,
                          base_xpath: str,
                          attributename: str,
                          attribv: Any,
-                         occurrences: Union[int, Iterable[int]] = None,
-                         create: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                         occurrences: int | Iterable[int] | None = None,
+                         create: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets an attribute in a xmltree to a given value. By default the attribute will be set
     on all nodes returned for the specified xpath.
@@ -207,7 +208,7 @@ def xml_set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
     n_nodes = len(converted_attribv) if is_sequence(converted_attribv) else 1
 
     if create:
-        nodes: List[etree._Element] = eval_xpath_create(xmltree,
+        nodes: list[etree._Element] = eval_xpath_create(xmltree,
                                                         schema_dict,
                                                         xpath,
                                                         base_xpath,
@@ -227,13 +228,13 @@ def xml_set_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_set_attrib_value_no_create(xmltree, xpath, attributename, converted_attribv, occurrences=occurrences)
 
 
-def xml_set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree],
-                               schema_dict: 'fleur_schema.SchemaDict',
+def xml_set_first_attrib_value(xmltree: etree._Element | etree._ElementTree,
+                               schema_dict: fleur_schema.SchemaDict,
                                xpath: XPathLike,
                                base_xpath: str,
                                attributename: str,
                                attribv: Any,
-                               create: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                               create: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets the first occurrence attribute in a xmltree to a given value.
     If there are no nodes under the specified xpath a tag can be created with `create=True`.
@@ -266,13 +267,13 @@ def xml_set_first_attrib_value(xmltree: Union[etree._Element, etree._ElementTree
                                 occurrences=0)
 
 
-def xml_set_text(xmltree: Union[etree._Element, etree._ElementTree],
-                 schema_dict: 'fleur_schema.SchemaDict',
+def xml_set_text(xmltree: etree._Element | etree._ElementTree,
+                 schema_dict: fleur_schema.SchemaDict,
                  xpath: XPathLike,
                  base_xpath: str,
                  text: Any,
-                 occurrences: Union[int, Iterable[int]] = None,
-                 create: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                 occurrences: int | Iterable[int]  | None= None,
+                 create: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets the text on tags in a xmltree to a given value. By default the text will be set
     on all nodes returned for the specified xpath.
@@ -307,7 +308,7 @@ def xml_set_text(xmltree: Union[etree._Element, etree._ElementTree],
     n_nodes = len(converted_text) if is_sequence(converted_text) else 1
 
     if create:
-        nodes: List[etree._Element] = eval_xpath_create(xmltree,
+        nodes: list[etree._Element] = eval_xpath_create(xmltree,
                                                         schema_dict,
                                                         xpath,
                                                         base_xpath,
@@ -326,12 +327,12 @@ def xml_set_text(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_set_text_no_create(xmltree, xpath, converted_text, occurrences=occurrences)
 
 
-def xml_set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
-                       schema_dict: 'fleur_schema.SchemaDict',
+def xml_set_first_text(xmltree: etree._Element | etree._ElementTree,
+                       schema_dict: fleur_schema.SchemaDict,
                        xpath: XPathLike,
                        base_xpath: str,
                        text: Any,
-                       create: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                       create: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets the text on the first occurrence of a tag in a xmltree to a given value.
     If there are no nodes under the specified xpath a tag can be created with `create=True`.
@@ -354,15 +355,14 @@ def xml_set_first_text(xmltree: Union[etree._Element, etree._ElementTree],
     return xml_set_text(xmltree, schema_dict, xpath, base_xpath, text, create=create, occurrences=0)
 
 
-def xml_add_number_to_attrib(
-        xmltree: Union[etree._Element, etree._ElementTree],
-        schema_dict: 'fleur_schema.SchemaDict',
-        xpath: XPathLike,
-        base_xpath: str,
-        attributename: str,
-        add_number: Any,
-        mode: Literal['abs', 'rel'] = 'abs',
-        occurrences: Union[int, Iterable[int]] = None) -> Union[etree._Element, etree._ElementTree]:
+def xml_add_number_to_attrib(xmltree: etree._Element | etree._ElementTree,
+                             schema_dict: fleur_schema.SchemaDict,
+                             xpath: XPathLike,
+                             base_xpath: str,
+                             attributename: str,
+                             add_number: Any,
+                             mode: Literal['abs', 'rel'] = 'abs',
+                             occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
     """
     Adds a given number to the attribute value in a xmltree. By default the attribute will be shifted
     on all nodes returned for the specified xpath.
@@ -423,19 +423,19 @@ def xml_add_number_to_attrib(
     elif not str(xpath).endswith(f'/@{attributename}'):
         xpath = '/@'.join([str(xpath), attributename])
 
-    stringattribute: List[str] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+    stringattribute: list[str] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
 
     tag_xpath, attributename = split_off_attrib(xpath)
 
     if len(stringattribute) == 0:
         raise ValueError(f"No attribute values found for '{attributename}'. Cannot add number")
 
-    res: Tuple[List[Union[int, float]], bool] = convert_from_xml(stringattribute,
-                                                                 schema_dict,
-                                                                 attributename,
-                                                                 text=False,
-                                                                 constants=constants,
-                                                                 list_return=True)  #type:ignore
+    res: tuple[list[int | float], bool] = convert_from_xml(stringattribute,
+                                                           schema_dict,
+                                                           attributename,
+                                                           text=False,
+                                                           constants=constants,
+                                                           list_return=True)  #type:ignore
     attribvalues, _ = res
 
     if occurrences is not None:
@@ -469,13 +469,13 @@ def xml_add_number_to_attrib(
     return xmltree
 
 
-def xml_add_number_to_first_attrib(xmltree: Union[etree._Element, etree._ElementTree],
-                                   schema_dict: 'fleur_schema.SchemaDict',
+def xml_add_number_to_first_attrib(xmltree: etree._Element | etree._ElementTree,
+                                   schema_dict: fleur_schema.SchemaDict,
                                    xpath: XPathLike,
                                    base_xpath: str,
                                    attributename: str,
                                    add_number: Any,
-                                   mode: Literal['abs', 'rel'] = 'abs') -> Union[etree._Element, etree._ElementTree]:
+                                   mode: Literal['abs', 'rel'] = 'abs') -> etree._Element | etree._ElementTree:
     """
     Adds a given number to the first occurrence of a attribute value in a xmltree.
     If there are no nodes under the specified xpath an error is raised
@@ -506,13 +506,13 @@ def xml_add_number_to_first_attrib(xmltree: Union[etree._Element, etree._Element
                                     occurrences=0)
 
 
-def xml_set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
-                       schema_dict: 'fleur_schema.SchemaDict',
+def xml_set_simple_tag(xmltree: etree._Element | etree._ElementTree,
+                       schema_dict: fleur_schema.SchemaDict,
                        xpath: XPathLike,
                        base_xpath: str,
                        tag_name: str,
-                       changes: Union[List[Dict[str, Any]], Dict[str, Any]],
-                       create_parents: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                       changes: list[dict[str, Any]] | dict[str, Any],
+                       create_parents: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets one or multiple `simple` tag(s) in an xmltree. A simple tag can only hold attributes and has no
     subtags.
@@ -584,12 +584,12 @@ def xml_set_simple_tag(xmltree: Union[etree._Element, etree._ElementTree],
     return xmltree
 
 
-def xml_set_complex_tag(xmltree: Union[etree._Element, etree._ElementTree],
-                        schema_dict: 'fleur_schema.SchemaDict',
+def xml_set_complex_tag(xmltree: etree._Element | etree._ElementTree,
+                        schema_dict: fleur_schema.SchemaDict,
                         xpath: XPathLike,
                         base_xpath: str,
-                        attributedict: Dict[str, Any],
-                        create: bool = False) -> Union[etree._Element, etree._ElementTree]:
+                        attributedict: dict[str, Any],
+                        create: bool = False) -> etree._Element | etree._ElementTree:
     """
     Recursive Function to correctly set tags/attributes for a given tag.
     Goes through the attributedict and decides based on the schema_dict, how the corresponding

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -22,14 +22,14 @@ except ImportError:
     from typing_extensions import Literal  #type:ignore
 
 from masci_tools.util.xml.xpathbuilder import XPathBuilder
-from masci_tools.util.typing import XPathLike
+from masci_tools.util.typing import XPathLike, XMLLike
 from masci_tools.util.xml.common_functions import eval_xpath, add_tag
 from masci_tools.io.parsers import fleur_schema
 
 from lxml import etree
 
 
-def xml_create_tag_schema_dict(xmltree: etree._Element | etree._ElementTree,
+def xml_create_tag_schema_dict(xmltree: XMLLike,
                                schema_dict: fleur_schema.SchemaDict,
                                xpath: XPathLike,
                                base_xpath: str,
@@ -107,7 +107,7 @@ def xml_create_tag_schema_dict(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def eval_xpath_create(xmltree: etree._Element | etree._ElementTree,
+def eval_xpath_create(xmltree: XMLLike,
                       schema_dict: fleur_schema.SchemaDict,
                       xpath: XPathLike,
                       base_xpath: str,
@@ -156,7 +156,7 @@ def eval_xpath_create(xmltree: etree._Element | etree._ElementTree,
     return nodes
 
 
-def xml_set_attrib_value(xmltree: etree._Element | etree._ElementTree,
+def xml_set_attrib_value(xmltree: XMLLike,
                          schema_dict: fleur_schema.SchemaDict,
                          xpath: XPathLike,
                          base_xpath: str,
@@ -228,7 +228,7 @@ def xml_set_attrib_value(xmltree: etree._Element | etree._ElementTree,
     return xml_set_attrib_value_no_create(xmltree, xpath, attributename, converted_attribv, occurrences=occurrences)
 
 
-def xml_set_first_attrib_value(xmltree: etree._Element | etree._ElementTree,
+def xml_set_first_attrib_value(xmltree: XMLLike,
                                schema_dict: fleur_schema.SchemaDict,
                                xpath: XPathLike,
                                base_xpath: str,
@@ -267,7 +267,7 @@ def xml_set_first_attrib_value(xmltree: etree._Element | etree._ElementTree,
                                 occurrences=0)
 
 
-def xml_set_text(xmltree: etree._Element | etree._ElementTree,
+def xml_set_text(xmltree: XMLLike,
                  schema_dict: fleur_schema.SchemaDict,
                  xpath: XPathLike,
                  base_xpath: str,
@@ -327,7 +327,7 @@ def xml_set_text(xmltree: etree._Element | etree._ElementTree,
     return xml_set_text_no_create(xmltree, xpath, converted_text, occurrences=occurrences)
 
 
-def xml_set_first_text(xmltree: etree._Element | etree._ElementTree,
+def xml_set_first_text(xmltree: XMLLike,
                        schema_dict: fleur_schema.SchemaDict,
                        xpath: XPathLike,
                        base_xpath: str,
@@ -355,7 +355,7 @@ def xml_set_first_text(xmltree: etree._Element | etree._ElementTree,
     return xml_set_text(xmltree, schema_dict, xpath, base_xpath, text, create=create, occurrences=0)
 
 
-def xml_add_number_to_attrib(xmltree: etree._Element | etree._ElementTree,
+def xml_add_number_to_attrib(xmltree: XMLLike,
                              schema_dict: fleur_schema.SchemaDict,
                              xpath: XPathLike,
                              base_xpath: str,
@@ -399,7 +399,7 @@ def xml_add_number_to_attrib(xmltree: etree._Element | etree._ElementTree,
     possible_types = schema_dict['attrib_types'][attributename]
 
     if not etree.iselement(xmltree):
-        constants = read_constants(xmltree.getroot(), schema_dict)  #type:ignore
+        constants = read_constants(xmltree.getroot(), schema_dict)
     else:
         constants = read_constants(xmltree, schema_dict)
 
@@ -469,7 +469,7 @@ def xml_add_number_to_attrib(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def xml_add_number_to_first_attrib(xmltree: etree._Element | etree._ElementTree,
+def xml_add_number_to_first_attrib(xmltree: XMLLike,
                                    schema_dict: fleur_schema.SchemaDict,
                                    xpath: XPathLike,
                                    base_xpath: str,
@@ -506,7 +506,7 @@ def xml_add_number_to_first_attrib(xmltree: etree._Element | etree._ElementTree,
                                     occurrences=0)
 
 
-def xml_set_simple_tag(xmltree: etree._Element | etree._ElementTree,
+def xml_set_simple_tag(xmltree: XMLLike,
                        schema_dict: fleur_schema.SchemaDict,
                        xpath: XPathLike,
                        base_xpath: str,
@@ -584,7 +584,7 @@ def xml_set_simple_tag(xmltree: etree._Element | etree._ElementTree,
     return xmltree
 
 
-def xml_set_complex_tag(xmltree: etree._Element | etree._ElementTree,
+def xml_set_complex_tag(xmltree: XMLLike,
                         schema_dict: fleur_schema.SchemaDict,
                         xpath: XPathLike,
                         base_xpath: str,

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -36,7 +36,7 @@ def xml_create_tag_schema_dict(xmltree: XMLLike,
                                element: str | etree._Element,
                                create_parents: bool = False,
                                number_nodes: int = 1,
-                               occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
+                               occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     This method evaluates an xpath expression and creates a tag in a xmltree under the
     returned nodes.
@@ -163,7 +163,7 @@ def xml_set_attrib_value(xmltree: XMLLike,
                          attributename: str,
                          attribv: Any,
                          occurrences: int | Iterable[int] | None = None,
-                         create: bool = False) -> etree._Element | etree._ElementTree:
+                         create: bool = False) -> XMLLike:
     """
     Sets an attribute in a xmltree to a given value. By default the attribute will be set
     on all nodes returned for the specified xpath.
@@ -234,7 +234,7 @@ def xml_set_first_attrib_value(xmltree: XMLLike,
                                base_xpath: str,
                                attributename: str,
                                attribv: Any,
-                               create: bool = False) -> etree._Element | etree._ElementTree:
+                               create: bool = False) -> XMLLike:
     """
     Sets the first occurrence attribute in a xmltree to a given value.
     If there are no nodes under the specified xpath a tag can be created with `create=True`.
@@ -273,7 +273,7 @@ def xml_set_text(xmltree: XMLLike,
                  base_xpath: str,
                  text: Any,
                  occurrences: int | Iterable[int] | None = None,
-                 create: bool = False) -> etree._Element | etree._ElementTree:
+                 create: bool = False) -> XMLLike:
     """
     Sets the text on tags in a xmltree to a given value. By default the text will be set
     on all nodes returned for the specified xpath.
@@ -332,7 +332,7 @@ def xml_set_first_text(xmltree: XMLLike,
                        xpath: XPathLike,
                        base_xpath: str,
                        text: Any,
-                       create: bool = False) -> etree._Element | etree._ElementTree:
+                       create: bool = False) -> XMLLike:
     """
     Sets the text on the first occurrence of a tag in a xmltree to a given value.
     If there are no nodes under the specified xpath a tag can be created with `create=True`.
@@ -362,7 +362,7 @@ def xml_add_number_to_attrib(xmltree: XMLLike,
                              attributename: str,
                              add_number: Any,
                              mode: Literal['abs', 'rel'] = 'abs',
-                             occurrences: int | Iterable[int] | None = None) -> etree._Element | etree._ElementTree:
+                             occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Adds a given number to the attribute value in a xmltree. By default the attribute will be shifted
     on all nodes returned for the specified xpath.
@@ -475,7 +475,7 @@ def xml_add_number_to_first_attrib(xmltree: XMLLike,
                                    base_xpath: str,
                                    attributename: str,
                                    add_number: Any,
-                                   mode: Literal['abs', 'rel'] = 'abs') -> etree._Element | etree._ElementTree:
+                                   mode: Literal['abs', 'rel'] = 'abs') -> XMLLike:
     """
     Adds a given number to the first occurrence of a attribute value in a xmltree.
     If there are no nodes under the specified xpath an error is raised
@@ -512,7 +512,7 @@ def xml_set_simple_tag(xmltree: XMLLike,
                        base_xpath: str,
                        tag_name: str,
                        changes: list[dict[str, Any]] | dict[str, Any],
-                       create_parents: bool = False) -> etree._Element | etree._ElementTree:
+                       create_parents: bool = False) -> XMLLike:
     """
     Sets one or multiple `simple` tag(s) in an xmltree. A simple tag can only hold attributes and has no
     subtags.
@@ -589,7 +589,7 @@ def xml_set_complex_tag(xmltree: XMLLike,
                         xpath: XPathLike,
                         base_xpath: str,
                         attributedict: dict[str, Any],
-                        create: bool = False) -> etree._Element | etree._ElementTree:
+                        create: bool = False) -> XMLLike:
     """
     Recursive Function to correctly set tags/attributes for a given tag.
     Goes through the attributedict and decides based on the schema_dict, how the corresponding

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -272,7 +272,7 @@ def xml_set_text(xmltree: etree._Element | etree._ElementTree,
                  xpath: XPathLike,
                  base_xpath: str,
                  text: Any,
-                 occurrences: int | Iterable[int]  | None= None,
+                 occurrences: int | Iterable[int] | None = None,
                  create: bool = False) -> etree._Element | etree._ElementTree:
     """
     Sets the text on tags in a xmltree to a given value. By default the text will be set

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -13,10 +13,17 @@
 This module contains Classes for building complex XPath expressions based on
 general attribute conditions from simple XPath expressions
 """
-from typing import Dict, Any, Iterable, cast, Union, Tuple
+from __future__ import annotations
+
+from typing import Any, Iterable, cast
+try:
+    from typing import TypeAlias  #type: ignore[attr-defined]
+except ImportError:
+    from typing_extensions import TypeAlias
+
 from lxml import etree
 
-FilterType = Dict[str, Any]
+FilterType: TypeAlias = 'dict[str, Any]'
 
 
 class XPathBuilder:
@@ -103,8 +110,8 @@ class XPathBuilder:
     }
 
     def __init__(self,
-                 simple_path: 'etree._xpath',
-                 filters: Dict[str, FilterType] = None,
+                 simple_path: etree._xpath,
+                 filters: dict[str, FilterType] = None,
                  compile_path: bool = False,
                  strict: bool = False,
                  **kwargs) -> None:
@@ -123,14 +130,14 @@ class XPathBuilder:
             raise NotImplementedError('The given xpath has multiple tags with the same name')
 
         self.path_kwargs = kwargs
-        self.filters: Dict[str, FilterType] = {}
-        self.path_variables: Dict[str, 'etree._XPathObject'] = {}
+        self.filters: dict[str, FilterType] = {}
+        self.path_variables: dict[str, etree._XPathObject] = {}
         self.value_conditions: int = 0
         if filters is not None:
             for key, val in filters.items():
                 self.add_filter(key, val)
 
-    def add_filter(self, tag: str, conditions: Union[FilterType, Any]) -> None:
+    def add_filter(self, tag: str, conditions: FilterType | Any) -> None:
         """
         Add a filter to the filters dictionary
 
@@ -289,7 +296,7 @@ class XPathBuilder:
 
         return predicate
 
-    def _path_condition(self, path: Union[str, Tuple[str, ...]], prefix: str) -> str:
+    def _path_condition(self, path: str | tuple[str, ...], prefix: str) -> str:
         """
         Prepare conditions based on variables
 
@@ -315,7 +322,7 @@ class XPathBuilder:
         return '/'.join(path_variable)
 
     @property
-    def path(self) -> 'etree._xpath':
+    def path(self) -> etree._xpath:
         """
         Property for constructing the complex Xpath
         """

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -111,10 +111,10 @@ class XPathBuilder:
 
     def __init__(self,
                  simple_path: etree._xpath,
-                 filters: dict[str, FilterType] = None,
+                 filters: dict[str, FilterType] | None = None,
                  compile_path: bool = False,
                  strict: bool = False,
-                 **kwargs) -> None:
+                 **kwargs: Any) -> None:
         self.compile_path = compile_path
         self.strict = strict
         if not self.compile_path and kwargs:

--- a/masci_tools/vis/bokeh_plots.py
+++ b/masci_tools/vis/bokeh_plots.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #
@@ -488,9 +487,9 @@ def bokeh_spinpol_dos(energy_grid,
         spin_up_data, spin_dn_data = spin_up_data[:len(spin_up_data) // 2], spin_up_data[len(spin_up_data) // 2:]
 
     if spin_up_data is None and data is not None:
-        spin_up_data = set(key for key in data.keys() if '_up' in key)
+        spin_up_data = {key for key in data.keys() if '_up' in key}
         spin_up_data = sorted(spin_up_data)
-        spin_dn_data = set(key for key in data.keys() if '_dn' in key)
+        spin_dn_data = {key for key in data.keys() if '_dn' in key}
         spin_dn_data = sorted(spin_dn_data)
 
     plot_data = process_data_arguments(data=data,

--- a/masci_tools/vis/bokeh_plotter.py
+++ b/masci_tools/vis/bokeh_plotter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/vis/common.py
+++ b/masci_tools/vis/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/vis/data.py
+++ b/masci_tools/vis/data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/vis/data.py
+++ b/masci_tools/vis/data.py
@@ -554,7 +554,7 @@ class PlotData:
         expand_data = not isinstance(self.data, list) and len(self) > 1
 
         data = []
-        for indx, ((entry, source), mask_indx) in enumerate(zip(self.items(mappable=True), mask)):
+        for indx, ((_, source), mask_indx) in enumerate(zip(self.items(mappable=True), mask)):
 
             if not isinstance(source, pd.DataFrame):
                 source = pd.DataFrame(data=source)

--- a/masci_tools/vis/fleur.py
+++ b/masci_tools/vis/fleur.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/vis/fleur.py
+++ b/masci_tools/vis/fleur.py
@@ -412,7 +412,7 @@ def _process_dos_kwargs(ordered_keys, backend=None, **kwargs):
             continue
         if isinstance(value, dict):
             new_dict = value.copy()
-            for plot_label, val in value.items():
+            for plot_label in value:
                 if not isinstance(plot_label, int):
                     if plot_label in ordered_keys:
                         new_dict[ordered_keys.index(plot_label)] = new_dict.pop(plot_label)
@@ -446,7 +446,7 @@ def _dos_order(key):
     if key in general:
         return (spin, general.index(key))
     if ':' in key:
-        before, after = key.split(':', maxsplit=1)
+        _, after = key.split(':', maxsplit=1)
         tail = after.lstrip('0123456789')
         index = int(after[:-len(tail)]) if len(tail) > 0 else int(after)
 

--- a/masci_tools/vis/kkr_plot_FS_qdos.py
+++ b/masci_tools/vis/kkr_plot_FS_qdos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/vis/kkr_plot_bandstruc_qdos.py
+++ b/masci_tools/vis/kkr_plot_bandstruc_qdos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #
@@ -14,10 +13,6 @@
 dispersionplot function for plotting KKR bandstructures (i.e. qdos) files
 """
 
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from six.moves import range  # pylint: disable=redefined-builtin
 
 
 def dispersionplot(

--- a/masci_tools/vis/kkr_plot_bandstruc_qdos.py
+++ b/masci_tools/vis/kkr_plot_bandstruc_qdos.py
@@ -14,7 +14,6 @@ dispersionplot function for plotting KKR bandstructures (i.e. qdos) files
 """
 
 
-
 def dispersionplot(
     p0='./',
     totonly=True,

--- a/masci_tools/vis/kkr_plot_dos.py
+++ b/masci_tools/vis/kkr_plot_dos.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/vis/kkr_plot_shapefun.py
+++ b/masci_tools/vis/kkr_plot_shapefun.py
@@ -10,7 +10,6 @@
 ###############################################################################
 
 
-
 def plot_shapefun(pos, out, mode):
     """
   Creates a simple matplotlib image to show the shapefunctions given it's positions in the unit cell, the atoms's vertices in `ut` and the plotting mode

--- a/masci_tools/vis/kkr_plot_shapefun.py
+++ b/masci_tools/vis/kkr_plot_shapefun.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), 2018 Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.    #
 #                All rights reserved.                                         #
@@ -10,9 +9,6 @@
 #                                                                             #
 ###############################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
-from six.moves import range
 
 
 def plot_shapefun(pos, out, mode):

--- a/masci_tools/vis/matplotlib_plotter.py
+++ b/masci_tools/vis/matplotlib_plotter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/masci_tools/vis/parameters.py
+++ b/masci_tools/vis/parameters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #
@@ -630,7 +629,7 @@ class Plotter:
 
         :param filename: filename,from  where the defaults should be taken
         """
-        with open(filename, 'r', encoding='utf-8') as file:
+        with open(filename, encoding='utf-8') as file:
             param_dict = json.load(file)
 
         self.set_defaults(**param_dict)

--- a/masci_tools/vis/parameters.py
+++ b/masci_tools/vis/parameters.py
@@ -163,10 +163,9 @@ class Plotter:
     Base class for handling parameters for plotting methods. For different plotting backends
     a subclass can be created to represent the specific parameters of the backend.
 
-    Args:
-        :param default_parameters: dict with hardcoded default parameters
-        :param general_keys: set of str optional, defines parameters which are
-                             not allowed to change for each entry in the plot data
+    :param default_parameters: dict with hardcoded default parameters
+    :param general_keys: set of str optional, defines parameters which are
+                            not allowed to change for each entry in the plot data
 
     Kwargs in the __init__ method are forwarded to :py:func:`Plotter.set_defaults()`
     to change the current defaults away from the hardcoded parameters.

--- a/masci_tools/vis/plot_methods.py
+++ b/masci_tools/vis/plot_methods.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 ###############################################################################
 # Copyright (c), Forschungszentrum Jülich GmbH, IAS-1/PGI-1, Germany.         #
 #                All rights reserved.                                         #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ PyYAML = "*"
 python_version="3.8"
 warn_unused_ignores=true
 warn_redundant_casts=true
+no_implicit_optional=true
 show_error_codes = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ warn_unused_ignores=true
 warn_redundant_casts=true
 no_implicit_optional=true
 show_error_codes = true
+warn_no_return = true
+disallow_incomplete_defs=true
+disallow_subclassing_any=true
 
 [[tool.mypy.overrides]]
 module = 'h5py'

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 setup: usage: pip install -e .[graphs]
 """
 
-from __future__ import absolute_import
 from setuptools import setup, find_packages
 import io  # needed to have `open` with encoding option
 
@@ -11,7 +9,7 @@ import io  # needed to have `open` with encoding option
 from os import path
 
 this_directory = path.abspath(path.dirname(__file__))
-with io.open(path.join(this_directory, 'README.md'), encoding='utf8') as f:
+with open(path.join(this_directory, 'README.md'), encoding='utf8') as f:
     long_description = f.read()
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ if __name__ == '__main__':
         extras_require={
             'pre-commit':
             ['mypy==0.930', 'pre-commit>=2.6.0', 'yapf>=0.30.0', 'pylint~=2.11.1', 'pytest~=6.0', 'lxml-stubs'],
-            'docs': ['Sphinx', 'docutils', 'sphinx_rtd_theme', 'sphinx-click'],
+            'docs':
+            ['Sphinx', 'docutils', 'sphinx_rtd_theme', 'sphinx-click', 'sphinx-toolbox', 'sphinx-autodoc-typehints'],
             'testing': ['pytest~=6.0', 'pytest-cov', 'pytest-mpl>=0.12', 'pytest-regressions>=1.0'],
             'bokeh-plots': [
                 'bokeh<=1.4.0'  # versions beyond 1.4.0 require a tornardo version not compatible with aiida-core /circus

--- a/tests/cmdline/conftest.py
+++ b/tests/cmdline/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Fixtures used for testing the cli commands
 """

--- a/tests/cmdline/test_fleur_schema.py
+++ b/tests/cmdline/test_fleur_schema.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the commands in the fleur-schema subgroup of the masci-tools cli
 """

--- a/tests/cmdline/test_inpxml_converter.py
+++ b/tests/cmdline/test_inpxml_converter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the inpxml converter
 """
@@ -23,7 +22,7 @@ def test_generate_conversion(file_regression, remove_conversion):
     print(result.output)
 
     assert result.exception is None, 'An unexpected exception occured: {result.exception}'
-    with open(file_path, 'r', encoding='utf-8') as f:
+    with open(file_path, encoding='utf-8') as f:
         content = f.read()
 
     file_regression.check(content, extension='.json')
@@ -44,7 +43,7 @@ def test_convert_inpxml(tmp_path, test_file, file_regression):
     print(result.output)
 
     assert result.exception is None, 'An unexpected exception occured: {result.exception}'
-    with open(tmp_path / 'inp.xml', 'r', encoding='utf-8') as f:
+    with open(tmp_path / 'inp.xml', encoding='utf-8') as f:
         content = f.read()
 
     file_regression.check(content, extension='.xml')

--- a/tests/cmdline/test_parse.py
+++ b/tests/cmdline/test_parse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the parse commands in the cli
 """

--- a/tests/cmdline/test_plot.py
+++ b/tests/cmdline/test_plot.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test of the plot commands in the cli
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Configurations for masci_tools tests
 """
@@ -34,7 +33,7 @@ def load_inpxml(test_file):
         import masci_tools.io.io_fleurxml as fleur_io
         if not absolute:
             path = test_file(path)
-        with open(path, 'r', encoding='utf-8') as inpxmlfile:
+        with open(path, encoding='utf-8') as inpxmlfile:
             return fleur_io.load_inpxml(inpxmlfile)
 
     return _load_inpxml
@@ -48,7 +47,7 @@ def load_outxml(test_file):
         import masci_tools.io.io_fleurxml as fleur_io
         if not absolute:
             path = test_file(path)
-        with open(path, 'r', encoding='utf-8') as outxmlfile:
+        with open(path, encoding='utf-8') as outxmlfile:
             return fleur_io.load_outxml(outxmlfile)
 
     return _load_outxml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 Configurations for masci_tools tests
 """
 import pytest
-from pprint import pprint
 from pathlib import Path
 import os
 

--- a/tests/files/fleur/collect_fleur_xml_files.py
+++ b/tests/files/fleur/collect_fleur_xml_files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Function to collect input files from a specfied folder and subfolders and copy them to
 the tests/files/fleur folder

--- a/tests/files/kkr/import_calc_old_style/test.py
+++ b/tests/files/kkr/import_calc_old_style/test.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 # pylint: skip-file
 
-from __future__ import absolute_import
 from masci_tools.io.kkr_params import kkrparams
 
 p = kkrparams(params_type='kkr')

--- a/tests/test_bokeh_plots.py
+++ b/tests/test_bokeh_plots.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the bokeh visualization. Since the concrete visualization is difficult
 to test we check the content of the underlying json for correctness

--- a/tests/test_cf_calculation.py
+++ b/tests/test_cf_calculation.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the crystal field calculations
 """

--- a/tests/test_common_functions.py
+++ b/tests/test_common_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 @author: ruess
 """
@@ -51,7 +50,7 @@ class Test_common_functions:
         assert abs(alat - np.sqrt(2) / 2) < 10**-10
 
     def test_search_string(self):
-        with open(DIR / Path('files/kkr/kkr_run_dos_output/output.0.txt'), 'r', encoding='utf-8') as f:
+        with open(DIR / Path('files/kkr/kkr_run_dos_output/output.0.txt'), encoding='utf-8') as f:
             txt = f.readlines()
         alatline = search_string('ALAT', txt)
         noline = search_string('ALT', txt)

--- a/tests/test_common_plots.py
+++ b/tests/test_common_plots.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the vis.common module Only the general routines are tested here (e.g. dos and bands routines are tested via the higher level fleur tests)
 """

--- a/tests/test_fleur_inpxml_parser.py
+++ b/tests/test_fleur_inpxml_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the inp.xml parser for Fleur
 """
@@ -76,7 +75,7 @@ def test_inpxml_valid_inpxml(inpxmlfilepath):
     assert inp_dict != {}
 
     #Pass file handle
-    with open(inpxmlfilepath, 'r', encoding='utf-8') as inpfile:
+    with open(inpxmlfilepath, encoding='utf-8') as inpfile:
         inp_dict = inpxml_parser(inpfile)
 
     assert inp_dict is not None

--- a/tests/test_fleur_outxml_conversions.py
+++ b/tests/test_fleur_outxml_conversions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for fleur outxml_parser specific conversion functions
 """

--- a/tests/test_fleur_outxml_parser.py
+++ b/tests/test_fleur_outxml_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the out.xml parser for Fleur
 """
@@ -46,7 +45,7 @@ def test_outxml_valid_outxml(outxmlfilepath):
     assert out_dict != {}
 
     #call with contextmanager
-    with open(outxmlfilepath, 'r', encoding='utf-8') as outfile:
+    with open(outxmlfilepath, encoding='utf-8') as outfile:
         out_dict = outxml_parser(outfile)
 
     assert out_dict is not None

--- a/tests/test_fleur_vis.py
+++ b/tests/test_fleur_vis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test of the DOS/bandstructure visualizations
 """

--- a/tests/test_fleurxmlmodifier.py
+++ b/tests/test_fleurxmlmodifier.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test for the FleurXMLModifier calss
 """

--- a/tests/test_hdf5_reader.py
+++ b/tests/test_hdf5_reader.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Regression tests for the HDF5Reader class
 """

--- a/tests/test_io_fleur_inpgen.py
+++ b/tests/test_io_fleur_inpgen.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the fleur_inpgen module
 """
@@ -333,7 +332,7 @@ def test_read_inpgen_file_contents(datadir, data_regression):
 
     TESTFILE = datadir / 'test_write_inpgen_file_defaults_dict.txt'
 
-    with open(TESTFILE, 'r', encoding='utf-8') as f:
+    with open(TESTFILE, encoding='utf-8') as f:
         content = f.read()
 
     cell, atom_sites, pbc, input_params = read_inpgen_file(content)
@@ -351,7 +350,7 @@ def test_read_inpgen_file_handle(datadir, data_regression):
 
     TESTFILE = datadir / 'test_write_inpgen_file_defaults_dict.txt'
 
-    with open(TESTFILE, 'r', encoding='utf-8') as f:
+    with open(TESTFILE, encoding='utf-8') as f:
         cell, atom_sites, pbc, input_params = read_inpgen_file(f)
 
     data_regression.check({

--- a/tests/test_io_fleurxml.py
+++ b/tests/test_io_fleurxml.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for the load functions in io_fleurxml
 """
@@ -25,7 +24,7 @@ def test_load_inpxml(test_file):
     assert schema_dict['inp_version'] == '0.34'
 
     #Pass file handle
-    with open(TEST_INPXML_PATH, 'r', encoding='utf-8') as inpfile:
+    with open(TEST_INPXML_PATH, encoding='utf-8') as inpfile:
         xmltree, schema_dict = load_inpxml(inpfile)
 
     assert xmltree is not None
@@ -53,7 +52,7 @@ def test_load_outxml(test_file):
     assert schema_dict['inp_version'] == '0.34'
 
     #Pass file handle
-    with open(TEST_OUTXML_PATH, 'r', encoding='utf-8') as inpfile:
+    with open(TEST_OUTXML_PATH, encoding='utf-8') as inpfile:
         xmltree, schema_dict = load_outxml(inpfile)
 
     assert xmltree is not None

--- a/tests/test_kkr_plotting.py
+++ b/tests/test_kkr_plotting.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 Tests for kkr-specific plotting functions
 """

--- a/tests/test_kkrimp_tools.py
+++ b/tests/test_kkrimp_tools.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Test of kkrimp tools
 """
@@ -21,7 +20,7 @@ class Test_modify_potential:
         atom2shapes = [1]
         shapefun_new = os.fspath(DIR / Path('files/mod_pot/test2/shapefun_new'))
         modify_potential().shapefun_from_scoef(scoefpath, shapefun_path, atom2shapes, shapefun_new)
-        with open(shapefun_new, 'r', encoding='utf-8') as f:
+        with open(shapefun_new, encoding='utf-8') as f:
             txt = f.read().strip()
         file_regression.check(txt)
 
@@ -32,7 +31,7 @@ class Test_modify_potential:
         neworder = [0, 1, 2]
         # test 1: neworder_potential standard
         modify_potential().neworder_potential(pot, out_pot, neworder)
-        with open(out_pot, 'r', encoding='utf-8') as f:
+        with open(out_pot, encoding='utf-8') as f:
             txt = f.read().strip()
         file_regression.check(txt)
 
@@ -45,7 +44,7 @@ class Test_modify_potential:
         # test 2: neworder_potential with replace from second potential
         replace_newpos = [[0, 0], [2, 0]]
         modify_potential().neworder_potential(pot1, out_pot, neworder, potfile_2=pot2, replace_from_pot2=replace_newpos)
-        with open(out_pot, 'r', encoding='utf-8') as f:
+        with open(out_pot, encoding='utf-8') as f:
             txt = f.read().strip()
         file_regression.check(txt)
 
@@ -124,7 +123,7 @@ class Test_KkrimpParserFunctions:
         print(f'\nmessages?\n{m}\n')
         print(f'\nout_dict?\n{o}\n')
         assert not s
-        assert set(m) == set([
+        assert set(m) == {
             'Error parsing output of KKRimp: Version Info', 'Error parsing output of KKRimp: rms-error',
             'Error parsing output of KKRimp: nspin/natom', 'Error parsing output of KKRimp: total magnetic moment',
             'Error parsing output of KKRimp: spin moment per atom', 'Error parsing output of KKRimp: orbital moment',
@@ -133,5 +132,5 @@ class Test_KkrimpParserFunctions:
             'Error parsing output of KKRimp: single particle energies', 'Error parsing output of KKRimp: charges',
             'Error parsing output of KKRimp: energy contour', 'Error parsing output of KKRimp: core_states',
             'Error parsing output of KKRimp: scfinfo'
-        ])
+        }
         assert o == {'convergence_group': {}}

--- a/tests/test_kkrparams.py
+++ b/tests/test_kkrparams.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Wed Nov 15 16:43:31 2017
 
@@ -126,8 +125,8 @@ class Test_get_info:  # pylint: disable=missing-class-docstring
     def test_get_mandatory(self):
         p = kkrparams()
         manlist = p.get_all_mandatory()
-        assert set(manlist) == set(
-            ['LMAX', 'NAEZ', 'BRAVAIS', 'RMAX', 'GMAX', 'NSPIN', '<RBASIS>', 'ALATBASIS', '<ZATOM>'])
+        assert set(manlist) == {
+            'LMAX', 'NAEZ', 'BRAVAIS', 'RMAX', 'GMAX', 'NSPIN', '<RBASIS>', 'ALATBASIS', '<ZATOM>'}
 
     def test_get_set_values(self):
         p = kkrparams()
@@ -177,7 +176,7 @@ class Test_get_info:  # pylint: disable=missing-class-docstring
         runopt = p.get_value('RUNOPT')
         testopt = p.get_value('TESTOPT')
         assert runopt == ['NEWSOSOL']
-        assert set(testopt) == set(['test1', 'test2'])
+        assert set(testopt) == {'test1', 'test2'}
 
 
 class Test_fill_inputfile:
@@ -231,7 +230,7 @@ class Test_fill_inputfile:
         with tempfile.TemporaryDirectory() as td:
             os.chdir(td)
             p.fill_keywords_to_inputfile(is_voro_calc=True)
-            with open('inputcard', 'r', encoding='utf-8') as f:
+            with open('inputcard', encoding='utf-8') as f:
                 file_content = f.read()
             os.chdir(cwd)
 
@@ -252,7 +251,7 @@ class Test_fill_inputfile:
         with tempfile.TemporaryDirectory() as td:
             os.chdir(td)
             p.fill_keywords_to_inputfile()
-            with open('inputcard', 'r', encoding='utf-8') as f:
+            with open('inputcard', encoding='utf-8') as f:
                 file_content = f.read().strip()
             os.chdir(cwd)
 
@@ -464,7 +463,7 @@ class Test_read_inputfile:  # pylint: disable=missing-class-docstring
         with tempfile.TemporaryDirectory() as td:
             os.chdir(td)
             p.fill_keywords_to_inputfile(output='input.temp.txt')
-            with open('input.temp.txt', 'r', encoding='utf-8') as f:
+            with open('input.temp.txt', encoding='utf-8') as f:
                 txt = f.readlines()
             # exchange some lines
             tmp = txt[0]
@@ -523,14 +522,14 @@ class Test_other:  # pylint: disable=missing-class-docstring
     def test_get_missing_keys(self):
         p = kkrparams()
         missing = p.get_missing_keys()
-        assert set(missing) == set(
-            ['<ZATOM>', 'BRAVAIS', 'LMAX', 'GMAX', 'RMAX', 'NAEZ', '<RBASIS>', 'NSPIN', 'ALATBASIS'])
+        assert set(missing) == {
+            '<ZATOM>', 'BRAVAIS', 'LMAX', 'GMAX', 'RMAX', 'NAEZ', '<RBASIS>', 'NSPIN', 'ALATBASIS'}
         missing = p.get_missing_keys(use_aiida=True)
-        assert set(missing) == set(['LMAX', 'GMAX', 'RMAX', 'NSPIN'])
+        assert set(missing) == {'LMAX', 'GMAX', 'RMAX', 'NSPIN'}
 
         p = kkrparams(params_type='voronoi', EMIN=-2, LMAX=3)
         missing = p.get_missing_keys()
-        assert set(missing) == set(['<ZATOM>', 'BRAVAIS', 'RCLUSTZ', 'NAEZ', '<RBASIS>', 'NSPIN', 'ALATBASIS'])
+        assert set(missing) == {'<ZATOM>', 'BRAVAIS', 'RCLUSTZ', 'NAEZ', '<RBASIS>', 'NSPIN', 'ALATBASIS'}
 
     def test_set_value_None(self):
         p = kkrparams()

--- a/tests/test_kkrparams.py
+++ b/tests/test_kkrparams.py
@@ -125,8 +125,7 @@ class Test_get_info:  # pylint: disable=missing-class-docstring
     def test_get_mandatory(self):
         p = kkrparams()
         manlist = p.get_all_mandatory()
-        assert set(manlist) == {
-            'LMAX', 'NAEZ', 'BRAVAIS', 'RMAX', 'GMAX', 'NSPIN', '<RBASIS>', 'ALATBASIS', '<ZATOM>'}
+        assert set(manlist) == {'LMAX', 'NAEZ', 'BRAVAIS', 'RMAX', 'GMAX', 'NSPIN', '<RBASIS>', 'ALATBASIS', '<ZATOM>'}
 
     def test_get_set_values(self):
         p = kkrparams()
@@ -522,8 +521,7 @@ class Test_other:  # pylint: disable=missing-class-docstring
     def test_get_missing_keys(self):
         p = kkrparams()
         missing = p.get_missing_keys()
-        assert set(missing) == {
-            '<ZATOM>', 'BRAVAIS', 'LMAX', 'GMAX', 'RMAX', 'NAEZ', '<RBASIS>', 'NSPIN', 'ALATBASIS'}
+        assert set(missing) == {'<ZATOM>', 'BRAVAIS', 'LMAX', 'GMAX', 'RMAX', 'NAEZ', '<RBASIS>', 'NSPIN', 'ALATBASIS'}
         missing = p.get_missing_keys(use_aiida=True)
         assert set(missing) == {'LMAX', 'GMAX', 'RMAX', 'NSPIN'}
 

--- a/tests/test_kkrparser_functions.py
+++ b/tests/test_kkrparser_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 @author: ruess
 """
@@ -113,14 +112,14 @@ class Test_kkr_parser_functions:
                                                            self.timing_file, self.potfile_out, self.nonco_out_file)
         out_dict['parser_warnings'] = msg_list
         assert not success
-        assert set(msg_list) == set([
+        assert set(msg_list) == {
             'Error parsing output of KKR: Version Info', 'Error parsing output of KKR: rms-error',
             'Error parsing output of KKR: charge neutrality', 'Error parsing output of KKR: total magnetic moment',
             'Error parsing output of KKR: spin moment per atom', 'Error parsing output of KKR: orbital moment',
             'Error parsing output of KKR: EF', 'Error parsing output of KKR: DOS@EF',
             'Error parsing output of KKR: total energy', 'Error parsing output of KKR: search for warnings',
             'Error parsing output of KKR: charges', 'Error parsing output of KKR: scfinfo'
-        ])
+        }
 
     def test_missing_outfile0init(self):
         """
@@ -131,7 +130,7 @@ class Test_kkr_parser_functions:
                                                            self.timing_file, self.potfile_out, self.nonco_out_file)
         out_dict['parser_warnings'] = msg_list
         assert not success
-        assert set(msg_list) == set([
+        assert set(msg_list) == {
             'Error parsing output of KKR: nspin/natom',
             'Error parsing output of KKR: spin moment per atom',
             'Error parsing output of KKR: orbital moment',
@@ -144,7 +143,7 @@ class Test_kkr_parser_functions:
             'Error parsing output of KKR: lattice vectors (direct/reciprocal)',
             'Error parsing output of KKR: noco angles rms value',
             'Error parsing output of KKR: BdG',
-        ])
+        }
 
     def test_missing_outfile000(self):
         """
@@ -155,11 +154,11 @@ class Test_kkr_parser_functions:
                                                            self.timing_file, self.potfile_out, self.nonco_out_file)
         out_dict['parser_warnings'] = msg_list
         assert not success
-        assert set(msg_list) == set([
+        assert set(msg_list) == {
             'Error parsing output of KKR: rms-error', 'Error parsing output of KKR: single particle energies',
             'Error parsing output of KKR: charges', 'Error parsing output of KKR: scfinfo',
             'Error parsing output of KKR: kmesh'
-        ])
+        }
 
     def test_missing_timingfile(self):
         """

--- a/tests/test_parse_tasks.py
+++ b/tests/test_parse_tasks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for the ParseTasks class
 """

--- a/tests/test_plot_data.py
+++ b/tests/test_plot_data.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the `masci_tools.vis.data` module
 """

--- a/tests/test_plot_methods.py
+++ b/tests/test_plot_methods.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 Tests of the matplotib plotting functions
 """

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -156,7 +156,7 @@ def test_plotter_save_defaults_complete(file_regression):
         file_regression.check(txt)
 
 
-def test_plotter_load_defaults(file_regression):
+def test_plotter_load_defaults():
     """
     Test adding of custom parameters
     """

--- a/tests/test_plotter.py
+++ b/tests/test_plotter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the plotter base class
 """

--- a/tests/test_schema_dict.py
+++ b/tests/test_schema_dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test of the consistency the input schema dictionaries with the SchemaFiles in the same folder
 """
@@ -625,7 +624,7 @@ def clean_for_reg_dump(value_to_clean):
         for indx, val in enumerate(value_to_clean):
             value_to_clean[indx] = clean_for_reg_dump(val)
     elif isinstance(value_to_clean, CaseInsensitiveFrozenSet):
-        value_to_clean = set(clean_for_reg_dump(val) for val in value_to_clean)
+        value_to_clean = {clean_for_reg_dump(val) for val in value_to_clean}
     elif isinstance(value_to_clean, AttributeType):
         value_to_clean = dict(value_to_clean._asdict())
 

--- a/tests/test_voroparser_functions.py
+++ b/tests/test_voroparser_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 @author: ruess
 """

--- a/tests/util/test_case_insensitive_dict.py
+++ b/tests/util/test_case_insensitive_dict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for the case insensitive containers implemented in util/case_insensitive_dict.py
 """

--- a/tests/util/test_case_insensitive_frozenset.py
+++ b/tests/util/test_case_insensitive_frozenset.py
@@ -66,6 +66,7 @@ def test_case_insensitive_frozenset_difference(test_set, exp_diff, exp_case):
 
     assert isinstance(actual, CaseInsensitiveFrozenSet)
     assert s - test_set == actual
+    assert actual == exp_diff
     assert actual.original_case == exp_case
 
 
@@ -153,5 +154,6 @@ def test_case_insensitive_frozenset_intersection(test_set, exp_intersect, exp_ca
     actual = s.intersection(test_set)
     print(actual.original_case)
     assert isinstance(actual, CaseInsensitiveFrozenSet)
+    assert actual == exp_intersect
     assert s & test_set == actual
     assert actual.original_case == exp_case

--- a/tests/util/test_case_insensitive_frozenset.py
+++ b/tests/util/test_case_insensitive_frozenset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test for the case insensitive, immutable set implemented in util
 """

--- a/tests/util/test_econfig.py
+++ b/tests/util/test_econfig.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the econfig module
 """

--- a/tests/util/test_fleur_calculate_expression.py
+++ b/tests/util/test_fleur_calculate_expression.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the calculator of mathematical expressions in the inp.xml files
 """

--- a/tests/util/test_fleur_calculate_expression.py
+++ b/tests/util/test_fleur_calculate_expression.py
@@ -4,7 +4,6 @@ Tests of the calculator of mathematical expressions in the inp.xml files
 import pytest
 from masci_tools.util.fleur_calculate_expression import calculate_expression, MissingConstant
 from masci_tools.util.constants import FLEUR_DEFINED_CONSTANTS
-import numpy as np
 
 
 def test_calculate_expression():

--- a/tests/util/test_lockable_containers.py
+++ b/tests/util/test_lockable_containers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the Lockable containers
 """

--- a/tests/xml/test_schema_dict_util.py
+++ b/tests/xml/test_schema_dict_util.py
@@ -723,6 +723,7 @@ def test_schema_dict_util_filters(load_inpxml):
                             'name': 'Pt-1'
                         }})
 
+
 def test_reverse_xinclude(load_inpxml):
     """
     Test of the reverse_xinclude function

--- a/tests/xml/test_schema_dict_util.py
+++ b/tests/xml/test_schema_dict_util.py
@@ -320,7 +320,6 @@ def test_single_value_tag(caplog, load_outxml):
     """
     Test of the evaluate_single_value_tag function
     """
-    from lxml import etree
     from masci_tools.util.schema_dict_util import evaluate_single_value_tag
     from masci_tools.util.xml.common_functions import eval_xpath
 
@@ -330,7 +329,7 @@ def test_single_value_tag(caplog, load_outxml):
     iteration_xpath = schema_dict.tag_xpath('iteration')
     iteration = eval_xpath(root, iteration_xpath, list_return=True)[0]
 
-    expected = {'comment': None, 'units': 'Htr', 'value': -4204.714048254}
+    expected = {'units': 'Htr', 'value': -4204.714048254}
     totalEnergy = evaluate_single_value_tag(iteration, schema_dict, 'totalEnergy', FLEUR_DEFINED_CONSTANTS)
     assert totalEnergy == expected
 

--- a/tests/xml/test_schema_dict_util.py
+++ b/tests/xml/test_schema_dict_util.py
@@ -499,7 +499,6 @@ def test_schema_dict_util_abs_to_rel_path(load_inpxml):
     """
     Test of the absolute to relative xpath conversion in schema_dict_util functions
     """
-    from lxml import etree
     from masci_tools.util.schema_dict_util import eval_simple_xpath, get_number_of_nodes, tag_exists, \
                                                   evaluate_attribute, evaluate_tag, evaluate_parent_tag, \
                                                   evaluate_text

--- a/tests/xml/test_schema_dict_util.py
+++ b/tests/xml/test_schema_dict_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test of the utility functions for the schema dictionaries
 both path finding and easy information extraction

--- a/tests/xml/test_xml_common_functions.py
+++ b/tests/xml/test_xml_common_functions.py
@@ -93,7 +93,6 @@ def test_clear_xml(load_inpxml):
     assert len(symmetry_tags) == 16
 
 
-
 def test_get_xml_attribute(load_inpxml, caplog):
     """
     Test of the clear_xml function

--- a/tests/xml/test_xml_common_functions.py
+++ b/tests/xml/test_xml_common_functions.py
@@ -93,45 +93,6 @@ def test_clear_xml(load_inpxml):
     assert len(symmetry_tags) == 16
 
 
-def test_reverse_xinclude(load_inpxml):
-    """
-    Test of the reverse_xinclude function
-    """
-    from masci_tools.util.xml.common_functions import eval_xpath, clear_xml, reverse_xinclude
-
-    xmltree, schema_dict = load_inpxml('fleur/test_clear.xml', absolute=False)
-
-    cleared_tree, all_include_tags = clear_xml(xmltree)
-    cleared_root = cleared_tree.getroot()
-
-    reexcluded_tree, included_trees = reverse_xinclude(cleared_tree, schema_dict, all_include_tags)
-    reexcluded_root = reexcluded_tree.getroot()
-
-    assert list(included_trees.keys()) == ['sym.xml']
-    sym_root = included_trees['sym.xml'].getroot()
-
-    include_tags = eval_xpath(cleared_root,
-                              '//xi:include',
-                              namespaces={'xi': 'http://www.w3.org/2001/XInclude'},
-                              list_return=True)
-    assert len(include_tags) == 0
-
-    include_tags = eval_xpath(reexcluded_root,
-                              '//xi:include',
-                              namespaces={'xi': 'http://www.w3.org/2001/XInclude'},
-                              list_return=True)
-    assert len(include_tags) == 2
-    assert [tag.attrib['href'] for tag in include_tags] == ['sym.xml', 'relax.xml']
-
-    symmetry_tags = eval_xpath(cleared_root, '//symOp', list_return=True)
-    assert len(symmetry_tags) == 16
-
-    symmetry_tags = eval_xpath(reexcluded_root, '//symOp', list_return=True)
-    assert len(symmetry_tags) == 0
-
-    symmetry_tags = eval_xpath(sym_root, 'symOp', list_return=True)
-    assert len(symmetry_tags) == 16
-
 
 def test_get_xml_attribute(load_inpxml, caplog):
     """

--- a/tests/xml/test_xml_common_functions.py
+++ b/tests/xml/test_xml_common_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test of the functions in masci_tools.util.xml.common_functions
 """

--- a/tests/xml/test_xml_common_functions.py
+++ b/tests/xml/test_xml_common_functions.py
@@ -2,7 +2,6 @@
 Test of the functions in masci_tools.util.xml.common_functions
 """
 import pytest
-import os
 import logging
 from lxml import etree
 

--- a/tests/xml/test_xml_common_functions.py
+++ b/tests/xml/test_xml_common_functions.py
@@ -154,12 +154,12 @@ def test_get_xml_attribute(load_inpxml, caplog):
     assert 'Tried to get attribute: "TEST" from element scfLoop.' in caplog.text
 
     with pytest.raises(TypeError,
-                       match='Can not get attributename: "TEST" from node of type <class \'etree._ElementTree\'>'):
+                       match='Can not get attributename: "TEST" from node of type <class \'lxml.etree._ElementTree\'>'):
         get_xml_attribute(xmltree, 'TEST')
 
     with caplog.at_level(logging.WARNING):
         assert get_xml_attribute(xmltree, 'TEST', logger=LOGGER) is None
-    assert 'Can not get attributename: "TEST" from node of type <class \'etree._ElementTree\'>' in caplog.text
+    assert 'Can not get attributename: "TEST" from node of type <class \'lxml.etree._ElementTree\'>' in caplog.text
 
 
 def test_split_off_tag():

--- a/tests/xml/test_xml_common_functions.py
+++ b/tests/xml/test_xml_common_functions.py
@@ -154,12 +154,12 @@ def test_get_xml_attribute(load_inpxml, caplog):
     assert 'Tried to get attribute: "TEST" from element scfLoop.' in caplog.text
 
     with pytest.raises(TypeError,
-                       match='Can not get attributename: "TEST" from node of type <class \'lxml.etree._ElementTree\'>'):
+                       match='Can not get attributename: "TEST" from node of type <class \'etree._ElementTree\'>'):
         get_xml_attribute(xmltree, 'TEST')
 
     with caplog.at_level(logging.WARNING):
         assert get_xml_attribute(xmltree, 'TEST', logger=LOGGER) is None
-    assert 'Can not get attributename: "TEST" from node of type <class \'lxml.etree._ElementTree\'>' in caplog.text
+    assert 'Can not get attributename: "TEST" from node of type <class \'etree._ElementTree\'>' in caplog.text
 
 
 def test_split_off_tag():

--- a/tests/xml/test_xml_converters.py
+++ b/tests/xml/test_xml_converters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test of the functions in masci_tools.util.xml.converters
 """

--- a/tests/xml/test_xml_getters.py
+++ b/tests/xml/test_xml_getters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the xml_getters
 """

--- a/tests/xml/test_xml_setter_signatures.py
+++ b/tests/xml/test_xml_setter_signatures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Test to make sure that signatures of the functions exposed to the FleurXMLModifier
 are not changed by accident.

--- a/tests/xml/test_xml_setters_basic.py
+++ b/tests/xml/test_xml_setters_basic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for the basic xml setter functions
 """
@@ -227,7 +226,7 @@ def test_xml_delete_att_single(load_inpxml):
     xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
-    keys = set([('Kmax', '4.00000000'), ('Gmax', '10.00000000'), ('GmaxXC', '8.70000000'), ('numbands', '0')])
+    keys = {('Kmax', '4.00000000'), ('Gmax', '10.00000000'), ('GmaxXC', '8.70000000'), ('numbands', '0')}
 
     node = eval_xpath(root, '/fleurInput/calculationSetup/cutoffs')
 

--- a/tests/xml/test_xml_setters_basic.py
+++ b/tests/xml/test_xml_setters_basic.py
@@ -13,7 +13,7 @@ def test_xml_set_attrib_value_no_create(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_set_attrib_value_no_create
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/@TEST_ATT', list_return=True)) == 0
@@ -30,7 +30,7 @@ def test_xml_set_attrib_value_no_create_not_str(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_set_attrib_value_no_create
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/@TEST_ATT', list_return=True)) == 0
@@ -47,7 +47,7 @@ def test_xml_set_attrib_value_no_create_errors(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_set_attrib_value_no_create
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     with pytest.raises(ValueError, match='Wrong value for occurrences'):
@@ -82,7 +82,7 @@ def test_xml_set_attrib_value_no_create_all(load_inpxml, attribv, expected_resul
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_set_attrib_value_no_create
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert eval_xpath(root, '/fleurInput/atomSpecies/species/mtSphere/@radius') == ['2.20000000', '2.20000000']
@@ -101,7 +101,7 @@ def test_xml_set_text_no_create(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_set_text_no_create
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert eval_xpath(root, '/fleurInput').text.strip() == ''
@@ -116,7 +116,7 @@ def test_xml_set_text_no_create_errors(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_set_text_no_create
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     kpoints_xpath = '/fleurInput/cell/bzIntegration/kPointLists/kPointList/kPoint'
@@ -144,7 +144,7 @@ def test_xml_set_text_no_create_all(load_inpxml, text, expected_result, occurren
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_set_text_no_create
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     kpoints_xpath = '/fleurInput/cell/bzIntegration/kPointLists/kPointList/kPoint'
@@ -163,7 +163,7 @@ def test_xml_delete_tag_single(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_delete_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/calculationSetup', list_return=True)) == 1
@@ -178,7 +178,7 @@ def test_xml_delete_tag_multiple(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_delete_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/atomSpecies/species', list_return=True)) == 2
@@ -193,7 +193,7 @@ def test_xml_delete_tag_occurrences_single(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_delete_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/atomSpecies/species', list_return=True)) == 2
@@ -208,7 +208,7 @@ def test_xml_delete_tag_occurrences_multiple(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_delete_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/atomSpecies/species', list_return=True)) == 2
@@ -223,7 +223,7 @@ def test_xml_delete_att_single(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_delete_att
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     keys = {('Kmax', '4.00000000'), ('Gmax', '10.00000000'), ('GmaxXC', '8.70000000'), ('numbands', '0')}
@@ -245,7 +245,7 @@ def test_xml_delete_att_multiple(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_delete_att
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert eval_xpath(root, '/fleurInput/atomSpecies/species/mtSphere/@radius') == ['2.20000000', '2.20000000']
@@ -260,7 +260,7 @@ def test_xml_delete_att_occurrences_single(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_delete_att
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert eval_xpath(root, '/fleurInput/atomSpecies/species/mtSphere/@radius') == ['2.20000000', '2.20000000']
@@ -276,7 +276,7 @@ def test_xml_delete_att_occurrences_multiple(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_delete_att
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert eval_xpath(root, '/fleurInput/atomSpecies/species/mtSphere/@radius') == ['2.20000000', '2.20000000']
@@ -296,7 +296,7 @@ def test_xml_replace_tag_single(load_inpxml):
     replace_element = etree.Element('test_tag')
     replace_element.attrib['test_attrib'] = 'test'
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/calculationSetup/cutoffs', list_return=True)) == 1
@@ -320,7 +320,7 @@ def test_xml_replace_tag_multiple(load_inpxml):
     replace_element = etree.Element('test_tag')
     replace_element.attrib['test_attrib'] = 'test'
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/atomSpecies/species/mtSphere', list_return=True)) == 2
@@ -345,7 +345,7 @@ def test_xml_replace_tag_occurrences_single(load_inpxml):
     replace_element = etree.Element('test_tag')
     replace_element.attrib['test_attrib'] = 'test'
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/atomSpecies/species/mtSphere', list_return=True)) == 2
@@ -368,7 +368,7 @@ def test_xml_replace_tag_occurrences_multiple(load_inpxml):
     replace_element = etree.Element('test_tag')
     replace_element.attrib['test_attrib'] = 'test'
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     assert len(eval_xpath(root, '/fleurInput/atomSpecies/species/mtSphere', list_return=True)) == 2
@@ -387,7 +387,7 @@ def test_xml_create_tag_string_append(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [
@@ -416,7 +416,7 @@ def test_xml_create_tag_element_append(load_inpxml):
     new_element = etree.Element('test_tag')
     new_element.attrib['test_attrib'] = 'test'
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [
@@ -442,7 +442,7 @@ def test_xml_create_tag_insert_first(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [
@@ -469,7 +469,7 @@ def test_xml_create_tag_insert_middle(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [
@@ -496,7 +496,7 @@ def test_xml_create_tag_tag_order_all_single(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [
@@ -524,7 +524,7 @@ def test_xml_create_tag_tag_order_multiple(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [[
@@ -563,7 +563,7 @@ def test_xml_create_tag_tag_order_multiple_selection(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [[
@@ -602,7 +602,7 @@ def test_xml_create_tag_tag_order_multiple_beginning(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [[
@@ -641,7 +641,7 @@ def test_xml_create_tag_tag_order_multiple_occurrences_single(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [[
@@ -680,7 +680,7 @@ def test_xml_create_tag_tag_order_multiple_occurrences_list(load_inpxml):
     from masci_tools.util.xml.common_functions import eval_xpath
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     tags = [[
@@ -717,7 +717,7 @@ def test_xml_create_tag_errors(load_inpxml):
 
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
 
     with pytest.raises(ValueError, match=r"Could not create tag 'test_tag' because atleast one subtag is missing."):
         xml_create_tag(xmltree, '/fleurInput/calculationSetup/not_existent', 'test_tag')
@@ -739,7 +739,7 @@ def test_xml_create_tag_misaligned_order(load_inpxml):
     from masci_tools.util.xml.xml_setters_basic import xml_create_tag
     from masci_tools.util.xml.common_functions import eval_xpath
 
-    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()
 
     xml_create_tag(xmltree, '/fleurInput/atomSpecies/species', 'ldaU')  #This creates an invalid order

--- a/tests/xml/test_xml_setters_names.py
+++ b/tests/xml/test_xml_setters_names.py
@@ -6,7 +6,7 @@ tests for the underlying functions in xml_setters_xpaths and xml_setters_basic
 """
 from lxml import etree
 import pytest
-from masci_tools.io.parsers.fleur_schema import NoUniquePathFound, NoPathFound
+from masci_tools.io.parsers.fleur_schema import NoUniquePathFound
 
 TEST_INPXML_PATH = 'fleur/Max-R5/FePt_film_SSFT_LO/files/inp2.xml'
 TEST_MAX4_INPXML_PATH = 'fleur/aiida_fleur/inpxml/FePt/inp.xml'

--- a/tests/xml/test_xml_setters_names.py
+++ b/tests/xml/test_xml_setters_names.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for the functions in xml_setters_names
 

--- a/tests/xml/test_xml_setters_nmmpmat.py
+++ b/tests/xml/test_xml_setters_nmmpmat.py
@@ -1,6 +1,5 @@
 """Contains tests for the set_nmmpmat routine used for modifying the
    density matrix for LDA+U calculations."""
-import os
 import pytest
 import numpy as np
 

--- a/tests/xml/test_xml_setters_nmmpmat.py
+++ b/tests/xml/test_xml_setters_nmmpmat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Contains tests for the set_nmmpmat routine used for modifying the
    density matrix for LDA+U calculations."""
 import os
@@ -40,7 +39,7 @@ def test_set_nmmpmat_file(load_inpxml, file_regression, test_file):
 
     xmltree, schema_dict = load_inpxml(TEST_INPXML_LDAU_PATH, absolute=False)
 
-    with open(test_file(TEST_NMMPMAT_PATH), mode='r', encoding='utf-8') as nmmpfile:
+    with open(test_file(TEST_NMMPMAT_PATH), encoding='utf-8') as nmmpfile:
         nmmp_lines = nmmpfile.read().split('\n')
 
     nmmp_lines = set_nmmpmat(xmltree,
@@ -123,7 +122,7 @@ def test_validate_nmmpmat(load_inpxml, test_file):
 
     xmltree, schema_dict = load_inpxml(TEST_INPXML_LDAU_PATH, absolute=False)
 
-    with open(test_file(TEST_NMMPMAT_PATH), mode='r', encoding='utf-8') as nmmpfile:
+    with open(test_file(TEST_NMMPMAT_PATH), encoding='utf-8') as nmmpfile:
         nmmp_lines_orig = nmmpfile.read().split('\n')
 
     validate_nmmpmat(xmltree, nmmp_lines_orig, schema_dict)  #should not raise

--- a/tests/xml/test_xml_setters_xpaths.py
+++ b/tests/xml/test_xml_setters_xpaths.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the functions xml_setter_xpaths
 """

--- a/tests/xml/test_xpathbuilder.py
+++ b/tests/xml/test_xpathbuilder.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests of the XPathBuilder class.
 """

--- a/utils/validate_version_consistency.py
+++ b/utils/validate_version_consistency.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 A simple script that checks the consistency between the version number specified in
 setup.json, and the version in the __init__.py file.


### PR DESCRIPTION
Moved a lot of the type annotations to modern type annotations using the future import annotations. This simplifies them alot, allowing the use of `|` for union types and using builtin dicts, lists, ... for type annotations
Also added pyupgrade pre-commit hook to perform automatic modernizations to a specific python version. It is set to modernize the code to python 3.7+

The sphinx configuration is adjusted adding plugins to help handle the type annotations