### PR TITLE
Tabulator expansion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,7 @@ repos:
             masci_tools/io/parsers/fleur/.*py|
             masci_tools/io/parsers/fleur_schema/.*py|
             masci_tools/io/parsers/hdf5/.*py|
+            masci_tools/io/parsers/tabulator/.*py|
             masci_tools/io/io_nmmpmat.py|
             masci_tools/io/io_fleurxml.py|
             masci_tools/io/fleur_inpgen.py|

--- a/masci_tools/io/parsers/tabulator/__init__.py
+++ b/masci_tools/io/parsers/tabulator/__init__.py
@@ -10,22 +10,12 @@
 # For further information please visit http://judft.de/.                      #
 #                                                                             #
 ###############################################################################
+#pylint: disable=undefined-variable
 """This subpackage contains a tabulator. Its purpose is to let you create a table of properties,
 say, a pandas DataFrame, from any collections of similar objects, and reused frequently used recipes.
 """
-# import submodules
-from . import transformers
-from . import recipes
-from . import tabulator
+from .tabulator import *
+from .recipes import *
+from .transformers import *
 
-# import most important user classes to this level
-from .transformers import \
-    Transformer, \
-    TransformedValue, \
-    DefaultTransformer
-
-from .recipes import \
-    Recipe
-
-from .tabulator import \
-    Tabulator
+__all__ = (tabulator.__all__ + recipes.__all__ + transformers.__all__)  #type: ignore

--- a/masci_tools/io/parsers/tabulator/recipes.py
+++ b/masci_tools/io/parsers/tabulator/recipes.py
@@ -207,13 +207,12 @@ class Recipe(abc.ABC):
         # or at least of type _typing.List[_typing.Tuple[list, _typing.Any]].
         # check that. if not, something is wrong.
         # otherwise, just return the paths.
-        if all(tup[1] is None for tup in keypaths):
-            keypaths = [tup[0] for tup in keypaths]  #type:ignore
-            datatypes = {path: dtype for path, dtype in keypaths if dtype is not None}
+        datatypes = {tuple(path): dtype for path, dtype in keypaths if dtype is not None}
+        keypaths = [tuple(path) for path, dtype in keypaths]  #type:ignore
 
         # postcondition: keypaths format
         is_list = isinstance(keypaths, list)
-        is_all_lists = is_list and all(isinstance(path, list) for path in keypaths)
+        is_all_lists = is_list and all(isinstance(path, tuple) for path in keypaths)
         if not is_all_lists:
             raise TypeError(f'Could not generate keypaths of required type list of lists '
                             f'from {name} list. Either specified list in wrong format '

--- a/masci_tools/io/parsers/tabulator/recipes.py
+++ b/masci_tools/io/parsers/tabulator/recipes.py
@@ -137,7 +137,7 @@ class Recipe(abc.ABC):
         """
         self._exclude_list: KeyPaths
         self._include_list: KeyPaths
-        self.dtypes: dict[tuple[str,...], type[Any]] = {}
+        self.dtypes: dict[tuple[str, ...], type[Any]] = {}
 
         self.transformer = transformer
 
@@ -210,7 +210,6 @@ class Recipe(abc.ABC):
         if all(tup[1] is None for tup in keypaths):
             keypaths = [tup[0] for tup in keypaths]  #type:ignore
             datatypes = {path: dtype for path, dtype in keypaths if dtype is not None}
-
 
         # postcondition: keypaths format
         is_list = isinstance(keypaths, list)

--- a/masci_tools/io/parsers/tabulator/recipes.py
+++ b/masci_tools/io/parsers/tabulator/recipes.py
@@ -30,6 +30,8 @@ from .transformers import Transformer
 KeyPaths: TypeAlias = 'list[Iterable[str]]'
 PathList: TypeAlias = 'list[Iterable[str]] | dict[str,Any]'
 
+__all__ = ('Recipe',)
+
 
 class Recipe(abc.ABC):
     """Recipe for a :py:class:`~.tabulator.Tabulator`.

--- a/masci_tools/io/parsers/tabulator/recipes.py
+++ b/masci_tools/io/parsers/tabulator/recipes.py
@@ -15,15 +15,23 @@ properties of a collections of objects into a table.
 
 Recipes let you reuse tabulator settings for different use cases.
 """
+from __future__ import annotations
 
-import abc as _abc
-import typing as _typing
+import abc
+from typing import Iterable, Any
+try:
+    from typing import TypeAlias  #type:ignore
+except ImportError:
+    from typing_extensions import TypeAlias
 
 import masci_tools.util.python_util as _masci_python_util
 from .transformers import Transformer
 
+KeyPaths: TypeAlias = 'list[Iterable[str]]'
+PathList: TypeAlias = 'list[Iterable[str]] | dict[str,Any]'
 
-class Recipe(_abc.ABC):
+
+class Recipe(abc.ABC):
     """Recipe for a :py:class:`~.tabulator.Tabulator`.
 
     Recipes hold the include, exclude list of properties which a tabulator should put into a table, by reading
@@ -39,7 +47,10 @@ class Recipe(_abc.ABC):
       have dtype 'object' or 'float64' and the table won't fit into memory anymore very quickly.
     """
 
-    def __init__(self, exclude_list: dict = None, include_list: dict = None, transformer: Transformer = None, **kwargs):
+    def __init__(self,
+                 exclude_list: PathList | None = None,
+                 include_list: PathList | None = None,
+                 transformer: Transformer | None = None):
         """Initialize a recipe for a :py:class:`~.tabulator.Tabulator`.
 
         The attributes :py:attr:`~.include_list` and :py:attr:`~.exclude_list` control which properties
@@ -122,33 +133,37 @@ class Recipe(_abc.ABC):
         :param transform: Specifies special transformations for certain properties for tabulation.
         :param kwargs: Additional keyword arguments for subclasses.
         """
-        # note: for the in/ex lists, using the public setter here,
-        # to trigger conversion
-        self._exclude_list = exclude_list if exclude_list else {}
-        self._include_list = include_list if include_list else {}
+        self._exclude_list: KeyPaths
+        self._include_list: KeyPaths
         self.transformer = transformer
 
+        self.exclude_list = exclude_list or []
+        self.include_list = include_list or []
+
     @property
-    def exclude_list(self) -> dict:
+    def exclude_list(self) -> KeyPaths:
         return self._exclude_list
 
     @exclude_list.setter
-    def exclude_list(self, exclude_list: _typing.Union[dict, list]):
-        self._exclude_list = exclude_list
+    def exclude_list(self, exclude_list: PathList) -> None:
         if isinstance(exclude_list, dict):
-            self._to_keypaths()
+            self._exclude_list = self._to_keypaths(exclude_list, 'exclude')
+        else:
+            self._exclude_list = exclude_list
 
     @property
-    def include_list(self) -> dict:
+    def include_list(self) -> KeyPaths:
         return self._include_list
 
     @include_list.setter
-    def include_list(self, include_list: _typing.Union[dict, list]):
-        self._include_list = include_list
+    def include_list(self, include_list: PathList) -> None:
         if isinstance(include_list, dict):
-            self._to_keypaths()
+            self._include_list = self._to_keypaths(include_list, 'include')
+        else:
+            self._include_list = include_list
 
-    def _to_keypaths(self):
+    @staticmethod
+    def _to_keypaths(path_dict: dict[str, Any], name: str) -> KeyPaths:
         """Generate paths from a possibly nested dictionary.
 
         This method can be used for handling include lists, exclude lists, and when writing
@@ -161,7 +176,7 @@ class Recipe(_abc.ABC):
         convert to keypaths (upper: done inside this one anyway)
         """
 
-        def _to_keypaths_recursive(sub_dict: dict, path: list):
+        def _to_keypaths_recursive(sub_dict: dict[str, Any], path: list[str]) -> list[tuple[list[str], Any]]:
             paths = []
             for k, v in sub_dict.items():
                 if isinstance(v, dict):
@@ -169,50 +184,39 @@ class Recipe(_abc.ABC):
                 paths.append((path + [k], v))
             return paths
 
-        for in_or_ex, a_dict in {'in': self._include_list, 'out': self._exclude_list}.items():
+        # if empty, convert to empty list. if not empty, convert to keypaths
+        if not path_dict:
+            return []
 
-            # precondition: not already keypaths format
-            is_list = isinstance(a_dict, list)
-            is_all_lists = is_list and all(isinstance(path, list) for path in a_dict)
-            if is_all_lists:
-                continue
+        # convert from include list with-list format with-none format:
+        # same-level subkeys mentioned as list [k1,k2] -> dict {k1:None, k2:None}.
+        _a_dict = _masci_python_util.modify_dict(a_dict=path_dict,
+                                                 transform_value=lambda v: {k: None for k in v}
+                                                 if isinstance(v, list) else v,
+                                                 to_level=99)
 
-            # if empty, convert to empty list. if not empty, convert to keypaths
-            if not a_dict:
-                keypaths = []
-            else:
-                # convert from include list with-list format with-none format:
-                # same-level subkeys mentioned as list [k1,k2] -> dict {k1:None, k2:None}.
-                _a_dict = _masci_python_util.modify_dict(a_dict=a_dict,
-                                                         transform_value=lambda v: {k: None for k in v}
-                                                         if isinstance(v, list) else v,
-                                                         to_level=99)
+        keypaths = _to_keypaths_recursive(sub_dict=_a_dict, path=[])
+        # the result consists of sets of subpaths. For each subset, there is
+        # an additianal entry where the value contains the whole subdict from
+        # which the paths were generated. We are not interested in those duplicate
+        # entries, so remove them.
+        keypaths = [tup for tup in keypaths if not isinstance(tup[1], dict)]
 
-                keypaths = _to_keypaths_recursive(sub_dict=_a_dict, path=[])
-                # the result consists of sets of subpaths. For each subset, there is
-                # an additianal entry where the value contains the whole subdict from
-                # which the paths were generated. We are not interested in those duplicate
-                # entries, so remove them.
-                keypaths = [tup for tup in keypaths if not isinstance(tup[1], dict)]
+        # now list should be like [(path1, None), (path2, None), ...],
+        # or at least of type _typing.List[_typing.Tuple[list, _typing.Any]].
+        # check that. if not, something is wrong.
+        # otherwise, just return the paths.
+        if all(tup[1] is None for tup in keypaths):
+            keypaths = [tup[0] for tup in keypaths]  #type:ignore
 
-                # now list should be like [(path1, None), (path2, None), ...],
-                # or at least of type _typing.List[_typing.Tuple[list, _typing.Any]].
-                # check that. if not, something is wrong.
-                # otherwise, just return the paths.
-                if all(tup[1] is None for tup in keypaths):
-                    keypaths = [tup[0] for tup in keypaths]
+        # postcondition: keypaths format
+        is_list = isinstance(keypaths, list)
+        is_all_lists = is_list and all(isinstance(path, list) for path in keypaths)
+        if not is_all_lists:
+            raise TypeError(f'Could not generate keypaths of required type list of lists '
+                            f'from {name} list. Either specified list in wrong format '
+                            f'(see class init docstring for examples), or list generated from '
+                            f'autolist stumbled over untreated special case for some unpacked '
+                            f'property.')
 
-            # postcondition: keypaths format
-            is_list = isinstance(keypaths, list)
-            is_all_lists = is_list and all(isinstance(path, list) for path in keypaths)
-            if not is_all_lists:
-                raise TypeError(f'Could not generate keypaths of required type {_typing.List[list]} '
-                                f'from {in_or_ex}clude list. Either specified list in wrong format '
-                                f'(see class init docstring for examples), or list generated from '
-                                f'autolist stumbled over untreated special case for some unpacked '
-                                f'property.')
-
-            if in_or_ex == 'in':
-                self._include_list = keypaths
-            elif in_or_ex == 'out':
-                self._exclude_list = keypaths
+        return keypaths

--- a/masci_tools/io/parsers/tabulator/recipes.py
+++ b/masci_tools/io/parsers/tabulator/recipes.py
@@ -151,7 +151,7 @@ class Recipe(abc.ABC):
         if isinstance(exclude_list, dict):
             self._exclude_list = self._to_keypaths(exclude_list, 'exclude')
         else:
-            self._exclude_list = exclude_list
+            self._exclude_list = [(path,) if not isinstance(path, (tuple,list)) else path for path in exclude_list]
 
     @property
     def include_list(self) -> KeyPaths:
@@ -162,7 +162,7 @@ class Recipe(abc.ABC):
         if isinstance(include_list, dict):
             self._include_list = self._to_keypaths(include_list, 'include')
         else:
-            self._include_list = include_list
+            self._include_list = [(path,) if not isinstance(path, (tuple,list)) else path for path in include_list]
 
     @staticmethod
     def _to_keypaths(path_dict: dict[str, Any], name: str) -> KeyPaths:

--- a/masci_tools/io/parsers/tabulator/recipes.py
+++ b/masci_tools/io/parsers/tabulator/recipes.py
@@ -151,7 +151,7 @@ class Recipe(abc.ABC):
         if isinstance(exclude_list, dict):
             self._exclude_list = self._to_keypaths(exclude_list, 'exclude')
         else:
-            self._exclude_list = [(path,) if not isinstance(path, (tuple,list)) else path for path in exclude_list]
+            self._exclude_list = [(path,) if not isinstance(path, (tuple, list)) else path for path in exclude_list]
 
     @property
     def include_list(self) -> KeyPaths:
@@ -162,7 +162,7 @@ class Recipe(abc.ABC):
         if isinstance(include_list, dict):
             self._include_list = self._to_keypaths(include_list, 'include')
         else:
-            self._include_list = [(path,) if not isinstance(path, (tuple,list)) else path for path in include_list]
+            self._include_list = [(path,) if not isinstance(path, (tuple, list)) else path for path in include_list]
 
     @staticmethod
     def _to_keypaths(path_dict: dict[str, Any], name: str) -> KeyPaths:

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -293,3 +293,37 @@ class NamedTupleTabulator(Tabulator):
             if value is None:
                 break
         return value
+
+
+class NestedDictTabulator(Tabulator):
+    """
+    Simple Example of Tabulator for creating Dataframes from nested dicts
+    """
+
+    def autolist(self, item: Any, overwrite: bool = False, pretty_print: bool = False, **kwargs: Any) -> None:
+        """
+        Just tabulate all the keys with recursing into subdicts
+        """
+
+        def collect_keypaths(item):
+            keypaths = []
+            for key, value in item.items():
+                if isinstance(value, dict):
+                    subpaths = collect_keypaths(value)
+                    keypaths.extend((key, *path) for path in subpaths)
+                else:
+                    keypaths.append((key,))
+            return keypaths
+
+        self.recipe.include_list = collect_keypaths(item)
+
+    def get_keypath(self, item, keypath):
+        """
+        Just recursively extract all the attributes
+        """
+        value = item
+        for key in keypath:
+            value = value.get(key)
+            if value is None:
+                break
+        return value

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -190,12 +190,18 @@ class Tabulator(abc.ABC):
             if len(paths) == 1:
                 continue
 
-            if abs(index) > len(paths[0]):
+            if abs(index) > max(len(path) for path in paths):
                 raise ValueError(f'Cannot disambiguate paths {paths}')
 
+            disambiguated_keypaths = []
+            for path in paths:
+                if abs(index) > len(path):
+                    disambiguated_keypaths.append((path, name))
+                else:
+                    disambiguated_keypaths.append((path[:index], f'{path[index]}{self.separator}{name}'))
+
             #Go up levels until they can be distinguished
-            unique_paths = self._remove_collisions(
-                [(path[:index], f'{path[index]}{self.separator}{name}') for path in paths], index=index - 1)
+            unique_paths = self._remove_collisions(disambiguated_keypaths, index=index - 1)
 
             for path, unique_path in zip(paths, unique_paths):
                 keypaths[keypaths.index((path, name))] = path, unique_path[1]

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -237,6 +237,7 @@ class Tabulator(abc.ABC):
 
         keypaths: KeyPaths = []
 
+        dtypes_set: frozenset[str] = frozenset()
         for index, item in enumerate(collection):
 
             # get inc/ex lists. assume that they are in valid keypaths format already
@@ -269,6 +270,11 @@ class Tabulator(abc.ABC):
                               dtypes=dtypes_set,
                               pass_item_to_transformer=pass_item_to_transformer,
                               **kwargs)
+            length = index + 1
+
+        #Adjust to actual length
+        for column in dtypes_set:
+            table[column] = table[column][:length]
 
         if drop_empty_columns:
             empty_columns = [colname for colname, values in table.items() if all(v is None for v in values)]

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -25,7 +25,7 @@ from .recipes import Recipe, KeyPaths
 
 __all__ = ('Tabulator', 'NamedTupleTabulator', 'TableType')
 
-TableType = TypeVar('TableType', type[dict], type[pd.DataFrame])
+TableType = TypeVar('TableType', 'dict[str,Any]', pd.DataFrame)
 
 
 class Tabulator(abc.ABC):
@@ -152,7 +152,7 @@ class Tabulator(abc.ABC):
                     row[column] = transformed_value.value
 
         for column, value in row.items():
-            table[column].append(value)
+            table.setdefault(column, []).append(value)
 
     def item_uuid(self, item: Any) -> str:
         """
@@ -195,7 +195,7 @@ class Tabulator(abc.ABC):
 
     def tabulate(self,
                  collection: Iterable[Any],
-                 table_type: TableType = pd.DataFrame,
+                 table_type: type[TableType] = pd.DataFrame,
                  append: bool = True,
                  column_policy: str = 'flat',
                  pass_item_to_transformer: bool = True,
@@ -224,7 +224,7 @@ class Tabulator(abc.ABC):
             raise ValueError(f'{collection=} is empty. Will do nothing.')
 
         # now we can finally build the table
-        table: dict[str, Any] = defaultdict(list)
+        table: dict[str, Any] = {}
 
         keypaths: KeyPaths = []
 
@@ -268,7 +268,7 @@ class Tabulator(abc.ABC):
         self._table = dict(table)
 
         if table_type == pd.DataFrame:
-            return self.table  #type:ignore
+            return self.table #type:ignore
         return self._table
 
 

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -189,7 +189,7 @@ class Tabulator(abc.ABC):
                                                    index=index - 1)
 
             for path, unique_path in zip(paths, unique_paths):
-                keypaths[keypaths.index((path, name))] = unique_path
+                keypaths[keypaths.index((path, name))] = path, unique_path[1]
 
         return keypaths
 

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -91,7 +91,7 @@ class Tabulator(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_keypath(self, item: Any, keypath: Iterable[str]) -> Any:
+    def get_value(self, item: Any, keypath: Iterable[str]) -> Any:
         """
         Extract a value based the path given as an iterable of attribute names
         :param item: Item under consideration
@@ -130,7 +130,7 @@ class Tabulator(abc.ABC):
         for keypath, column in keypaths:
             row[column] = None
 
-            value = self.get_keypath(item, keypath)
+            value = self.get_value(item, keypath)
             if value is None:
                 failed_paths[keypath].append(self.item_uuid(item))
                 continue
@@ -283,7 +283,7 @@ class NamedTupleTabulator(Tabulator):
         """
         self.recipe.include_list = list(item._fields)
 
-    def get_keypath(self, item, keypath):
+    def get_value(self, item, keypath):
         """
         Just recursively extract all the attributes
         """
@@ -317,7 +317,7 @@ class NestedDictTabulator(Tabulator):
 
         self.recipe.include_list = collect_keypaths(item)
 
-    def get_keypath(self, item, keypath):
+    def get_value(self, item, keypath):
         """
         Just recursively extract all the attributes
         """

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -23,7 +23,7 @@ import pandas as pd
 
 from .recipes import Recipe
 
-__all__ = ('Tabulator', 'NamedTupleTabulator')
+__all__ = ('Tabulator', 'NamedTupleTabulator', 'TableType')
 
 TableType = TypeVar('TableType', dict, pd.DataFrame)
 

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -25,7 +25,7 @@ from .recipes import Recipe, KeyPaths
 
 __all__ = ('Tabulator', 'NamedTupleTabulator', 'TableType')
 
-TableType = TypeVar('TableType', dict, pd.DataFrame)
+TableType = TypeVar('TableType', type[dict], type[pd.DataFrame])
 
 
 class Tabulator(abc.ABC):

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -268,7 +268,7 @@ class Tabulator(abc.ABC):
         self._table = dict(table)
 
         if table_type == pd.DataFrame:
-            return self.table #type:ignore
+            return self.table  #type:ignore
         return self._table
 
 

--- a/masci_tools/io/parsers/tabulator/tabulator.py
+++ b/masci_tools/io/parsers/tabulator/tabulator.py
@@ -164,7 +164,7 @@ class Tabulator(abc.ABC):
                            keypaths: list[tuple[tuple[str, ...], str]],
                            index: int = -2) -> list[tuple[tuple[str, ...], str]]:
         """
-        Disambigouate keypaths so that there are no key collisions. If there is a collision
+        Disambiguate keypaths so that there are no key collisions. If there is a collision
         the key one level up is taken and combined with apoint
 
         :param keypaths: Paths to investigate
@@ -182,7 +182,7 @@ class Tabulator(abc.ABC):
                 continue
 
             if abs(index) > len(paths[0]):
-                raise ValueError(f'Cannot disambigouate paths {paths}')
+                raise ValueError(f'Cannot disambiguate paths {paths}')
 
             #Go up levels until they can be distinguished
             unique_paths = self._remove_collisions([(path[:index], f'{path[index]}.{name}') for path in paths],

--- a/masci_tools/io/parsers/tabulator/transformers.py
+++ b/masci_tools/io/parsers/tabulator/transformers.py
@@ -15,22 +15,25 @@ properties of a collections of objects into a table.
 
 Transformers let you transform properties while they get tabulated.
 """
+from __future__ import annotations
 
-import abc as _abc
+import abc
 import typing as _typing
-import dataclasses as _dc
+import dataclasses as dc
+
+__all__ = ('Transformer', 'TransformedValue', 'DefaultTransformer')
 
 
-@_dc.dataclass(init=True, repr=True, eq=True, order=False, frozen=False)
+@dc.dataclass(init=True, repr=True, eq=True, order=False, frozen=False)
 class TransformedValue:
     """Return type of the :py:class:`~.Transformer`."""
     is_transformed: bool = False
-    value: _typing.Union[object, dict] = None
-    dtypes: _typing.Union[object, dict] = None
-    error: _typing.Optional[Exception] = None
+    value: object | dict | None = None
+    dtypes: object | dict | None = None
+    error: Exception | None = None
 
 
-class Transformer(_abc.ABC):
+class Transformer(abc.ABC):
     """Specify how to transformer an object's properties for use in :py:class:`Tabulator`.
 
     To subclass, you have to implement the :py:meth:`~transformer` method.
@@ -45,12 +48,12 @@ class Transformer(_abc.ABC):
       is optional, otherwise Tabulator will use standard dtypes or try to guess best dtypes for data on its own.
     """
 
-    @_abc.abstractmethod
+    @abc.abstractmethod
     def transform(self,
-                  keypath: _typing.Union[str, _typing.List[str]],
+                  keypath: str | _typing.Iterable[str],
                   value: _typing.Any,
                   obj: _typing.Any = None,
-                  **kwargs) -> TransformedValue:
+                  **kwargs: _typing.Any) -> TransformedValue:
         """Specify how to transform properties, based on their keypath and type.
 
         Extends :py:meth:`~.Transformer.transform`. See also its docstring.
@@ -110,8 +113,8 @@ class DefaultTransformer(Transformer):
     """
 
     def transform(self,
-                  keypath: _typing.Union[str, _typing.List[str]],
+                  keypath: str | _typing.Iterable[str],
                   value: _typing.Any,
                   obj: _typing.Any = None,
-                  **kwargs) -> _typing.Tuple[_typing.Union[None, _typing.Any, dict], bool]:
+                  **kwargs: _typing.Any) -> TransformedValue:
         return TransformedValue(is_transformed=False, value=value, error=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,8 @@ disallow_subclassing_any = true
 module = [
     'h5py',
     'humanfriendly',
-    'yaml'
+    'yaml',
+    'pandas',
 ]
 follow_imports = 'skip'
 ignore_missing_imports = true


### PR DESCRIPTION
This PR tries to consolidate the `Tabulator` class in masci-tools/aiida-jutools. @Irratzo I hope you don't mind. I just noticed that the base class was essentially empty, which wastes a lot of potential.
Most of the non-aiida specific code is moved into the abstract base class in masci-tools. Now the design requires implementing two functions
- `autolist`: as before for a default set of paths to include
- `get_keypath`: specifies how to extract a given path from an item to be tabulated (See examples at the bottom of `tabulator.py`)

TODO:
- [ ] To start I essentially dropped all the error handling that is in the `NodeTabulator`
- [ ] Datatypes as mentioned in the docstring are also not implemented
- [ ] It should be relatively easy to add tests for this implementation