### PR TITLE
Allow referencing xml_getter functions in outxml parsing tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Improvements
 - Fleur schema parsing functions now recognize a new alias from the fleur schemas `FortranComplex` which is a number of the form `(float,float)`. Converters for complex values are added [[#106]](https://github.com/JuDFTteam/masci-tools/pull/106)
 - Added `IncompatibleSchemaVersions` error when a combination of output and input version for `OutputSchemaDict` is given, for which it is known that no XML schema can be compiled
-- `xml_getter` functions can now be used in the task definitions of the `outxml_parser` to keep information consistent.Example: `{'parse_type':'xmlGetter', 'name': 'get_structure_data'}`
+- `xml_getter` functions can now be used in the task definitions of the `outxml_parser` to keep information consistent.Example: `{'parse_type':'xmlGetter', 'name': 'get_structure_data'}` [[#107]](https://github.com/JuDFTteam/masci-tools/pull/107)
 
 ### Bugfixes
 - Fix in ``load_inpxml`` and ``load_outxml`` (this also effects the ``inpxml/outxml_parser``). Previously file handle like objects not directly subclassing ``io.IOBase`` would lead to an exception

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Improvements
 - Fleur schema parsing functions now recognize a new alias from the fleur schemas `FortranComplex` which is a number of the form `(float,float)`. Converters for complex values are added [[#106]](https://github.com/JuDFTteam/masci-tools/pull/106)
 - Added `IncompatibleSchemaVersions` error when a combination of output and input version for `OutputSchemaDict` is given, for which it is known that no XML schema can be compiled
+- `xml_getter` functions can now be used in the task definitions of the `outxml_parser` to keep information consistent.Example: `{'parse_type':'xmlGetter', 'name': 'get_structure_data'}`
 
 ### Bugfixes
 - Fix in ``load_inpxml`` and ``load_outxml`` (this also effects the ``inpxml/outxml_parser``). Previously file handle like objects not directly subclassing ``io.IOBase`` would lead to an exception

--- a/docs/source/devel_guide/fleur_parser.rst
+++ b/docs/source/devel_guide/fleur_parser.rst
@@ -51,6 +51,7 @@ The following are possible:
                   into a dictionary, but for the parent of the tag
   :singleValue: Special case of allAttribs to parse value and units
                 attribute for the given tag
+  :xmlGetter: Will execute a function in the module `masci_tools.util.xml.xml_getters` given in the `name` entry
 
 The ```path_spec``` key specifies how the key can be uniquely identified.
 

--- a/masci_tools/io/parsers/fleur/default_parse_tasks.py
+++ b/masci_tools/io/parsers/fleur/default_parse_tasks.py
@@ -21,10 +21,17 @@ correspond to the keys in the output dictionary
 
 The following keys are expected in each entry:
     :param parse_type: str, defines which methods to use when extracting the information
-    :param path_spec: dict with all the arguments that should be passed to tag_xpath
-                      or attrib_xpath to get the correct path
     :param subdict: str, if present the parsed values are put into this key in the output dictionary
     :param overwrite_last: bool, if True no list is inserted and each entry overwrites the last
+
+If `parse_type` is not equal to `xmlGetter` the following key is required:
+    :param path_spec: dict with all the arguments that should be passed to tag_xpath
+                      or attrib_xpath to get the correct path
+
+In the case of `xmlGetter` the following keys are allowed:
+    :param name: name of the function in `masci_tools.util.xml.xml_getters` (required)
+    :param kwargs: additional arguments to pass
+    :param result_names: list of str defining the keys under which to enter the outputs of the function
 
 For the allAttribs parse_type there are more keys that can appear:
     :param base_value: str, optional. If given the attribute

--- a/masci_tools/io/parsers/fleur/default_parse_tasks.py
+++ b/masci_tools/io/parsers/fleur/default_parse_tasks.py
@@ -207,101 +207,20 @@ TASKS_DEFINITION = {
     },
     #--------Defintions for relaxation info from input section (bravais matrix, atompos)
     #--------for Bulk and film
-    'bulk_relax_info': {
+    'relax_info': {
         '_general': True,
-        '_modes': [('relax', True), ('film', False)],
+        '_modes': [
+            ('relax', True),
+        ],
         '_conversions': ['convert_relax_info'],
-        'lat_row1': {
-            'parse_type': 'text',
-            'path_spec': {
-                'name': 'row-1',
-                'contains': 'bulkLattice/bravais'
+        'parsed_relax_info': {
+            'parse_type': 'xmlGetter',
+            'name': 'get_structure_data',
+            'kwargs': {
+                'convert_to_angstroem': False,
+                'include_relaxations': False
             }
-        },
-        'lat_row2': {
-            'parse_type': 'text',
-            'path_spec': {
-                'name': 'row-2',
-                'contains': 'bulkLattice/bravais'
-            }
-        },
-        'lat_row3': {
-            'parse_type': 'text',
-            'path_spec': {
-                'name': 'row-3',
-                'contains': 'bulkLattice/bravais'
-            }
-        },
-        'atom_positions': {
-            'parse_type': 'text',
-            'path_spec': {
-                'name': 'relPos'
-            }
-        },
-        'position_species': {
-            'parse_type': 'parentAttribs',
-            'path_spec': {
-                'name': 'relPos'
-            },
-            'flat': False,
-            'only_required': True
-        },
-        'element_species': {
-            'parse_type': 'allAttribs',
-            'path_spec': {
-                'name': 'species'
-            },
-            'flat': False,
-            'ignore': ['vcaAddCharge', 'magField']
-        },
-    },
-    'film_relax_info': {
-        '_general': True,
-        '_modes': [('relax', True), ('film', True)],
-        '_conversions': ['convert_relax_info'],
-        'lat_row1': {
-            'parse_type': 'text',
-            'path_spec': {
-                'name': 'row-1',
-                'contains': 'filmLattice/bravais'
-            }
-        },
-        'lat_row2': {
-            'parse_type': 'text',
-            'path_spec': {
-                'name': 'row-2',
-                'contains': 'filmLattice/bravais'
-            }
-        },
-        'lat_row3': {
-            'parse_type': 'text',
-            'path_spec': {
-                'name': 'row-3',
-                'contains': 'filmLattice/bravais'
-            }
-        },
-        'atom_positions': {
-            'parse_type': 'text',
-            'path_spec': {
-                'name': 'filmPos'
-            }
-        },
-        'position_species': {
-            'parse_type': 'parentAttribs',
-            'path_spec': {
-                'name': 'filmPos'
-            },
-            'flat': False,
-            'only_required': True
-        },
-        'element_species': {
-            'parse_type': 'allAttribs',
-            'path_spec': {
-                'name': 'species'
-            },
-            'flat': False,
-            'ignore': ['vcaAddCharge', 'magField']
-        },
+        }
     },
     #----General iteration tasks
     # iteration number

--- a/masci_tools/io/parsers/fleur/outxml_conversions.py
+++ b/masci_tools/io/parsers/fleur/outxml_conversions.py
@@ -201,7 +201,7 @@ def convert_relax_info(out_dict: dict[str, Any], logger: Logger) -> dict[str, An
         positions = [abs_to_rel(position, cell) for position in positions]
 
     out_dict['relax_brav_vectors'] = cell.tolist()
-    out_dict['relax_atom_positions'] = [[round(x,16) for x in pos] for pos in positions]
+    out_dict['relax_atom_positions'] = [[round(x, 16) for x in pos] for pos in positions]
     out_dict['relax_atomtype_info'] = [(site.kind, site.symbol) for site in atoms]
 
     return out_dict

--- a/masci_tools/io/parsers/fleur/outxml_conversions.py
+++ b/masci_tools/io/parsers/fleur/outxml_conversions.py
@@ -19,7 +19,7 @@ from datetime import date
 import numpy as np
 from masci_tools.util.constants import HTR_TO_EV
 from masci_tools.util.parse_tasks_decorators import conversion_function
-from masci_tools.io.common_functions import convert_to_pystd
+from masci_tools.io.common_functions import convert_to_pystd, abs_to_rel, abs_to_rel_f
 from typing import Any
 from logging import Logger
 
@@ -190,23 +190,19 @@ def convert_relax_info(out_dict: dict[str, Any], logger: Logger) -> dict[str, An
 
     :param out_dict: dict with the already parsed information
     """
-    v_1 = out_dict.pop('lat_row1')
-    v_2 = out_dict.pop('lat_row2')
-    v_3 = out_dict.pop('lat_row3')
 
-    out_dict['relax_brav_vectors'] = [v_1, v_2, v_3]
+    atoms, cell, pbc = out_dict.pop('parsed_relax_info')
+    film = not all(pbc)
 
-    out_dict['relax_atom_positions'] = out_dict.pop('atom_positions')
-    species = out_dict.pop('position_species')
-    species = species['species']
-    species_info = out_dict.pop('element_species')
-    if isinstance(species_info['name'], str):
-        species_info = {key: [val] for key, val in species_info.items()}
-    species_info = dict(zip(species_info['name'], species_info['element']))
+    positions = [convert_to_pystd(site.position) for site in atoms]
+    if film:
+        positions = [abs_to_rel_f(position, cell, pbc) for position in positions]
+    else:
+        positions = [abs_to_rel(position, cell) for position in positions]
 
-    out_dict['relax_atomtype_info'] = []
-    for specie in species:
-        out_dict['relax_atomtype_info'].append((specie, species_info[specie]))
+    out_dict['relax_brav_vectors'] = cell.tolist()
+    out_dict['relax_atom_positions'] = [[round(x,16) for x in pos] for pos in positions]
+    out_dict['relax_atomtype_info'] = [(site.kind, site.symbol) for site in atoms]
 
     return out_dict
 

--- a/masci_tools/util/parse_tasks.py
+++ b/masci_tools/util/parse_tasks.py
@@ -111,7 +111,7 @@ class ParseTasks:
         'parse_type', 'path_spec', 'subdict', 'base_value', 'ignore', 'overwrite', 'flat', 'only_required', 'subtags',
         'text'
     }
-    ALLOWED_KEYS_XML_GETTER = {'parse_type', 'name', 'kwargs'}
+    ALLOWED_KEYS_XML_GETTER = {'parse_type', 'name', 'kwargs', 'result_names'}
 
     _version = '0.3.0'
     _migrations: MigrationDict = {}
@@ -454,6 +454,15 @@ class ParseTasks:
                 parsed_dict = out_dict.setdefault(spec['subdict'], {})
 
             parsed_value = action(node, schema_dict, logger=logger, **args)
+
+            if spec['parse_type'] == 'xmlGetter' and 'result_names' in spec:
+                if isinstance(parsed_value, tuple):
+                    if len(spec['result_names']) != len(parsed_value):
+                        raise ValueError('Wrong number of result names given.'
+                                         f"Got {len(parsed_value)} values and {len(spec['result_names'])} names")
+                    parsed_value = dict(zip(spec['result_names'], parsed_value))
+                else:
+                    task_key = spec['result_names'][0]
 
             if isinstance(parsed_value, dict):
 

--- a/tests/parsers/test_parse_tasks.py
+++ b/tests/parsers/test_parse_tasks.py
@@ -10,11 +10,11 @@ def test_default_parse_tasks():
     from masci_tools.util.parse_tasks import ParseTasks
 
     expected_keys = {
-        'film_relax_info', 'distances', 'forcetheorem_jij', 'ldau_info', 'bulk_relax_info', 'orbital_magnetic_moments',
-        'forcetheorem_mae', 'charges', 'magnetic_distances', 'bandgap', 'forcetheorem_ssdisp',
-        'total_energy_contributions', 'ldau_energy_correction', 'general_out_info', 'forces', 'nmmp_distances',
-        'total_energy', 'magnetic_moments', 'iteration_number', 'forcetheorem_dmi', 'general_inp_info', 'fermi_energy',
-        'torques', 'noco_angles', 'corelevels'
+        'relax_info', 'distances', 'forcetheorem_jij', 'ldau_info', 'orbital_magnetic_moments', 'forcetheorem_mae',
+        'charges', 'magnetic_distances', 'bandgap', 'forcetheorem_ssdisp', 'total_energy_contributions',
+        'ldau_energy_correction', 'general_out_info', 'forces', 'nmmp_distances', 'total_energy', 'magnetic_moments',
+        'iteration_number', 'forcetheorem_dmi', 'general_inp_info', 'fermi_energy', 'torques', 'noco_angles',
+        'corelevels'
     }
 
     p = ParseTasks('0.33', validate_defaults=True)


### PR DESCRIPTION
The parsing tasks pre-date the xml getters and at some points try to replicate behaviour,
which is very well defined and constructed in the xml_getters (e.g. reading cell and atoms data).

In the next release of Fleur there are some changes that would need to be taken into account to keep the film_relax_info
and bulk_relax_info tasks working, which is not worth it.

Instead we allow parse_type to be `xmlGetter` and give an argument `name` for the function