### PR TITLE
Move to namedtuples for conversion function definitions in `outxml_parser`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,8 @@ repos:
             masci_tools/util/python_util.py|
             masci_tools/util/math_util.py|
             masci_tools/util/parse_tasks.py|
+            masci_tools/util/parse_utils.py|
+            masci_tools/util/typing.py|
             masci_tools/util/econfig.py|
             masci_tools/util/fleur_calculate_expression.py|
             masci_tools/tools/fleur_inpxml_converter.py|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@
 - Fleur schema parsing functions now recognize a new alias from the fleur schemas `FortranComplex` which is a number of the form `(float,float)`. Converters for complex values are added [[#106]](https://github.com/JuDFTteam/masci-tools/pull/106)
 - Added `IncompatibleSchemaVersions` error when a combination of output and input version for `OutputSchemaDict` is given, for which it is known that no XML schema can be compiled
 - `xml_getters` functions can now be used in the task definitions of the `outxml_parser` to keep information consistent. This example definition will insert the structure data, i.e. a tuple of atoms, bravais matrix and periodic boundary conditions into the output dictionary. `{'parse_type':'xmlGetter', 'name': 'get_structure_data'}` [[#107]](https://github.com/JuDFTteam/masci-tools/pull/107)
-
+- The `_conversions` key in the `outxml_parser` now accepts namedtuples `Conversion` to enable passing additional arguments to these functions. [[#109]](https://github.com/JuDFTteam/masci-tools/pull/109)
 ### Bugfixes
 - Fix in ``load_inpxml`` and ``load_outxml`` (this also effects the ``inpxml/outxml_parser``). Previously file handle like objects not directly subclassing ``io.IOBase`` would lead to an exception
 - Added patch for `OutputSchemaDict` objects with `FleurOutputSchema.xsd` files before version `0.35`. The attribute `qPoints` in the DMI output was actually called `qpoints` in these schemas, making it impossible to retrieve this attribute
 
+### Deprecated
+- Passing strings in the `_conversions` key in task definitions for the `outxml_parser`. Use `masci_tools.util.parse_utils.Conversion` instead. [[#109]](https://github.com/JuDFTteam/masci-tools/pull/109)
 ### For developers
 - Reorganized visualization tests, making the regeneration of baseline images with `pytest-mpl` easier [[#101]](https://github.com/JuDFTteam/masci-tools/pull/101)
 - Switched build system from `setuptools` to `flit`, since this way all the configuration can be specified in the `pyproject.toml` and a lot of duplication of information is avoided (e.g. version numbers) [[#102]](https://github.com/JuDFTteam/masci-tools/pull/102)

--- a/masci_tools/io/parsers/fleur/default_parse_tasks.py
+++ b/masci_tools/io/parsers/fleur/default_parse_tasks.py
@@ -250,8 +250,13 @@ TASKS_DEFINITION = {
         }
     },
     'total_energy': {
-        '_minimal': True,
-        '_conversions': [Conversion(name='convert_total_energy')],
+        '_minimal':
+        True,
+        '_conversions':
+        [Conversion(name='convert_htr_to_ev', kwargs={
+            'name': 'energy_hartree',
+            'converted_name': 'energy',
+        })],
         'energy_hartree': {
             'parse_type': 'attrib',
             'path_spec': {

--- a/masci_tools/io/parsers/fleur/default_parse_tasks.py
+++ b/masci_tools/io/parsers/fleur/default_parse_tasks.py
@@ -68,6 +68,7 @@ Following is the current specification of tasks
    :linenos:
 
 """
+from masci_tools.util.parse_utils import Conversion
 
 __working_out_versions__ = {'0.34'}
 __base_version__ = '0.34'
@@ -77,7 +78,7 @@ TASKS_DEFINITION = {
     'general_out_info': {
         '_general': True,
         '_minimal': True,
-        '_conversions': ['calculate_walltime'],
+        '_conversions': [Conversion(name='calculate_walltime')],
         'creator_name': {
             'parse_type': 'attrib',
             'path_spec': {
@@ -190,7 +191,7 @@ TASKS_DEFINITION = {
     'ldau_info': {
         '_general': True,
         '_modes': [('ldau', True)],
-        '_conversions': ['convert_ldau_definitions'],
+        '_conversions': [Conversion(name='convert_ldau_definitions')],
         'parsed_ldau': {
             'parse_type': 'allAttribs',
             'path_spec': {
@@ -219,7 +220,7 @@ TASKS_DEFINITION = {
         '_modes': [
             ('relax', True),
         ],
-        '_conversions': ['convert_relax_info'],
+        '_conversions': [Conversion(name='convert_relax_info')],
         'parsed_relax_info': {
             'parse_type': 'xmlGetter',
             'name': 'get_structure_data',
@@ -250,7 +251,7 @@ TASKS_DEFINITION = {
     },
     'total_energy': {
         '_minimal': True,
-        '_conversions': ['convert_total_energy'],
+        '_conversions': [Conversion(name='convert_total_energy')],
         'energy_hartree': {
             'parse_type': 'attrib',
             'path_spec': {
@@ -399,7 +400,7 @@ TASKS_DEFINITION = {
     'forces': {
         '_minimal': True,
         '_modes': [('relax', True)],
-        '_conversions': ['convert_forces'],
+        '_conversions': [Conversion(name='convert_forces')],
         'force_units': {
             'parse_type': 'attrib',
             'path_spec': {
@@ -418,7 +419,7 @@ TASKS_DEFINITION = {
         }
     },
     'charges': {
-        '_conversions': ['calculate_total_magnetic_moment'],
+        '_conversions': [Conversion(name='calculate_total_magnetic_moment')],
         'spin_dependent_charge': {
             'parse_type': 'allAttribs',
             'path_spec': {

--- a/masci_tools/io/parsers/fleur/outxml_conversions.py
+++ b/masci_tools/io/parsers/fleur/outxml_conversions.py
@@ -25,33 +25,41 @@ from logging import Logger
 
 
 @conversion_function
-def convert_total_energy(out_dict: dict[str, Any], logger: Logger) -> dict[str, Any]:
+def convert_htr_to_ev(out_dict: dict[str, Any],
+                      name: str,
+                      converted_name: str | None = None,
+                      pop: bool = False,
+                      add_unit: bool = True,
+                      logger: Logger | None = None) -> dict[str, Any]:
     """
-    Convert total energy to eV
+    Convert value from htr to eV
     """
 
-    total_energy = out_dict.get('energy_hartree', None)
+    if pop:
+        old = out_dict.pop(name, None)
+    else:
+        old = out_dict.get(name)
 
-    if total_energy is None:
-        if 'energy_hartree' in out_dict:
+    if converted_name is None:
+        converted_name = f'{old}_ev'
+
+    if add_unit:
+        out_dict[f'{converted_name}_units'] = 'eV'
+
+    if old is None:
+        if name in out_dict:
             if logger is not None:
-                logger.warning('convert_total_energy cannot convert None to eV')
-            out_dict['energy'] = None
-            out_dict['energy_units'] = 'eV'
+                logger.warning(f'convert_htr_to_ev cannot convert None to eV (Name: {name})')
+            out_dict[converted_name] = None
         return out_dict
 
-    total_energy = total_energy[-1]
-
-    if 'energy' not in out_dict:
-        out_dict['energy'] = []
-        out_dict['energy_units'] = 'eV'
-
-    if total_energy is not None:
-        out_dict['energy'].append(total_energy * HTR_TO_EV)
+    old = old[-1]
+    if old is not None:
+        out_dict.setdefault(converted_name, []).append(old * HTR_TO_EV)
     else:
         if logger is not None:
-            logger.warning('convert_total_energy cannot convert None to eV')
-        out_dict['energy'].append(None)
+            logger.warning(f'convert_htr_to_ev cannot convert None to eV (Name: {name})')
+        out_dict.setdefault(converted_name, []).append(None)
 
     return out_dict
 

--- a/masci_tools/util/parse_tasks.py
+++ b/masci_tools/util/parse_tasks.py
@@ -33,6 +33,8 @@ from masci_tools.io.parsers import fleur_schema
 
 from masci_tools.util.xml.converters import convert_str_version_number
 from .xml import xml_getters
+from .parse_utils import Conversion
+
 from masci_tools.util.typing import XMLLike
 import masci_tools
 
@@ -495,8 +497,14 @@ class ParseTasks:
 
         conversions = tasks_definition.get('_conversions', [])
         for conversion in conversions:
-            action = self.conversion_functions[conversion]
-            out_dict = action(out_dict, logger=logger)
+            if not isinstance(conversion, Conversion):
+                warnings.warn(
+                    'Providing the _conversions as a list of strings is deprecated'
+                    'Use the Conversion namedtuple from masci_tools.util.parse_utils instead', DeprecationWarning)
+                conversion = Conversion(name=conversion)
+
+            action = self.conversion_functions[conversion.name]
+            out_dict = action(out_dict, *conversion.args, logger=logger, **conversion.kwargs)
 
         return out_dict
 

--- a/masci_tools/util/parse_utils.py
+++ b/masci_tools/util/parse_utils.py
@@ -1,0 +1,12 @@
+"""
+Module for utilities for parsing. Should be independent of the actual parsing functions
+"""
+from __future__ import annotations
+
+from typing import NamedTuple, Any
+
+
+class Conversion(NamedTuple):
+    name: str
+    args: tuple[Any, ...] = ()
+    kwargs: dict[str, Any] = {}

--- a/tests/parsers/test_fleur_outxml_parser/test_outxml_broken_firstiter.yml
+++ b/tests/parsers/test_fleur_outxml_parser/test_outxml_broken_firstiter.yml
@@ -85,7 +85,7 @@ warnings:
   - Enddate was unparsed, inp.xml prob not complete, do not believe the walltime!
   - '[Iteration 1] No values found for attribute value'
   - '[Iteration 1] No values found for attribute units'
-  - '[Iteration 1] convert_total_energy cannot convert None to eV'
+  - '[Iteration 1] convert_htr_to_ev cannot convert None to eV (Name: energy_hartree)'
   - '[Iteration 1] No values found for attribute distance'
   - '[Iteration 1] No values found for attribute units'
   - '[Iteration 1] No values found for attribute distance'


### PR DESCRIPTION
Inspired by the same mechanism for transformations in `HDF5Reader`. Since the old way provided no way of giving arguments the conversion functions are quite static and need to be made custom for all types. See [ase-fleur](https://github.com/JuDFTteam/ase-fleur/blob/develop/ase_fleur/io.py) for an example of this problem. Maybe at some point we can even unify the transformations in hdf5 and the ones for the xml parser