### PR TITLE
Make detection whether a xpath contains a tag more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `xml_getters` functions can now be used in the task definitions of the `outxml_parser` to keep information consistent. This example definition will insert the structure data, i.e. a tuple of atoms, bravais matrix and periodic boundary conditions into the output dictionary. `{'parse_type':'xmlGetter', 'name': 'get_structure_data'}` [[#107]](https://github.com/JuDFTteam/masci-tools/pull/107)
 - The `_conversions` key in the `outxml_parser` now accepts namedtuples `Conversion` to enable passing additional arguments to these functions. [[#109]](https://github.com/JuDFTteam/masci-tools/pull/109)
 - Adjusted `get_cell` to understand the `bravaisMatrixFilm` inut introduced with the MaX6 release of fleur [[#110]](https://github.com/JuDFTteam/masci-tools/pull/110)
+- Improved detection, whether a given xpath contains a tag including stripping predicates. Added function `contains_tag` in `masci_tools.util.xml.common_functions` [[#113]](https://github.com/JuDFTteam/masci-tools/pull/113)
 
 ### Bugfixes
 - Fix in ``load_inpxml`` and ``load_outxml`` (this also effects the ``inpxml/outxml_parser``). Previously file handle like objects not directly subclassing ``io.IOBase`` would lead to an exception

--- a/masci_tools/io/parsers/fleur_schema/schema_dict.py
+++ b/masci_tools/io/parsers/fleur_schema/schema_dict.py
@@ -35,7 +35,7 @@ from lxml import etree
 
 from masci_tools.util.lockable_containers import LockableDict, LockableList
 from masci_tools.util.case_insensitive_dict import CaseInsensitiveFrozenSet, CaseInsensitiveDict
-from masci_tools.util.xml.common_functions import abs_to_rel_xpath, split_off_tag
+from masci_tools.util.xml.common_functions import abs_to_rel_xpath, split_off_tag, contains_tag
 from .inpschema_todict import create_inpschema_dict, InputSchemaData
 from .outschema_todict import create_outschema_dict, merge_schema_dicts
 
@@ -364,7 +364,7 @@ class SchemaDict(LockableDict):
         paths = self._find_paths(name, self._tag_entries, contains=contains, not_contains=not_contains)
         #Filter out paths which contain the rootTag explicitly not a tag name containing the root tag
         #e.g. bravaisMatrix vs. bravaisMatrixFilm
-        paths = [path for path in paths if f'{root_tag}/' in path or path.endswith(root_tag)]
+        paths = [path for path in paths if contains_tag(path, root_tag)]
 
         relative_paths = {abs_to_rel_xpath(xpath, root_tag) for xpath in paths}
 
@@ -491,7 +491,7 @@ class SchemaDict(LockableDict):
         paths = self._find_paths(name, entries, contains=contains, not_contains=not_contains)
         #Filter out paths which contain the rootTag explicitly not a tag name containing the root tag
         #e.g. bravaisMatrix vs. bravaisMatrixFilm
-        paths = [path for path in paths if f'{root_tag}/' in path or path.endswith(root_tag)]
+        paths = [path for path in paths if contains_tag(path, root_tag)]
         relative_paths = {abs_to_rel_xpath(xpath, root_tag) for xpath in paths}
 
         if len(relative_paths) == 1:
@@ -945,15 +945,15 @@ class OutputSchemaDict(SchemaDict):
             raise ValueError(f"{iteration_tag} is not a valid iteration tag valid are: {list(self['iteration_tags'])}")
         iteration_path = self.tag_xpath(iteration_tag)
 
-        if f'/{root_tag}' not in iteration_path:
+        if not contains_tag(iteration_path, root_tag):
             #The paths have to include the root_tag
             contains = _add_condition(contains, root_tag)
 
         paths = self._find_paths(name, ('iteration_tag_paths',), contains=contains, not_contains=not_contains)
-        if f'/{root_tag}' not in iteration_path:
+        if not contains_tag(iteration_path, root_tag):
             #Filter out paths which contain the rootTag explicitly not a tag name containing the root tag
             #e.g. bravaisMatrix vs. bravaisMatrixFilm
-            paths = [path for path in paths if f'{root_tag}/' in path or path.endswith(root_tag)]
+            paths = [path for path in paths if contains_tag(path, root_tag)]
         paths = [f"{iteration_path}{path.lstrip('.')}" for path in paths]
         relative_paths = {abs_to_rel_xpath(xpath, root_tag) for xpath in paths}
 
@@ -1102,14 +1102,14 @@ class OutputSchemaDict(SchemaDict):
             if 'iteration' in entry and all(f'{excl}_attribs' not in entry for excl in exclude)
         ]
 
-        if f'/{root_tag}' not in iteration_path:
+        if not contains_tag(iteration_path, root_tag):
             contains = _add_condition(contains, root_tag)
 
         paths = self._find_paths(name, entries, contains=contains, not_contains=not_contains)
-        if f'/{root_tag}' not in iteration_path:
+        if not contains_tag(iteration_path, root_tag):
             #Filter out paths which contain the rootTag explicitly not a tag name containing the root tag
             #e.g. bravaisMatrix vs. bravaisMatrixFilm
-            paths = [path for path in paths if f'{root_tag}/' in path or path.endswith(root_tag)]
+            paths = [path for path in paths if contains_tag(path, root_tag)]
         paths = [f"{iteration_path}{path.lstrip('.')}" for path in paths]
         relative_paths = {abs_to_rel_xpath(xpath, root_tag) for xpath in paths}
 

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -393,7 +393,7 @@ def abs_to_rel_xpath(xpath: str, new_root: str) -> str:
 
     :returns: str of the relative xpath
     """
-    if f'{new_root}/' in xpath or xpath.endswith(new_root):
+    if contains_tag(xpath, new_root):
         xpath = xpath + '/'
         xpath_to_root = '/'.join(xpath.split(new_root + '/')[:-1]) + new_root
         xpath = xpath.replace(f'{xpath_to_root}/', './')
@@ -412,3 +412,32 @@ def normalize_xmllike(xmllike: XMLLike) -> etree._Element:
         return xmllike
     xmllike, _ = clear_xml(xmllike)
     return xmllike.getroot()
+
+
+def contains_tag(xpath: XPathLike, tag: str) -> bool:
+    """
+    Return whether a given xpath contains a given tag
+    This assumes that predicates of xpaths can't be nested
+    since otherwise the regex for removing them could fail
+
+    This function will only return True if one of the
+    tags exactly matches the tag argument not if one tag contains the
+    given name in it's name
+
+    :param xpath: xpath expression
+    :param tag: tag to check for
+
+    :returns: whether a tag is contained in the xpath
+    """
+    import re
+    if isinstance(xpath, XPathBuilder):
+        return tag in xpath.components
+
+    if isinstance(xpath, etree.XPath):
+        xpath_str = xpath.path  #type:ignore
+    else:
+        xpath_str = str(xpath)
+
+    #Strip out predicates
+    xpath_str = re.sub(r'[\[].*?[\]]', '', xpath_str)
+    return tag in xpath_str.split('/')

--- a/tests/xml/test_xml_common_functions.py
+++ b/tests/xml/test_xml_common_functions.py
@@ -4,6 +4,7 @@ Test of the functions in masci_tools.util.xml.common_functions
 import pytest
 import logging
 from lxml import etree
+from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
 LOGGER = logging.getLogger(__name__)
 
@@ -126,7 +127,6 @@ def test_split_off_tag():
     Test of the split_off_tag function
     """
     from masci_tools.util.xml.common_functions import split_off_tag
-    from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
     assert split_off_tag('/fleurInput/calculationSetup/cutoffs') == ('/fleurInput/calculationSetup', 'cutoffs')
     assert split_off_tag('/fleurInput/calculationSetup/cutoffs/') == ('/fleurInput/calculationSetup', 'cutoffs')
@@ -146,7 +146,6 @@ def test_add_tag():
     Test of the add_tag function
     """
     from masci_tools.util.xml.common_functions import add_tag
-    from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
     assert add_tag('/fleurInput/calculationSetup', 'cutoffs') == '/fleurInput/calculationSetup/cutoffs'
     assert add_tag('/fleurInput/calculationSetup/', 'cutoffs') == '/fleurInput/calculationSetup/cutoffs'
@@ -164,7 +163,6 @@ def test_split_off_attrib():
     Test of the split_off_tag function
     """
     from masci_tools.util.xml.common_functions import split_off_attrib
-    from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
     assert split_off_attrib('/fleurInput/calculationSetup/cutoffs/@Kmax') == ('/fleurInput/calculationSetup/cutoffs',
                                                                               'Kmax')
@@ -226,3 +224,27 @@ def test_abs_to_rel_xpath():
     assert abs_to_rel_xpath('/test/new_root/relativeExtra/path', 'relativeExtra') == './path'
     with pytest.raises(ValueError):
         abs_to_rel_xpath('/test/new_root/relativeExtra/path', 'relative')
+
+
+@pytest.mark.parametrize('xpath,tag,result', [
+    ('/test/tag/path', 'tag', True),
+    ('/test/tags/path', 'tag', False),
+    ('/test/tag/path', 'path', True),
+    ('/test/tag/path', 'test', True),
+    ('test/tag/path', 'tag', True),
+    ('./test/tag/path', 'test', True),
+    ('.', 'tag', False),
+    ('/test/tag/path[asf]', 'tag', True),
+    ('/test/tag[tests]/path[test]', 'tag', True),
+    ('/test/tag[tests]/path[test]', 'tests', False),
+    ('/test/tag[tests]/path[test]', 'test', True),
+    (XPathBuilder('/test/tag/path'), 'test', True),
+    (etree.XPath('/test/tag[tests]/path[test]'), 'test', True),
+])
+def test_contains_tag(xpath, tag, result):
+    """
+    Test of the contains tag function
+    """
+    from masci_tools.util.xml.common_functions import contains_tag
+
+    assert contains_tag(xpath, tag) == result


### PR DESCRIPTION
previously the string was just checked for the containing tag
this hass a number of drawbacks including if the tag is in a Xpath
predicate or another part of the xpath contains the tag name to search

A function contains_tag is introduced to solve these problems. This
strips out the predicates and creates the explicit list of contained
tags.