### PR TITLE
Fix pytest-mpl artifact upload

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -129,10 +129,10 @@ jobs:
         codecov
 
     - uses: actions/upload-artifact@v2
+      if: failure()
       with:
         name: Matplotlib comparison
-        path: mpl-results/fig_comparison.html
-        if-no-files-found: ignore
+        path: mpl-results
 
   publish:
     name: Publish to PyPi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         codecov
 
     - uses: actions/upload-artifact@v2
+      if: failure()
       with:
         name: Matplotlib comparison
-        path: mpl-results/fig_comparison.html
-        if-no-files-found: ignore
+        path: mpl-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Fix for signatures of `set_text`/`set_first_text`. These contained names of attribute setting functions [[#118]](https://github.com/JuDFTteam/masci-tools/pull/118)
 - Fix for validating arguments in `FleurXMLModifier` not accepting an argument named `name` when passed by keyword. [[#118]](https://github.com/JuDFTteam/masci-tools/pull/118)
 
+### For developers
+- Fixed upload of pytest-mpl results artifacts to include the whole directory with images and not just the HTML file [[#117]](https://github.com/JuDFTteam/masci-tools/pull/117)
+
 # v.0.8.0
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.7.2...v0.8.0)
 


### PR DESCRIPTION
I noticed this project uses the pytest-mpl HTML summary, however the CI is only saving the HTML file as an artifact and not the whole results directory. This means that when you download the artifact and open it, the images are not shown. This PR fixes this, and is similar to [this](https://github.com/SciTools/cartopy/blob/22cdafca511744143c5b673598a1889f169c1e3d/.github/workflows/ci-testing.yml#L90).

You may want to also include the `${{ matrix.python-version }}` in the artifact name and path so each job doesn't write the same artifact.