### PR TITLE
Cleanup XML setter arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.8.0...develop)
 
 ### Improvements
-- Several arguments in XML setter functions were renamed for more consistent signatures. The main changes are 
+- Several arguments in XML setter functions were renamed for more consistent signatures.
+  The main changes are 
    - `attributedict`/`change_dict` -> `changes`
    - `attributename`/`attribv` -> `name`/`value`
    - `add_number` -> `number_to_add`
+  
   The old signatures are still supported with deprecations if called via the `FleurXMLModifier` [[#118]](https://github.com/JuDFTteam/masci-tools/pull/118)
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@
 # latest
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.8.0...develop)
 
-Nothing here yet
+### Improvements
+- Several arguments in XML setter functions were renamed for more consistent signatures. The main changes are 
+   - `attributedict`/`change_dict` -> `changes`
+   - `attributename`/`attribv` -> `name`/`value`
+   - `add_number` -> `number_to_add`
+  The old signatures are still supported with deprecations if called via the `FleurXMLModifier` [[#118]](https://github.com/JuDFTteam/masci-tools/pull/118)
+
+### Bugfixes
+- Fix for signatures of `set_text`/`set_first_text`. These contained names of attribute setting functions [[#118]](https://github.com/JuDFTteam/masci-tools/pull/118)
+- Fix for validating arguments in `FleurXMLModifier` not accepting an argument named `name` when passed by keyword. [[#118]](https://github.com/JuDFTteam/masci-tools/pull/118)
 
 # v.0.8.0
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.7.2...v0.8.0)

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -28,6 +28,7 @@ from masci_tools.io.io_fleurxml import load_inpxml
 from masci_tools.util.typing import XMLFileLike, FileLike
 from pathlib import Path
 from lxml import etree
+import warnings
 #Enable warnings for missing docstrings
 #pylint: enable=missing-function-docstring
 
@@ -802,6 +803,10 @@ class FleurXMLModifier:
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
+        if 'newelement' in kwargs:
+            warnings.warn('The argument newelement is deprecated. Use element instead', DeprecationWarning)
+            kwargs['element'] = kwargs.pop('newelement')
+
         self._validate_signature('xml_replace_tag', *args, **kwargs)
         self._tasks.append(ModifierTask('xml_replace_tag', args, kwargs))
 
@@ -827,6 +832,9 @@ class FleurXMLModifier:
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
+        if 'attributename' in kwargs:
+            warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
+            kwargs['name'] = kwargs.pop('attributename')
         self._validate_signature('xml_delete_att', *args, **kwargs)
         self._tasks.append(ModifierTask('xml_delete_att', args, kwargs))
 
@@ -840,6 +848,12 @@ class FleurXMLModifier:
         :param attribv: value or list of values to set (if not str they will be converted with `str(value)`)
         :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
         """
+        if 'attributename' in kwargs:
+            warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
+            kwargs['attribute_name'] = kwargs.pop('attributename')
+        if 'attribv' in kwargs:
+            warnings.warn('The argument attribv is deprecated. Use value instead', DeprecationWarning)
+            kwargs['value'] = kwargs.pop('attribv')
         self._validate_signature('xml_set_attrib_value_no_create', *args, **kwargs)
         self._tasks.append(ModifierTask('xml_set_attrib_value_no_create', args, kwargs))
 

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -129,7 +129,16 @@ class FleurXMLModifier:
             except KeyError as exc:
                 raise ValueError(f"Unknown modification method '{name}'") from exc
 
-    def _validate_signature(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
+    def _validate_signature(self, name: str, *args: Any, **kwargs: Any) -> None:
+        """
+        DEPRECATED: use `_validate_arguments` instead without unpacking args/kwargs
+        """
+        warnings.warn(
+            'The _validate_signature method is deprecated. '
+            'Please use _validate_arguments without unpacking args/kwargs instead', DeprecationWarning)
+        self._validate_arguments(name, args, kwargs)
+
+    def _validate_arguments(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
         """
         Validate that the given arguments to the registration
         method can be used to call the corresponding XML modifying function
@@ -341,7 +350,7 @@ class FleurXMLModifier:
         if 'change_dict' in kwargs:
             warnings.warn('The argument change_dict is deprecated. Use changes instead', DeprecationWarning)
             kwargs['changes'] = kwargs.pop('change_dict')
-        self._validate_signature('set_inpchanges', args, kwargs)
+        self._validate_arguments('set_inpchanges', args, kwargs)
         self._tasks.append(ModifierTask('set_inpchanges', args, kwargs))
 
     def shift_value(self, *args: Any, **kwargs: Any) -> None:
@@ -362,7 +371,7 @@ class FleurXMLModifier:
         if 'change_dict' in kwargs:
             warnings.warn('The argument change_dict is deprecated. Use changes instead', DeprecationWarning)
             kwargs['changes'] = kwargs.pop('change_dict')
-        self._validate_signature('shift_value', args, kwargs)
+        self._validate_arguments('shift_value', args, kwargs)
         self._tasks.append(ModifierTask('shift_value', args, kwargs))
 
     def set_species(self, *args: Any, **kwargs: Any) -> None:
@@ -394,7 +403,7 @@ class FleurXMLModifier:
         if 'attributedict' in kwargs:
             warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
             kwargs['changes'] = kwargs.pop('attributedict')
-        self._validate_signature('set_species', args, kwargs)
+        self._validate_arguments('set_species', args, kwargs)
         self._tasks.append(ModifierTask('set_species', args, kwargs))
 
     def set_species_label(self, *args: Any, **kwargs: Any) -> None:
@@ -409,7 +418,7 @@ class FleurXMLModifier:
         if 'attributedict' in kwargs:
             warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
             kwargs['changes'] = kwargs.pop('attributedict')
-        self._validate_signature('set_species_label', args, kwargs)
+        self._validate_arguments('set_species_label', args, kwargs)
         self._tasks.append(ModifierTask('set_species_label', args, kwargs))
 
     def clone_species(self, *args: Any, **kwargs: Any) -> None:
@@ -422,7 +431,7 @@ class FleurXMLModifier:
         :param new_name: new name of the cloned species
         :param changes: a optional python dict specifying what you want to change.
         """
-        self._validate_signature('clone_species', args, kwargs)
+        self._validate_arguments('clone_species', args, kwargs)
         self._tasks.append(ModifierTask('clone_species', args, kwargs))
 
     def switch_species(self, *args: Any, **kwargs: Any) -> None:
@@ -439,7 +448,7 @@ class FleurXMLModifier:
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details`
         """
-        self._validate_signature('switch_species', args, kwargs)
+        self._validate_arguments('switch_species', args, kwargs)
         self._tasks.append(ModifierTask('switch_species', args, kwargs))
 
     def switch_species_label(self, *args: Any, **kwargs: Any) -> None:
@@ -453,7 +462,7 @@ class FleurXMLModifier:
                   from one species the species will be cloned with :py:func:`clone_species()`
         :param changes: changes to do if the species is cloned
         """
-        self._validate_signature('switch_species_label', args, kwargs)
+        self._validate_arguments('switch_species_label', args, kwargs)
         self._tasks.append(ModifierTask('switch_species_label', args, kwargs))
 
     def shift_value_species_label(self, *args: Any, **kwargs: Any) -> None:
@@ -479,7 +488,7 @@ class FleurXMLModifier:
         if 'value_given' in kwargs:
             warnings.warn('The argument value_given is deprecated. Use number_to_add instead', DeprecationWarning)
             kwargs['number_to_add'] = kwargs.pop('value_given')
-        self._validate_signature('shift_value_species_label', args, kwargs)
+        self._validate_arguments('shift_value_species_label', args, kwargs)
         self._tasks.append(ModifierTask('shift_value_species_label', args, kwargs))
 
     def set_atomgroup(self, *args: Any, **kwargs: Any) -> None:
@@ -506,7 +515,7 @@ class FleurXMLModifier:
         if 'create' in kwargs:
             warnings.warn('The argument create is deprecated and is ignored.', DeprecationWarning)
             kwargs.pop('create')
-        self._validate_signature('set_atomgroup', args, kwargs)
+        self._validate_arguments('set_atomgroup', args, kwargs)
         self._tasks.append(ModifierTask('set_atomgroup', args, kwargs))
 
     def set_atomgroup_label(self, *args: Any, **kwargs: Any) -> None:
@@ -530,7 +539,7 @@ class FleurXMLModifier:
         if 'create' in kwargs:
             warnings.warn('The argument create is deprecatedand is ignored.', DeprecationWarning)
             kwargs.pop('create')
-        self._validate_signature('set_atomgroup_label', args, kwargs)
+        self._validate_arguments('set_atomgroup_label', args, kwargs)
         self._tasks.append(ModifierTask('set_atomgroup_label', args, kwargs))
 
     def create_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -552,7 +561,7 @@ class FleurXMLModifier:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
         """
-        self._validate_signature('create_tag', args, kwargs)
+        self._validate_arguments('create_tag', args, kwargs)
         self._tasks.append(ModifierTask('create_tag', args, kwargs))
 
     def delete_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -572,7 +581,7 @@ class FleurXMLModifier:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
         """
-        self._validate_signature('delete_tag', args, kwargs)
+        self._validate_arguments('delete_tag', args, kwargs)
         self._tasks.append(ModifierTask('delete_tag', args, kwargs))
 
     def delete_att(self, *args: Any, **kwargs: Any) -> None:
@@ -599,7 +608,7 @@ class FleurXMLModifier:
             warnings.warn('The argument attrib_name is deprecated. Use name instead', DeprecationWarning)
             kwargs['name'] = kwargs.pop('attrib_name')
         print(args, kwargs)
-        self._validate_signature('delete_att', args, kwargs)
+        self._validate_arguments('delete_att', args, kwargs)
         self._tasks.append(ModifierTask('delete_att', args, kwargs))
 
     def replace_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -623,7 +632,7 @@ class FleurXMLModifier:
         if 'newelement' in kwargs:
             warnings.warn('The argument newelement is deprecated. Use element instead', DeprecationWarning)
             kwargs['element'] = kwargs.pop('newelement')
-        self._validate_signature('replace_tag', args, kwargs)
+        self._validate_arguments('replace_tag', args, kwargs)
         self._tasks.append(ModifierTask('replace_tag', args, kwargs))
 
     def set_complex_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -646,7 +655,7 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
 
         """
-        self._validate_signature('set_complex_tag', args, kwargs)
+        self._validate_arguments('set_complex_tag', args, kwargs)
         self._tasks.append(ModifierTask('set_complex_tag', args, kwargs))
 
     def set_simple_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -668,7 +677,7 @@ class FleurXMLModifier:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
         """
-        self._validate_signature('set_simple_tag', args, kwargs)
+        self._validate_arguments('set_simple_tag', args, kwargs)
         self._tasks.append(ModifierTask('set_simple_tag', args, kwargs))
 
     def set_text(self, *args: Any, **kwargs: Any) -> None:
@@ -690,7 +699,7 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
 
         """
-        self._validate_signature('set_text', args, kwargs)
+        self._validate_arguments('set_text', args, kwargs)
         self._tasks.append(ModifierTask('set_text', args, kwargs))
 
     def set_first_text(self, *args: Any, **kwargs: Any) -> None:
@@ -711,7 +720,7 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
 
         """
-        self._validate_signature('set_first_text', args, kwargs)
+        self._validate_arguments('set_first_text', args, kwargs)
         self._tasks.append(ModifierTask('set_first_text', args, kwargs))
 
     def set_attrib_value(self, *args: Any, **kwargs: Any) -> None:
@@ -742,7 +751,7 @@ class FleurXMLModifier:
         if 'attribv' in kwargs:
             warnings.warn('The argument attribv is deprecated. Use value instead', DeprecationWarning)
             kwargs['value'] = kwargs.pop('attribv')
-        self._validate_signature('set_attrib_value', args, kwargs)
+        self._validate_arguments('set_attrib_value', args, kwargs)
         self._tasks.append(ModifierTask('set_attrib_value', args, kwargs))
 
     def set_first_attrib_value(self, *args: Any, **kwargs: Any) -> None:
@@ -772,7 +781,7 @@ class FleurXMLModifier:
         if 'attribv' in kwargs:
             warnings.warn('The argument attribv is deprecated. Use value instead', DeprecationWarning)
             kwargs['value'] = kwargs.pop('attribv')
-        self._validate_signature('set_first_attrib_value', args, kwargs)
+        self._validate_arguments('set_first_attrib_value', args, kwargs)
         self._tasks.append(ModifierTask('set_first_attrib_value', args, kwargs))
 
     def add_number_to_attrib(self, *args: Any, **kwargs: Any) -> None:
@@ -805,7 +814,7 @@ class FleurXMLModifier:
         if 'add_number' in kwargs:
             warnings.warn('The argument add_number is deprecated. Use number_to_add instead', DeprecationWarning)
             kwargs['number_to_add'] = kwargs.pop('add_number')
-        self._validate_signature('add_number_to_attrib', args, kwargs)
+        self._validate_arguments('add_number_to_attrib', args, kwargs)
         self._tasks.append(ModifierTask('add_number_to_attrib', args, kwargs))
 
     def add_number_to_first_attrib(self, *args: Any, **kwargs: Any) -> None:
@@ -837,7 +846,7 @@ class FleurXMLModifier:
         if 'add_number' in kwargs:
             warnings.warn('The argument add_number is deprecated. Use number_to_add instead', DeprecationWarning)
             kwargs['number_to_add'] = kwargs.pop('add_number')
-        self._validate_signature('add_number_to_first_attrib', args, kwargs)
+        self._validate_arguments('add_number_to_first_attrib', args, kwargs)
         self._tasks.append(ModifierTask('add_number_to_first_attrib', args, kwargs))
 
     def xml_create_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -852,7 +861,7 @@ class FleurXMLModifier:
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
-        self._validate_signature('xml_create_tag', args, kwargs)
+        self._validate_arguments('xml_create_tag', args, kwargs)
         self._tasks.append(ModifierTask('xml_create_tag', args, kwargs))
 
     def xml_replace_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -869,7 +878,7 @@ class FleurXMLModifier:
             warnings.warn('The argument newelement is deprecated. Use element instead', DeprecationWarning)
             kwargs['element'] = kwargs.pop('newelement')
 
-        self._validate_signature('xml_replace_tag', args, kwargs)
+        self._validate_arguments('xml_replace_tag', args, kwargs)
         self._tasks.append(ModifierTask('xml_replace_tag', args, kwargs))
 
     def xml_delete_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -881,7 +890,7 @@ class FleurXMLModifier:
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
-        self._validate_signature('xml_delete_tag', args, kwargs)
+        self._validate_arguments('xml_delete_tag', args, kwargs)
         self._tasks.append(ModifierTask('xml_delete_tag', args, kwargs))
 
     def xml_delete_att(self, *args: Any, **kwargs: Any) -> None:
@@ -897,7 +906,7 @@ class FleurXMLModifier:
         if 'attributename' in kwargs:
             warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
             kwargs['name'] = kwargs.pop('attributename')
-        self._validate_signature('xml_delete_att', args, kwargs)
+        self._validate_arguments('xml_delete_att', args, kwargs)
         self._tasks.append(ModifierTask('xml_delete_att', args, kwargs))
 
     def xml_set_attrib_value_no_create(self, *args: Any, **kwargs: Any) -> None:
@@ -916,7 +925,7 @@ class FleurXMLModifier:
         if 'attribv' in kwargs:
             warnings.warn('The argument attribv is deprecated. Use value instead', DeprecationWarning)
             kwargs['value'] = kwargs.pop('attribv')
-        self._validate_signature('xml_set_attrib_value_no_create', args, kwargs)
+        self._validate_arguments('xml_set_attrib_value_no_create', args, kwargs)
         self._tasks.append(ModifierTask('xml_set_attrib_value_no_create', args, kwargs))
 
     def xml_set_text_no_create(self, *args: Any, **kwargs: Any) -> None:
@@ -928,7 +937,7 @@ class FleurXMLModifier:
         :param text: value or list of values to set (if not str they will be converted with `str(value)`)
         :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
         """
-        self._validate_signature('xml_set_text_no_create', args, kwargs)
+        self._validate_arguments('xml_set_text_no_create', args, kwargs)
         self._tasks.append(ModifierTask('xml_set_text_no_create', args, kwargs))
 
     def set_nmmpmat(self, *args: Any, **kwargs: Any) -> None:
@@ -947,7 +956,7 @@ class FleurXMLModifier:
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         """
-        self._validate_signature('set_nmmpmat', args, kwargs)
+        self._validate_arguments('set_nmmpmat', args, kwargs)
         self._tasks.append(ModifierTask('set_nmmpmat', args, kwargs))
 
     def rotate_nmmpmat(self, *args: Any, **kwargs: Any) -> None:
@@ -962,7 +971,7 @@ class FleurXMLModifier:
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         """
-        self._validate_signature('rotate_nmmpmat', args, kwargs)
+        self._validate_arguments('rotate_nmmpmat', args, kwargs)
         self._tasks.append(ModifierTask('rotate_nmmpmat', args, kwargs))
 
     def set_kpointlist(self, *args: Any, **kwargs: Any) -> None:
@@ -983,7 +992,7 @@ class FleurXMLModifier:
         :param switch: bool, if True the kPointlist will be used by Fleur when starting the next calculation
         :param overwrite: bool, if True and a kPointlist with the given name already exists it will be overwritten
         """
-        self._validate_signature('set_kpointlist', args, kwargs)
+        self._validate_arguments('set_kpointlist', args, kwargs)
         self._tasks.append(ModifierTask('set_kpointlist', args, kwargs))
 
     def switch_kpointset(self, *args: Any, **kwargs: Any) -> None:
@@ -996,7 +1005,7 @@ class FleurXMLModifier:
 
         :param list_name: name of the kPoint set to use
         """
-        self._validate_signature('switch_kpointset', args, kwargs)
+        self._validate_arguments('switch_kpointset', args, kwargs)
         self._tasks.append(ModifierTask('switch_kpointset', args, kwargs))
 
     def set_nkpts(self, *args: Any, **kwargs: Any) -> None:
@@ -1011,7 +1020,7 @@ class FleurXMLModifier:
         :param gamma: bool that controls if the gamma-point should be included
                       in the k-point mesh
         """
-        self._validate_signature('set_nkpts', args, kwargs)
+        self._validate_arguments('set_nkpts', args, kwargs)
         self._tasks.append(ModifierTask('set_nkpts', args, kwargs))
 
     def set_kpath(self, *args: Any, **kwargs: Any) -> None:
@@ -1027,5 +1036,5 @@ class FleurXMLModifier:
         :param gamma: bool that controls if the gamma-point should be included
                       in the k-point mesh
         """
-        self._validate_signature('set_kpath', args, kwargs)
+        self._validate_arguments('set_kpath', args, kwargs)
         self._tasks.append(ModifierTask('set_kpath', args, kwargs))

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -35,8 +35,8 @@ import warnings
 
 class ModifierTask(NamedTuple):
     name: str
-    args: tuple[Any, ...]
-    kwargs: dict[str, Any]
+    args: tuple[Any, ...] = ()
+    kwargs: dict[str, Any] = {}
 
 
 class FleurXMLModifier:
@@ -129,7 +129,7 @@ class FleurXMLModifier:
             except KeyError as exc:
                 raise ValueError(f"Unknown modification method '{name}'") from exc
 
-    def _validate_signature(self, name: str, *args: Any, **kwargs: Any) -> None:
+    def _validate_signature(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
         """
         Validate that the given arguments to the registration
         method can be used to call the corresponding XML modifying function
@@ -341,7 +341,7 @@ class FleurXMLModifier:
         if 'change_dict' in kwargs:
             warnings.warn('The argument change_dict is deprecated. Use changes instead', DeprecationWarning)
             kwargs['changes'] = kwargs.pop('change_dict')
-        self._validate_signature('set_inpchanges', *args, **kwargs)
+        self._validate_signature('set_inpchanges', args, kwargs)
         self._tasks.append(ModifierTask('set_inpchanges', args, kwargs))
 
     def shift_value(self, *args: Any, **kwargs: Any) -> None:
@@ -362,7 +362,7 @@ class FleurXMLModifier:
         if 'change_dict' in kwargs:
             warnings.warn('The argument change_dict is deprecated. Use changes instead', DeprecationWarning)
             kwargs['changes'] = kwargs.pop('change_dict')
-        self._validate_signature('shift_value', *args, **kwargs)
+        self._validate_signature('shift_value', args, kwargs)
         self._tasks.append(ModifierTask('shift_value', args, kwargs))
 
     def set_species(self, *args: Any, **kwargs: Any) -> None:
@@ -375,7 +375,6 @@ class FleurXMLModifier:
         :param changes: a python dict specifying what you want to change.
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-        :param create: bool, if species does not exist create it and all subtags?
 
         **changes** is a python dictionary containing dictionaries that specify attributes
         to be set inside the certain specie. For example, if one wants to set a MT radius it
@@ -395,7 +394,7 @@ class FleurXMLModifier:
         if 'attributedict' in kwargs:
             warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
             kwargs['changes'] = kwargs.pop('attributedict')
-        self._validate_signature('set_species', *args, **kwargs)
+        self._validate_signature('set_species', args, kwargs)
         self._tasks.append(ModifierTask('set_species', args, kwargs))
 
     def set_species_label(self, *args: Any, **kwargs: Any) -> None:
@@ -410,7 +409,7 @@ class FleurXMLModifier:
         if 'attributedict' in kwargs:
             warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
             kwargs['changes'] = kwargs.pop('attributedict')
-        self._validate_signature('set_species_label', *args, **kwargs)
+        self._validate_signature('set_species_label', args, kwargs)
         self._tasks.append(ModifierTask('set_species_label', args, kwargs))
 
     def clone_species(self, *args: Any, **kwargs: Any) -> None:
@@ -423,7 +422,7 @@ class FleurXMLModifier:
         :param new_name: new name of the cloned species
         :param changes: a optional python dict specifying what you want to change.
         """
-        self._validate_signature('clone_species', *args, **kwargs)
+        self._validate_signature('clone_species', args, kwargs)
         self._tasks.append(ModifierTask('clone_species', args, kwargs))
 
     def switch_species(self, *args: Any, **kwargs: Any) -> None:
@@ -440,7 +439,7 @@ class FleurXMLModifier:
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details`
         """
-        self._validate_signature('switch_species', *args, **kwargs)
+        self._validate_signature('switch_species', args, kwargs)
         self._tasks.append(ModifierTask('switch_species', args, kwargs))
 
     def switch_species_label(self, *args: Any, **kwargs: Any) -> None:
@@ -454,7 +453,7 @@ class FleurXMLModifier:
                   from one species the species will be cloned with :py:func:`clone_species()`
         :param changes: changes to do if the species is cloned
         """
-        self._validate_signature('switch_species_label', *args, **kwargs)
+        self._validate_signature('switch_species_label', args, kwargs)
         self._tasks.append(ModifierTask('switch_species_label', args, kwargs))
 
     def shift_value_species_label(self, *args: Any, **kwargs: Any) -> None:
@@ -480,7 +479,7 @@ class FleurXMLModifier:
         if 'value_given' in kwargs:
             warnings.warn('The argument value_given is deprecated. Use number_to_add instead', DeprecationWarning)
             kwargs['number_to_add'] = kwargs.pop('value_given')
-        self._validate_signature('shift_value_species_label', *args, **kwargs)
+        self._validate_signature('shift_value_species_label', args, kwargs)
         self._tasks.append(ModifierTask('shift_value_species_label', args, kwargs))
 
     def set_atomgroup(self, *args: Any, **kwargs: Any) -> None:
@@ -505,9 +504,9 @@ class FleurXMLModifier:
             warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
             kwargs['changes'] = kwargs.pop('attributedict')
         if 'create' in kwargs:
-            warnings.warn('The argument create is deprecatedand is ignored.', DeprecationWarning)
+            warnings.warn('The argument create is deprecated and is ignored.', DeprecationWarning)
             kwargs.pop('create')
-        self._validate_signature('set_atomgroup', *args, **kwargs)
+        self._validate_signature('set_atomgroup', args, kwargs)
         self._tasks.append(ModifierTask('set_atomgroup', args, kwargs))
 
     def set_atomgroup_label(self, *args: Any, **kwargs: Any) -> None:
@@ -531,7 +530,7 @@ class FleurXMLModifier:
         if 'create' in kwargs:
             warnings.warn('The argument create is deprecatedand is ignored.', DeprecationWarning)
             kwargs.pop('create')
-        self._validate_signature('set_atomgroup_label', *args, **kwargs)
+        self._validate_signature('set_atomgroup_label', args, kwargs)
         self._tasks.append(ModifierTask('set_atomgroup_label', args, kwargs))
 
     def create_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -553,7 +552,7 @@ class FleurXMLModifier:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
         """
-        self._validate_signature('create_tag', *args, **kwargs)
+        self._validate_signature('create_tag', args, kwargs)
         self._tasks.append(ModifierTask('create_tag', args, kwargs))
 
     def delete_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -573,7 +572,7 @@ class FleurXMLModifier:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
         """
-        self._validate_signature('delete_tag', *args, **kwargs)
+        self._validate_signature('delete_tag', args, kwargs)
         self._tasks.append(ModifierTask('delete_tag', args, kwargs))
 
     def delete_att(self, *args: Any, **kwargs: Any) -> None:
@@ -597,9 +596,10 @@ class FleurXMLModifier:
                             valid values are: settable, settable_contains, other
         """
         if 'attrib_name' in kwargs:
-            warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
+            warnings.warn('The argument attrib_name is deprecated. Use name instead', DeprecationWarning)
             kwargs['name'] = kwargs.pop('attrib_name')
-        self._validate_signature('delete_att', *args, **kwargs)
+        print(args, kwargs)
+        self._validate_signature('delete_att', args, kwargs)
         self._tasks.append(ModifierTask('delete_att', args, kwargs))
 
     def replace_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -623,7 +623,7 @@ class FleurXMLModifier:
         if 'newelement' in kwargs:
             warnings.warn('The argument newelement is deprecated. Use element instead', DeprecationWarning)
             kwargs['element'] = kwargs.pop('newelement')
-        self._validate_signature('replace_tag', *args, **kwargs)
+        self._validate_signature('replace_tag', args, kwargs)
         self._tasks.append(ModifierTask('replace_tag', args, kwargs))
 
     def set_complex_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -646,7 +646,7 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
 
         """
-        self._validate_signature('set_complex_tag', *args, **kwargs)
+        self._validate_signature('set_complex_tag', args, kwargs)
         self._tasks.append(ModifierTask('set_complex_tag', args, kwargs))
 
     def set_simple_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -668,7 +668,7 @@ class FleurXMLModifier:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
         """
-        self._validate_signature('set_simple_tag', *args, **kwargs)
+        self._validate_signature('set_simple_tag', args, kwargs)
         self._tasks.append(ModifierTask('set_simple_tag', args, kwargs))
 
     def set_text(self, *args: Any, **kwargs: Any) -> None:
@@ -690,7 +690,7 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
 
         """
-        self._validate_signature('set_text', *args, **kwargs)
+        self._validate_signature('set_text', args, kwargs)
         self._tasks.append(ModifierTask('set_text', args, kwargs))
 
     def set_first_text(self, *args: Any, **kwargs: Any) -> None:
@@ -711,7 +711,7 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
 
         """
-        self._validate_signature('set_first_text', *args, **kwargs)
+        self._validate_signature('set_first_text', args, kwargs)
         self._tasks.append(ModifierTask('set_first_text', args, kwargs))
 
     def set_attrib_value(self, *args: Any, **kwargs: Any) -> None:
@@ -742,7 +742,7 @@ class FleurXMLModifier:
         if 'attribv' in kwargs:
             warnings.warn('The argument attribv is deprecated. Use value instead', DeprecationWarning)
             kwargs['value'] = kwargs.pop('attribv')
-        self._validate_signature('set_attrib_value', *args, **kwargs)
+        self._validate_signature('set_attrib_value', args, kwargs)
         self._tasks.append(ModifierTask('set_attrib_value', args, kwargs))
 
     def set_first_attrib_value(self, *args: Any, **kwargs: Any) -> None:
@@ -772,7 +772,7 @@ class FleurXMLModifier:
         if 'attribv' in kwargs:
             warnings.warn('The argument attribv is deprecated. Use value instead', DeprecationWarning)
             kwargs['value'] = kwargs.pop('attribv')
-        self._validate_signature('set_first_attrib_value', *args, **kwargs)
+        self._validate_signature('set_first_attrib_value', args, kwargs)
         self._tasks.append(ModifierTask('set_first_attrib_value', args, kwargs))
 
     def add_number_to_attrib(self, *args: Any, **kwargs: Any) -> None:
@@ -805,7 +805,7 @@ class FleurXMLModifier:
         if 'add_number' in kwargs:
             warnings.warn('The argument add_number is deprecated. Use number_to_add instead', DeprecationWarning)
             kwargs['number_to_add'] = kwargs.pop('add_number')
-        self._validate_signature('add_number_to_attrib', *args, **kwargs)
+        self._validate_signature('add_number_to_attrib', args, kwargs)
         self._tasks.append(ModifierTask('add_number_to_attrib', args, kwargs))
 
     def add_number_to_first_attrib(self, *args: Any, **kwargs: Any) -> None:
@@ -837,7 +837,7 @@ class FleurXMLModifier:
         if 'add_number' in kwargs:
             warnings.warn('The argument add_number is deprecated. Use number_to_add instead', DeprecationWarning)
             kwargs['number_to_add'] = kwargs.pop('add_number')
-        self._validate_signature('add_number_to_first_attrib', *args, **kwargs)
+        self._validate_signature('add_number_to_first_attrib', args, kwargs)
         self._tasks.append(ModifierTask('add_number_to_first_attrib', args, kwargs))
 
     def xml_create_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -852,7 +852,7 @@ class FleurXMLModifier:
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
-        self._validate_signature('xml_create_tag', *args, **kwargs)
+        self._validate_signature('xml_create_tag', args, kwargs)
         self._tasks.append(ModifierTask('xml_create_tag', args, kwargs))
 
     def xml_replace_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -869,7 +869,7 @@ class FleurXMLModifier:
             warnings.warn('The argument newelement is deprecated. Use element instead', DeprecationWarning)
             kwargs['element'] = kwargs.pop('newelement')
 
-        self._validate_signature('xml_replace_tag', *args, **kwargs)
+        self._validate_signature('xml_replace_tag', args, kwargs)
         self._tasks.append(ModifierTask('xml_replace_tag', args, kwargs))
 
     def xml_delete_tag(self, *args: Any, **kwargs: Any) -> None:
@@ -881,7 +881,7 @@ class FleurXMLModifier:
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
-        self._validate_signature('xml_delete_tag', *args, **kwargs)
+        self._validate_signature('xml_delete_tag', args, kwargs)
         self._tasks.append(ModifierTask('xml_delete_tag', args, kwargs))
 
     def xml_delete_att(self, *args: Any, **kwargs: Any) -> None:
@@ -897,7 +897,7 @@ class FleurXMLModifier:
         if 'attributename' in kwargs:
             warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
             kwargs['name'] = kwargs.pop('attributename')
-        self._validate_signature('xml_delete_att', *args, **kwargs)
+        self._validate_signature('xml_delete_att', args, kwargs)
         self._tasks.append(ModifierTask('xml_delete_att', args, kwargs))
 
     def xml_set_attrib_value_no_create(self, *args: Any, **kwargs: Any) -> None:
@@ -912,11 +912,11 @@ class FleurXMLModifier:
         """
         if 'attributename' in kwargs:
             warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
-            kwargs['attribute_name'] = kwargs.pop('attributename')
+            kwargs['name'] = kwargs.pop('attributename')
         if 'attribv' in kwargs:
             warnings.warn('The argument attribv is deprecated. Use value instead', DeprecationWarning)
             kwargs['value'] = kwargs.pop('attribv')
-        self._validate_signature('xml_set_attrib_value_no_create', *args, **kwargs)
+        self._validate_signature('xml_set_attrib_value_no_create', args, kwargs)
         self._tasks.append(ModifierTask('xml_set_attrib_value_no_create', args, kwargs))
 
     def xml_set_text_no_create(self, *args: Any, **kwargs: Any) -> None:
@@ -928,7 +928,7 @@ class FleurXMLModifier:
         :param text: value or list of values to set (if not str they will be converted with `str(value)`)
         :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
         """
-        self._validate_signature('xml_set_text_no_create', *args, **kwargs)
+        self._validate_signature('xml_set_text_no_create', args, kwargs)
         self._tasks.append(ModifierTask('xml_set_text_no_create', args, kwargs))
 
     def set_nmmpmat(self, *args: Any, **kwargs: Any) -> None:
@@ -947,7 +947,7 @@ class FleurXMLModifier:
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         """
-        self._validate_signature('set_nmmpmat', *args, **kwargs)
+        self._validate_signature('set_nmmpmat', args, kwargs)
         self._tasks.append(ModifierTask('set_nmmpmat', args, kwargs))
 
     def rotate_nmmpmat(self, *args: Any, **kwargs: Any) -> None:
@@ -962,7 +962,7 @@ class FleurXMLModifier:
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         """
-        self._validate_signature('rotate_nmmpmat', *args, **kwargs)
+        self._validate_signature('rotate_nmmpmat', args, kwargs)
         self._tasks.append(ModifierTask('rotate_nmmpmat', args, kwargs))
 
     def set_kpointlist(self, *args: Any, **kwargs: Any) -> None:
@@ -983,7 +983,7 @@ class FleurXMLModifier:
         :param switch: bool, if True the kPointlist will be used by Fleur when starting the next calculation
         :param overwrite: bool, if True and a kPointlist with the given name already exists it will be overwritten
         """
-        self._validate_signature('set_kpointlist', *args, **kwargs)
+        self._validate_signature('set_kpointlist', args, kwargs)
         self._tasks.append(ModifierTask('set_kpointlist', args, kwargs))
 
     def switch_kpointset(self, *args: Any, **kwargs: Any) -> None:
@@ -996,7 +996,7 @@ class FleurXMLModifier:
 
         :param list_name: name of the kPoint set to use
         """
-        self._validate_signature('switch_kpointset', *args, **kwargs)
+        self._validate_signature('switch_kpointset', args, kwargs)
         self._tasks.append(ModifierTask('switch_kpointset', args, kwargs))
 
     def set_nkpts(self, *args: Any, **kwargs: Any) -> None:
@@ -1011,7 +1011,7 @@ class FleurXMLModifier:
         :param gamma: bool that controls if the gamma-point should be included
                       in the k-point mesh
         """
-        self._validate_signature('set_nkpts', *args, **kwargs)
+        self._validate_signature('set_nkpts', args, kwargs)
         self._tasks.append(ModifierTask('set_nkpts', args, kwargs))
 
     def set_kpath(self, *args: Any, **kwargs: Any) -> None:
@@ -1027,5 +1027,5 @@ class FleurXMLModifier:
         :param gamma: bool that controls if the gamma-point should be included
                       in the k-point mesh
         """
-        self._validate_signature('set_kpath', *args, **kwargs)
+        self._validate_signature('set_kpath', args, kwargs)
         self._tasks.append(ModifierTask('set_kpath', args, kwargs))

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -328,16 +328,19 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_inpchanges()` to
         the list of tasks that will be done on the xmltree.
 
-        :param change_dict: a dictionary with changes
+        :param changes: a dictionary with changes
         :param path_spec: dict, with ggf. necessary further specifications for the path of the attribute
 
-        An example of change_dict::
+        An example of changes::
 
-            change_dict = {'itmax' : 1,
-                           'l_noco': True,
-                           'ctail': False,
-                           'l_ss': True}
+            changes = {'itmax' : 1,
+                       'l_noco': True,
+                       'ctail': False,
+                       'l_ss': True}
         """
+        if 'change_dict' in kwargs:
+            warnings.warn('The argument change_dict is deprecated. Use changes instead', DeprecationWarning)
+            kwargs['changes'] = kwargs.pop('change_dict')
         self._validate_signature('set_inpchanges', *args, **kwargs)
         self._tasks.append(ModifierTask('set_inpchanges', args, kwargs))
 
@@ -346,14 +349,19 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.shift_value()` to
         the list of tasks that will be done on the xmltree.
 
-        :param change_dict: a python dictionary with the keys to shift and the shift values.
-        :param mode: 'abs' if change given is absolute, 'rel' if relative
+        :param changes: a python dictionary with the keys to shift and the shift values.
+        :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
+                     `rel`/`relative` multiplies the old value with the given value
+                     `abs`/`absolute` adds the old value and the given value
         :param path_spec: dict, with ggf. necessary further specifications for the path of the attribute
 
-        An example of change_dict::
+        An example of changes::
 
-                change_dict = {'itmax' : 1, 'dVac': -0.123}
+                changes = {'itmax' : 1, 'dVac': -0.123}
         """
+        if 'change_dict' in kwargs:
+            warnings.warn('The argument change_dict is deprecated. Use changes instead', DeprecationWarning)
+            kwargs['changes'] = kwargs.pop('change_dict')
         self._validate_signature('shift_value', *args, **kwargs)
         self._tasks.append(ModifierTask('shift_value', args, kwargs))
 
@@ -364,26 +372,29 @@ class FleurXMLModifier:
 
         :param species_name: string, name of the specie you want to change
                              Can be name of the species, 'all' or 'all-<string>' (sets species with the string in the species name)
-        :param attributedict: a python dict specifying what you want to change.
+        :param changes: a python dict specifying what you want to change.
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         :param create: bool, if species does not exist create it and all subtags?
 
-        **attributedict** is a python dictionary containing dictionaries that specify attributes
+        **changes** is a python dictionary containing dictionaries that specify attributes
         to be set inside the certain specie. For example, if one wants to set a MT radius it
         can be done via::
 
-            attributedict = {'mtSphere' : {'radius' : 2.2}}
+            changes = {'mtSphere' : {'radius' : 2.2}}
 
         Another example::
 
-            'attributedict': {'special': {'socscale': 0.0}}
+            'changes': {'special': {'socscale': 0.0}}
 
         that switches SOC terms on a sertain specie. ``mtSphere``, ``atomicCutoffs``,
         ``energyParameters``, ``lo``, ``electronConfig``, ``nocoParams``, ``ldaU`` and
         ``special`` keys are supported. To find possible
         keys of the inner dictionary please refer to the FLEUR documentation flapw.de
         """
+        if 'attributedict' in kwargs:
+            warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
+            kwargs['changes'] = kwargs.pop('attributedict')
         self._validate_signature('set_species', *args, **kwargs)
         self._tasks.append(ModifierTask('set_species', args, kwargs))
 
@@ -393,9 +404,12 @@ class FleurXMLModifier:
         the list of tasks that will be done on the xmltree.
 
         :param atom_label: string, a label of the atom which specie will be changed. 'all' to change all the species
-        :param attributedict: a python dict specifying what you want to change.
+        :param changes: a python dict specifying what you want to change.
 
         """
+        if 'attributedict' in kwargs:
+            warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
+            kwargs['changes'] = kwargs.pop('attributedict')
         self._validate_signature('set_species_label', *args, **kwargs)
         self._tasks.append(ModifierTask('set_species_label', args, kwargs))
 
@@ -449,15 +463,23 @@ class FleurXMLModifier:
         the list of tasks that will be done on the xmltree.
 
         :param atom_label: string, a label of the atom which specie will be changed. 'all' if set up all species
-        :param attributename: name of the attribute to change
-        :param value_given: value to add or to multiply by
-        :param mode: 'rel' for multiplication or 'abs' for addition
+        :param attribute_name: name of the attribute to change
+        :param number_to_add: value to add or to multiply by
+        :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
+                    `rel`/`relative` multiplies the old value with `number_to_add`
+                    `abs`/`absolute` adds the old value and `number_to_add`
 
-        Kwargs if the attributename does not correspond to a unique path:
+        Kwargs if the attribute_name does not correspond to a unique path:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
 
         """
+        if 'attributename' in kwargs:
+            warnings.warn('The argument attributename is deprecated. Use attribute_name instead', DeprecationWarning)
+            kwargs['attribute_name'] = kwargs.pop('attributename')
+        if 'value_given' in kwargs:
+            warnings.warn('The argument value_given is deprecated. Use number_to_add instead', DeprecationWarning)
+            kwargs['number_to_add'] = kwargs.pop('value_given')
         self._validate_signature('shift_value_species_label', *args, **kwargs)
         self._tasks.append(ModifierTask('shift_value_species_label', args, kwargs))
 
@@ -466,20 +488,25 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_atomgroup()` to
         the list of tasks that will be done on the xmltree.
 
-        :param attributedict: a python dict specifying what you want to change.
+        :param changes: a python dict specifying what you want to change.
         :param position: position of an atom group to be changed. If equals to 'all', all species will be changed
         :param species: atom groups, corresponding to the given species will be changed
-        :param create: bool, if species does not exist create it and all subtags?
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
-        **attributedict** is a python dictionary containing dictionaries that specify attributes
+        **changes** is a python dictionary containing dictionaries that specify attributes
         to be set inside the certain specie. For example, if one wants to set a beta noco parameter it
         can be done via::
 
-            'attributedict': {'nocoParams': {'beta': val}}
+            'changes': {'nocoParams': {'beta': val}}
 
         """
+        if 'attributedict' in kwargs:
+            warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
+            kwargs['changes'] = kwargs.pop('attributedict')
+        if 'create' in kwargs:
+            warnings.warn('The argument create is deprecatedand is ignored.', DeprecationWarning)
+            kwargs.pop('create')
         self._validate_signature('set_atomgroup', *args, **kwargs)
         self._tasks.append(ModifierTask('set_atomgroup', args, kwargs))
 
@@ -489,16 +516,21 @@ class FleurXMLModifier:
         the list of tasks that will be done on the xmltree.
 
         :param atom_label: string, a label of the atom which specie will be changed. 'all' to change all the species
-        :param attributedict: a python dict specifying what you want to change.
-        :param create: bool, if species does not exist create it and all subtags?
+        :param changes: a python dict specifying what you want to change.
 
-        **attributedict** is a python dictionary containing dictionaries that specify attributes
+        **changes** is a python dictionary containing dictionaries that specify attributes
         to be set inside the certain specie. For example, if one wants to set a beta noco parameter it
         can be done via::
 
-            'attributedict': {'nocoParams': {'beta': val}}
+            'changes': {'nocoParams': {'beta': val}}
 
         """
+        if 'attributedict' in kwargs:
+            warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
+            kwargs['changes'] = kwargs.pop('attributedict')
+        if 'create' in kwargs:
+            warnings.warn('The argument create is deprecatedand is ignored.', DeprecationWarning)
+            kwargs.pop('create')
         self._validate_signature('set_atomgroup_label', *args, **kwargs)
         self._tasks.append(ModifierTask('set_atomgroup_label', args, kwargs))
 
@@ -549,7 +581,7 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.delete_att()` to
         the list of tasks that will be done on the xmltree.
 
-        :param tag: str of the attribute to delete
+        :param name: str of the attribute to delete
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param occurrences: int or list of int. Which occurrence of the parent nodes to delete a attribute.
                             By default all nodes are used.
@@ -564,6 +596,9 @@ class FleurXMLModifier:
             :param exclude: list of str, here specific types of attributes can be excluded
                             valid values are: settable, settable_contains, other
         """
+        if 'attrib_name' in kwargs:
+            warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
+            kwargs['name'] = kwargs.pop('attrib_name')
         self._validate_signature('delete_att', *args, **kwargs)
         self._tasks.append(ModifierTask('delete_att', args, kwargs))
 
@@ -573,7 +608,7 @@ class FleurXMLModifier:
         the list of tasks that will be done on the xmltree.
 
         :param tag: str of the tag to replace
-        :param newelement: a new tag
+        :param element: a new tag
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param occurrences: int or list of int. Which occurrence of the parent nodes to replace a tag.
                             By default all nodes are used.
@@ -585,6 +620,9 @@ class FleurXMLModifier:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
         """
+        if 'newelement' in kwargs:
+            warnings.warn('The argument newelement is deprecated. Use element instead', DeprecationWarning)
+            kwargs['element'] = kwargs.pop('newelement')
         self._validate_signature('replace_tag', *args, **kwargs)
         self._tasks.append(ModifierTask('replace_tag', args, kwargs))
 
@@ -594,8 +632,8 @@ class FleurXMLModifier:
         the list of tasks that will be done on the xmltree.
 
         :param tag_name: name of the tag to set
-        :param attributedict: Keys in the dictionary correspond to names of tags and the values are the modifications
-                              to do on this tag (attributename, subdict with changes to the subtag, ...)
+        :param changes: Keys in the dictionary correspond to names of tags and the values are the modifications
+                        to do on this tag (attributename, subdict with changes to the subtag, ...)
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param create: bool optional (default False), if True and the path, where the complex tag is
                        set does not exist it is created
@@ -681,8 +719,8 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_attrib_value()` to
         the list of tasks that will be done on the xmltree.
 
-        :param attributename: the attribute name to set
-        :param attribv: value or list of values to set
+        :param name: the attribute name to set
+        :param value: value or list of values to set
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
         :param create: bool optional (default False), if True the tag is created if is missing
@@ -698,6 +736,12 @@ class FleurXMLModifier:
                             valid values are: settable, settable_contains, other
 
         """
+        if 'attributename' in kwargs:
+            warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
+            kwargs['name'] = kwargs.pop('attributename')
+        if 'attribv' in kwargs:
+            warnings.warn('The argument attribv is deprecated. Use value instead', DeprecationWarning)
+            kwargs['value'] = kwargs.pop('attribv')
         self._validate_signature('set_attrib_value', *args, **kwargs)
         self._tasks.append(ModifierTask('set_attrib_value', args, kwargs))
 
@@ -706,8 +750,8 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_first_attrib_value()` to
         the list of tasks that will be done on the xmltree.
 
-        :param attributename: the attribute name to set
-        :param attribv: value or list of values to set
+        :param name: the attribute name to set
+        :param value: value or list of values to set
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param create: bool optional (default False), if True the tag is created if is missing
         :param filters: Dict specifying constraints to apply on the xpath.
@@ -722,6 +766,12 @@ class FleurXMLModifier:
                             valid values are: settable, settable_contains, other
 
         """
+        if 'attributename' in kwargs:
+            warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
+            kwargs['name'] = kwargs.pop('attributename')
+        if 'attribv' in kwargs:
+            warnings.warn('The argument attribv is deprecated. Use value instead', DeprecationWarning)
+            kwargs['value'] = kwargs.pop('attribv')
         self._validate_signature('set_first_attrib_value', *args, **kwargs)
         self._tasks.append(ModifierTask('set_first_attrib_value', args, kwargs))
 
@@ -730,12 +780,12 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.add_number_to_attrib()` to
         the list of tasks that will be done on the xmltree.
 
-        :param attributename: the attribute name to change
-        :param add_number: number to add/multiply with the old attribute value
+        :param name: the attribute name to change
+        :param number_to_add: number to add/multiply with the old attribute value
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param mode: str (either `rel` or `abs`).
-                     `rel` multiplies the old value with `add_number`
-                     `abs` adds the old value and `add_number`
+        :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
+                    `rel`/`relative` multiplies the old value with `number_to_add`
+                    `abs`/`absolute` adds the old value and `number_to_add`
         :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
@@ -749,6 +799,12 @@ class FleurXMLModifier:
                             valid values are: settable, settable_contains, other
 
         """
+        if 'attributename' in kwargs:
+            warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
+            kwargs['name'] = kwargs.pop('attributename')
+        if 'add_number' in kwargs:
+            warnings.warn('The argument add_number is deprecated. Use number_to_add instead', DeprecationWarning)
+            kwargs['number_to_add'] = kwargs.pop('add_number')
         self._validate_signature('add_number_to_attrib', *args, **kwargs)
         self._tasks.append(ModifierTask('add_number_to_attrib', args, kwargs))
 
@@ -757,12 +813,12 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.add_number_to_first_attrib()` to
         the list of tasks that will be done on the xmltree.
 
-        :param attributename: the attribute name to change
-        :param add_number: number to add/multiply with the old attribute value
+        :param name: the attribute name to change
+        :param number_to_add: number to add/multiply with the old attribute value
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param mode: str (either `rel` or `abs`).
-                     `rel` multiplies the old value with `add_number`
-                     `abs` adds the old value and `add_number`
+        :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
+                    `rel`/`relative` multiplies the old value with `number_to_add`
+                    `abs`/`absolute` adds the old value and `number_to_add`
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
@@ -775,6 +831,12 @@ class FleurXMLModifier:
                             valid values are: settable, settable_contains, other
 
         """
+        if 'attributename' in kwargs:
+            warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
+            kwargs['name'] = kwargs.pop('attributename')
+        if 'add_number' in kwargs:
+            warnings.warn('The argument add_number is deprecated. Use number_to_add instead', DeprecationWarning)
+            kwargs['number_to_add'] = kwargs.pop('add_number')
         self._validate_signature('add_number_to_first_attrib', *args, **kwargs)
         self._tasks.append(ModifierTask('add_number_to_first_attrib', args, kwargs))
 
@@ -799,7 +861,7 @@ class FleurXMLModifier:
         the list of tasks that will be done on the xmltree.
 
         :param xpath: a path to the tag to be replaced
-        :param newelement: a new tag
+        :param element: a new tag
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
@@ -828,7 +890,7 @@ class FleurXMLModifier:
         the list of tasks that will be done on the xmltree.
 
         :param xpath: a path to the attribute to be deleted
-        :param attrib: the name of an attribute
+        :param name: the name of an attribute
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
@@ -844,8 +906,8 @@ class FleurXMLModifier:
         the list of tasks that will be done on the xmltree.
 
         :param xpath: a path where to set the attributes
-        :param attributename: the attribute name to set
-        :param attribv: value or list of values to set (if not str they will be converted with `str(value)`)
+        :param name: the attribute name to set
+        :param value: value or list of values to set (if not str they will be converted with `str(value)`)
         :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
         """
         if 'attributename' in kwargs:

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -28,14 +28,14 @@ from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
 def xml_replace_tag(xmltree: XMLLike,
                     xpath: XPathLike,
-                    new_element: etree._Element,
+                    element: etree._Element,
                     occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     replaces xml tags by another tag on an xmletree in place
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path to the tag to be replaced
-    :param new_element: a new tag
+    :param element: an Element to replace the found tags with
     :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                         By default all nodes are used.
 
@@ -68,7 +68,7 @@ def xml_replace_tag(xmltree: XMLLike,
             raise ValueError('Could not find parent of node')
         index = parent.index(node)  #type:ignore
         parent.remove(node)
-        parent.insert(index, copy.deepcopy(new_element))
+        parent.insert(index, copy.deepcopy(element))
 
     etree.indent(xmltree)
     return xmltree
@@ -76,14 +76,14 @@ def xml_replace_tag(xmltree: XMLLike,
 
 def xml_delete_att(xmltree: XMLLike,
                    xpath: XPathLike,
-                   attribute_name: str,
+                   name: str,
                    occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Deletes an xml attribute in an xmletree.
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path to the attribute to be deleted
-    :param attribute_name: the name of an attribute
+    :param name: the name of an attribute to delete
     :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                         By default all nodes are used.
 
@@ -111,7 +111,7 @@ def xml_delete_att(xmltree: XMLLike,
             raise ValueError('Wrong value for occurrences') from exc
 
     for node in nodes:
-        node.attrib.pop(attribute_name, '')
+        node.attrib.pop(name, '')
 
     return xmltree
 

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -17,7 +17,7 @@ to do these operations robustly
 """
 from __future__ import annotations
 
-from typing import Iterable, Any, cast
+from typing import Iterable, Any
 from lxml import etree
 import warnings
 
@@ -28,21 +28,20 @@ from masci_tools.util.xml.xpathbuilder import XPathBuilder
 
 def xml_replace_tag(xmltree: XMLLike,
                     xpath: XPathLike,
-                    newelement: etree._Element,
+                    new_element: etree._Element,
                     occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     replaces xml tags by another tag on an xmletree in place
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path to the tag to be replaced
-    :param newelement: a new tag
+    :param new_element: a new tag
     :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                         By default all nodes are used.
 
     :returns: xmltree with replaced tag
     """
     import copy
-    from masci_tools.io.common_functions import is_sequence
 
     if not etree.iselement(xmltree):
         root = xmltree.getroot()
@@ -56,10 +55,10 @@ def xml_replace_tag(xmltree: XMLLike,
             f'No nodes to replace found on xpath: {str(xpath.path) if isinstance(xpath, XPathBuilder) else str(xpath)}')
 
     if occurrences is not None:
-        if not is_sequence(occurrences):
-            occurrences = [occurrences]  #type:ignore
+        if not isinstance(occurrences, Iterable):
+            occurrences = [occurrences]
         try:
-            nodes = [nodes[occ] for occ in cast(Iterable[int], occurrences)]
+            nodes = [nodes[occ] for occ in occurrences]
         except IndexError as exc:
             raise ValueError('Wrong value for occurrences') from exc
 
@@ -69,7 +68,7 @@ def xml_replace_tag(xmltree: XMLLike,
             raise ValueError('Could not find parent of node')
         index = parent.index(node)  #type:ignore
         parent.remove(node)
-        parent.insert(index, copy.deepcopy(newelement))
+        parent.insert(index, copy.deepcopy(new_element))
 
     etree.indent(xmltree)
     return xmltree
@@ -77,20 +76,19 @@ def xml_replace_tag(xmltree: XMLLike,
 
 def xml_delete_att(xmltree: XMLLike,
                    xpath: XPathLike,
-                   attrib: str,
+                   attribute_name: str,
                    occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Deletes an xml attribute in an xmletree.
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path to the attribute to be deleted
-    :param attrib: the name of an attribute
+    :param attribute_name: the name of an attribute
     :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                         By default all nodes are used.
 
     :returns: xmltree with deleted attribute
     """
-    from masci_tools.io.common_functions import is_sequence
 
     if not etree.iselement(xmltree):
         root = xmltree.getroot()
@@ -105,15 +103,15 @@ def xml_delete_att(xmltree: XMLLike,
         )
 
     if occurrences is not None:
-        if not is_sequence(occurrences):
-            occurrences = [occurrences]  #type:ignore
+        if not isinstance(occurrences, Iterable):
+            occurrences = [occurrences]
         try:
-            nodes = [nodes[occ] for occ in cast(Iterable[int], occurrences)]
+            nodes = [nodes[occ] for occ in occurrences]
         except IndexError as exc:
             raise ValueError('Wrong value for occurrences') from exc
 
     for node in nodes:
-        node.attrib.pop(attrib, None)  #type:ignore
+        node.attrib.pop(attribute_name, '')
 
     return xmltree
 
@@ -129,7 +127,6 @@ def xml_delete_tag(xmltree: XMLLike, xpath: XPathLike, occurrences: int | Iterab
 
     :returns: xmltree with deleted tag
     """
-    from masci_tools.io.common_functions import is_sequence
 
     if not etree.iselement(xmltree):
         root = xmltree.getroot()
@@ -143,10 +140,10 @@ def xml_delete_tag(xmltree: XMLLike, xpath: XPathLike, occurrences: int | Iterab
             f'No nodes to delete found on xpath: {str(xpath.path) if isinstance(xpath, XPathBuilder) else str(xpath)}')
 
     if occurrences is not None:
-        if not is_sequence(occurrences):
-            occurrences = [occurrences]  #type:ignore
+        if not isinstance(occurrences, Iterable):
+            occurrences = [occurrences]
         try:
-            nodes = [nodes[occ] for occ in cast(Iterable[int], occurrences)]
+            nodes = [nodes[occ] for occ in occurrences]
         except IndexError as exc:
             raise ValueError('Wrong value for occurrences') from exc
 
@@ -229,7 +226,6 @@ def xml_create_tag(xmltree: XMLLike,
     """
     import copy
     from more_itertools import unique_justseen
-    from masci_tools.io.common_functions import is_sequence
 
     if not etree.iselement(element):
         element_name: str = element  #type:ignore
@@ -247,10 +243,10 @@ def xml_create_tag(xmltree: XMLLike,
                          'Use create=True to create the subtags')
 
     if occurrences is not None:
-        if not is_sequence(occurrences):
-            occurrences = [occurrences]  #type:ignore
+        if not isinstance(occurrences, Iterable):
+            occurrences = [occurrences]
         try:
-            parent_nodes = [parent_nodes[occ] for occ in cast(Iterable[int], occurrences)]
+            parent_nodes = [parent_nodes[occ] for occ in occurrences]
         except IndexError as exc:
             raise ValueError('Wrong value for occurrences') from exc
 
@@ -329,8 +325,8 @@ def xml_create_tag(xmltree: XMLLike,
 
 def xml_set_attrib_value_no_create(xmltree: XMLLike,
                                    xpath: XPathLike,
-                                   attributename: str,
-                                   attribv: Any,
+                                   name: str,
+                                   value: Any,
                                    occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Sets an attribute in a xmltree to a given value. By default the attribute will be set
@@ -338,8 +334,8 @@ def xml_set_attrib_value_no_create(xmltree: XMLLike,
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path where to set the attributes
-    :param attributename: the attribute name to set
-    :param attribv: value or list of values to set (if not str they will be converted with `str(value)`)
+    :param name: the attribute name to set
+    :param value: value or list of values to set (if not str they will be converted with `str(value)`)
     :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
 
     :raises ValueError: If the lengths of attribv or occurrences do not match number of nodes
@@ -357,28 +353,28 @@ def xml_set_attrib_value_no_create(xmltree: XMLLike,
 
     if len(nodes) == 0:
         warnings.warn(
-            f'No nodes to set attribute {attributename} on found on xpath: {str(xpath.path) if isinstance(xpath, XPathBuilder) else str(xpath)}'
+            f'No nodes to set attribute {name} on found on xpath: {str(xpath.path) if isinstance(xpath, XPathBuilder) else str(xpath)}'
         )
         return xmltree
 
     if occurrences is not None:
-        if not is_sequence(occurrences):
-            occurrences = [occurrences]  #type:ignore
+        if not isinstance(occurrences, Iterable):
+            occurrences = [occurrences]
         try:
-            nodes = [nodes[occ] for occ in cast(Iterable[int], occurrences)]
+            nodes = [nodes[occ] for occ in occurrences]
         except IndexError as exc:
             raise ValueError('Wrong value for occurrences') from exc
 
-    if is_sequence(attribv):
-        if len(attribv) != len(nodes):
-            raise ValueError(f'Wrong length for attribute values. Expected {len(nodes)} items. Got: {len(attribv)}')
+    if is_sequence(value):
+        if len(value) != len(nodes):
+            raise ValueError(f'Wrong length for attribute values. Expected {len(nodes)} items. Got: {len(value)}')
     else:
-        attribv = [attribv] * len(nodes)
+        value = [value] * len(nodes)
 
-    attribv = [val if isinstance(val, str) else str(val) for val in attribv]
+    value = [val if isinstance(val, str) else str(val) for val in value]
 
-    for node, value in zip(nodes, attribv):
-        node.set(attributename, value)
+    for node, val in zip(nodes, value):
+        node.set(name, val)
 
     return xmltree
 
@@ -416,10 +412,10 @@ def xml_set_text_no_create(xmltree: XMLLike,
         return xmltree
 
     if occurrences is not None:
-        if not is_sequence(occurrences):
-            occurrences = [occurrences]  #type:ignore
+        if not isinstance(occurrences, Iterable):
+            occurrences = [occurrences]
         try:
-            nodes = [nodes[occ] for occ in cast(Iterable[int], occurrences)]
+            nodes = [nodes[occ] for occ in occurrences]
         except IndexError as exc:
             raise ValueError('Wrong value for occurrences') from exc
 

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -70,7 +70,6 @@ def create_tag(xmltree: XMLLike,
         tag_name = tag  #type:ignore
 
     base_xpath = schema_dict.tag_xpath(tag_name, **kwargs)
-
     parent_xpath, tag_name = split_off_tag(base_xpath)
 
     if complex_xpath is None:
@@ -138,7 +137,7 @@ def delete_tag(xmltree: XMLLike,
 
 def delete_att(xmltree: XMLLike,
                schema_dict: fleur_schema.SchemaDict,
-               attrib_name: str,
+               name: str,
                complex_xpath: XPathLike = None,
                filters: FilterType = None,
                occurrences: int | Iterable[int] | None = None,
@@ -148,7 +147,7 @@ def delete_att(xmltree: XMLLike,
 
     :param xmltree: an xmltree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :param tag: str of the attribute to delete
+    :param name: str of the attribute to delete
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
@@ -167,8 +166,8 @@ def delete_att(xmltree: XMLLike,
     from masci_tools.util.xml.xml_setters_basic import xml_delete_att
     from masci_tools.util.xml.common_functions import check_complex_xpath, split_off_attrib
 
-    base_xpath = schema_dict.attrib_xpath(attrib_name, **kwargs)
-    tag_xpath, attrib_name = split_off_attrib(base_xpath)
+    base_xpath = schema_dict.attrib_xpath(name, **kwargs)
+    tag_xpath, name = split_off_attrib(base_xpath)
 
     if complex_xpath is None:
         complex_xpath = XPathBuilder(tag_xpath, filters=filters, strict=True)
@@ -180,13 +179,13 @@ def delete_att(xmltree: XMLLike,
             complex_xpath.add_filter(key, val)
     check_complex_xpath(xmltree, tag_xpath, complex_xpath)
 
-    return xml_delete_att(xmltree, complex_xpath, attrib_name, occurrences=occurrences)
+    return xml_delete_att(xmltree, complex_xpath, name, occurrences=occurrences)
 
 
 def replace_tag(xmltree: XMLLike,
                 schema_dict: fleur_schema.SchemaDict,
                 tag_name: str,
-                newelement: etree._Element,
+                element: etree._Element,
                 complex_xpath: XPathLike = None,
                 filters: FilterType = None,
                 occurrences: int | Iterable[int] | None = None,
@@ -197,7 +196,7 @@ def replace_tag(xmltree: XMLLike,
     :param xmltree: an xmltree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param tag: str of the tag to replace
-    :param newelement: etree Element to replace the tag
+    :param element: etree Element to replace the tag
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
@@ -225,16 +224,16 @@ def replace_tag(xmltree: XMLLike,
             complex_xpath.add_filter(key, val)
     check_complex_xpath(xmltree, base_xpath, complex_xpath)
 
-    return xml_replace_tag(xmltree, complex_xpath, newelement, occurrences=occurrences)
+    return xml_replace_tag(xmltree, complex_xpath, element, occurrences=occurrences)
 
 
 def add_number_to_attrib(xmltree: XMLLike,
                          schema_dict: fleur_schema.SchemaDict,
-                         attributename: str,
-                         add_number: Any,
+                         name: str,
+                         number_to_add: Any,
                          complex_xpath: XPathLike = None,
                          filters: FilterType = None,
-                         mode: Literal['abs', 'rel'] = 'abs',
+                         mode: Literal['abs', 'absolute', 'rel', 'relative'] = 'absolute',
                          occurrences: int | Iterable[int] | None = None,
                          **kwargs: Any) -> XMLLike:
     """
@@ -244,14 +243,14 @@ def add_number_to_attrib(xmltree: XMLLike,
 
     :param xmltree: an xmltree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :param attributename: the attribute name to change
-    :param add_number: number to add/multiply with the old attribute value
+    :param name: the attribute name to change
+    :param number_to_add: number to add/multiply with the old attribute value
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-    :param mode: str (either `rel` or `abs`).
-                 `rel` multiplies the old value with `add_number`
-                 `abs` adds the old value and `add_number`
+    :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
+                 `rel`/`relative` multiplies the old value with `number_to_add`
+                 `abs`/`absolute` adds the old value and `number_to_add`
     :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
 
     Kwargs:
@@ -266,8 +265,8 @@ def add_number_to_attrib(xmltree: XMLLike,
     from masci_tools.util.xml.xml_setters_xpaths import xml_add_number_to_attrib
     from masci_tools.util.xml.common_functions import split_off_attrib
 
-    attrib_xpath = schema_dict.attrib_xpath(attributename, **kwargs)
-    base_xpath, attributename = split_off_attrib(attrib_xpath)
+    attrib_xpath = schema_dict.attrib_xpath(name, **kwargs)
+    base_xpath, name = split_off_attrib(attrib_xpath)
 
     if complex_xpath is None:
         complex_xpath = XPathBuilder(base_xpath, filters=filters, strict=True)
@@ -282,19 +281,19 @@ def add_number_to_attrib(xmltree: XMLLike,
                                     schema_dict,
                                     complex_xpath,
                                     base_xpath,
-                                    attributename,
-                                    add_number,
+                                    name,
+                                    number_to_add,
                                     mode=mode,
                                     occurrences=occurrences)
 
 
 def add_number_to_first_attrib(xmltree: XMLLike,
                                schema_dict: fleur_schema.SchemaDict,
-                               attributename: str,
-                               add_number: Any,
+                               name: str,
+                               number_to_add: Any,
                                complex_xpath: XPathLike = None,
                                filters: FilterType = None,
-                               mode: Literal['abs', 'rel'] = 'abs',
+                               mode: Literal['abs', 'absolute', 'rel', 'relative'] = 'absolute',
                                **kwargs: Any) -> XMLLike:
     """
     Adds a given number to the first occurrence of an attribute value in a xmltree specified by the name of the attribute
@@ -303,12 +302,12 @@ def add_number_to_first_attrib(xmltree: XMLLike,
 
     :param xmltree: an xmltree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :param attributename: the attribute name to change
-    :param add_number: number to add/multiply with the old attribute value
+    :param name: the attribute name to change
+    :param number_to_add: number to add/multiply with the old attribute value
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-    :param mode: str (either `rel` or `abs`).
-                 `rel` multiplies the old value with `add_number`
-                 `abs` adds the old value and `add_number`
+    :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
+                 `rel`/`relative` multiplies the old value with `number_to_add`
+                 `abs`/`absolute` adds the old value and `number_to_add`
 
     Kwargs:
         :param tag_name: str, name of the tag where the attribute should be parsed
@@ -321,8 +320,8 @@ def add_number_to_first_attrib(xmltree: XMLLike,
     """
     return add_number_to_attrib(xmltree,
                                 schema_dict,
-                                attributename,
-                                add_number,
+                                name,
+                                number_to_add,
                                 complex_xpath=complex_xpath,
                                 mode=mode,
                                 occurrences=0,
@@ -332,8 +331,8 @@ def add_number_to_first_attrib(xmltree: XMLLike,
 
 def set_attrib_value(xmltree: XMLLike,
                      schema_dict: fleur_schema.SchemaDict,
-                     attributename: str,
-                     attribv: Any,
+                     name: str,
+                     value: Any,
                      complex_xpath: XPathLike = None,
                      filters: FilterType = None,
                      occurrences: int | Iterable[int] | None = None,
@@ -349,8 +348,8 @@ def set_attrib_value(xmltree: XMLLike,
 
     :param xmltree: an xmltree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :param attributename: the attribute name to set
-    :param attribv: value or list of values to set
+    :param name: the attribute name to set
+    :param value: value or list of values to set
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
@@ -371,12 +370,12 @@ def set_attrib_value(xmltree: XMLLike,
 
     #Special case for xcFunctional
     #(Also implemented here to not confuse users since it would only work in set_inpchanges otherwise)
-    if attributename == 'xcFunctional':
-        attributename = 'name'
+    if name == 'xcFunctional':
+        name = 'name'
         kwargs.setdefault('exclude', []).append('other')
 
-    base_xpath = schema_dict.attrib_xpath(attributename, **kwargs)
-    base_xpath, attributename = split_off_attrib(base_xpath)
+    base_xpath = schema_dict.attrib_xpath(name, **kwargs)
+    base_xpath, name = split_off_attrib(base_xpath)
 
     if complex_xpath is None:
         complex_xpath = XPathBuilder(base_xpath, filters=filters, strict=True)
@@ -391,16 +390,16 @@ def set_attrib_value(xmltree: XMLLike,
                                 schema_dict,
                                 complex_xpath,
                                 base_xpath,
-                                attributename,
-                                attribv,
+                                name,
+                                value,
                                 occurrences=occurrences,
                                 create=create)
 
 
 def set_first_attrib_value(xmltree: XMLLike,
                            schema_dict: fleur_schema.SchemaDict,
-                           attributename: str,
-                           attribv: Any,
+                           name: str,
+                           value: Any,
                            complex_xpath: XPathLike = None,
                            filters: FilterType = None,
                            create: bool = False,
@@ -415,8 +414,8 @@ def set_first_attrib_value(xmltree: XMLLike,
 
     :param xmltree: an xmltree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :param attributename: the attribute name to set
-    :param attribv: value or list of values to set
+    :param name: the attribute name to set
+    :param value: value or list of values to set
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
@@ -433,8 +432,8 @@ def set_first_attrib_value(xmltree: XMLLike,
     """
     return set_attrib_value(xmltree,
                             schema_dict,
-                            attributename,
-                            attribv,
+                            name,
+                            value,
                             complex_xpath=complex_xpath,
                             create=create,
                             occurrences=0,
@@ -493,8 +492,8 @@ def set_text(xmltree: XMLLike,
 
 def set_first_text(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
-                   attributename: str,
-                   attribv: Any,
+                   tag_name: str,
+                   text: Any,
                    complex_xpath: XPathLike = None,
                    filters: FilterType = None,
                    create: bool = False,
@@ -524,8 +523,8 @@ def set_first_text(xmltree: XMLLike,
     """
     return set_text(xmltree,
                     schema_dict,
-                    attributename,
-                    attribv,
+                    tag_name,
+                    text,
                     complex_xpath=complex_xpath,
                     create=create,
                     occurrences=0,
@@ -567,9 +566,8 @@ def set_simple_tag(xmltree: XMLLike,
     from masci_tools.util.xml.xml_setters_xpaths import xml_set_simple_tag
     from masci_tools.util.xml.common_functions import split_off_tag
 
-    base_xpath = schema_dict.tag_xpath(tag_name, **kwargs)
-
     #Since we can set multiple simple tags we need to provide the path for the parent
+    base_xpath = schema_dict.tag_xpath(tag_name, **kwargs)
     parent_xpath, tag_name = split_off_tag(base_xpath)
 
     tag_info = schema_dict['tag_info'][base_xpath]
@@ -618,8 +616,8 @@ def set_complex_tag(xmltree: XMLLike,
     :param xmltree: an xmltree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param tag_name: name of the tag to set
-    :param attributedict: Keys in the dictionary correspond to names of tags and the values are the modifications
-                          to do on this tag (attributename, subdict with changes to the subtag, ...)
+    :param changes: Keys in the dictionary correspond to names of tags and the values are the modifications
+                    to do on this tag (attributename, subdict with changes to the subtag, ...)
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
@@ -651,7 +649,7 @@ def set_complex_tag(xmltree: XMLLike,
 def set_species_label(xmltree: XMLLike,
                       schema_dict: fleur_schema.SchemaDict,
                       atom_label: str,
-                      attributedict: dict[str, Any],
+                      changes: dict[str, Any],
                       create: bool = False) -> XMLLike:
     """
     This method calls :func:`~masci_tools.util.xml.xml_setters_names.set_species()`
@@ -668,7 +666,7 @@ def set_species_label(xmltree: XMLLike,
     from masci_tools.util.schema_dict_util import tag_exists, evaluate_attribute
 
     if atom_label == 'all':
-        return set_species(xmltree, schema_dict, 'all', attributedict, create=create)
+        return set_species(xmltree, schema_dict, 'all', changes, create=create)
 
     film = tag_exists(xmltree, schema_dict, 'filmPos')
     label_path = f"/{'filmPos' if film else 'relPos'}/@label"
@@ -686,7 +684,7 @@ def set_species_label(xmltree: XMLLike,
                            optional=True))
 
     for species_name in species_to_set:
-        xmltree = set_species(xmltree, schema_dict, species_name, attributedict, create=create)
+        xmltree = set_species(xmltree, schema_dict, species_name, changes, create=create)
 
     return xmltree
 
@@ -694,7 +692,7 @@ def set_species_label(xmltree: XMLLike,
 def set_species(xmltree: XMLLike,
                 schema_dict: fleur_schema.SchemaDict,
                 species_name: str,
-                attributedict: dict[str, Any],
+                changes: dict[str, Any],
                 filters: FilterType = None,
                 create: bool = False) -> XMLLike:
     """
@@ -704,7 +702,7 @@ def set_species(xmltree: XMLLike,
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param species_name: string, name of the specie you want to change
                          Can be name of the species, 'all' or 'all-<string>' (sets species with the string in the species name)
-    :param attributedict: a python dict specifying what you want to change.
+    :param changes: a python dict specifying what you want to change.
     :param create: bool, if species does not exist create it and all subtags?
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
@@ -742,7 +740,7 @@ def set_species(xmltree: XMLLike,
     elif species_name != 'all':
         xpath_species.add_filter('species', {'name': {'=': species_name}})
 
-    return xml_set_complex_tag(xmltree, schema_dict, xpath_species, base_xpath_species, attributedict, create=create)
+    return xml_set_complex_tag(xmltree, schema_dict, xpath_species, base_xpath_species, changes, create=create)
 
 
 def clone_species(xmltree: XMLLike,
@@ -799,9 +797,9 @@ def clone_species(xmltree: XMLLike,
 def shift_value_species_label(xmltree: XMLLike,
                               schema_dict: fleur_schema.SchemaDict,
                               atom_label: str,
-                              attributename: str,
-                              value_given: Any,
-                              mode: Literal['abs', 'rel'] = 'abs',
+                              attribute_name: str,
+                              number_to_add: Any,
+                              mode: Literal['abs', 'absolute', 'rel', 'relative'] = 'absolute',
                               **kwargs: Any) -> XMLLike:
     """
     Shifts the value of an attribute on a species by label
@@ -810,11 +808,13 @@ def shift_value_species_label(xmltree: XMLLike,
     :param xmltree: xml etree of the inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param atom_label: string, a label of the atom which specie will be changed. 'all' if set up all species
-    :param attributename: name of the attribute to change
-    :param value_given: value to add or to multiply by
-    :param mode: 'rel' for multiplication or 'abs' for addition
+    :param attribute_name: name of the attribute to change
+    :param number_to_add: value to add or to multiply by
+    :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
+                 `rel`/`relative` multiplies the old value with `number_to_add`
+                 `abs`/`absolute` adds the old value and `number_to_add`
 
-    Kwargs if the attributename does not correspond to a unique path:
+    Kwargs if the attribute_name does not correspond to a unique path:
         :param contains: str, this string has to be in the final path
         :param not_contains: str, this string has to NOT be in the final path
 
@@ -833,8 +833,8 @@ def shift_value_species_label(xmltree: XMLLike,
     else:
         kwargs['contains'] = 'species'
 
-    attr_base_path = schema_dict.attrib_xpath(attributename, **kwargs)
-    tag_base_xpath, attributename = split_off_attrib(attr_base_path)
+    attr_base_path = schema_dict.attrib_xpath(attribute_name, **kwargs)
+    tag_base_xpath, attribute_name = split_off_attrib(attr_base_path)
 
     film = tag_exists(xmltree, schema_dict, 'filmPos')
     label_path = f"/{'filmPos' if film else 'relPos'}/@label"
@@ -851,18 +851,15 @@ def shift_value_species_label(xmltree: XMLLike,
                                                  schema_dict,
                                                  tag_xpath,
                                                  tag_base_xpath,
-                                                 attributename,
-                                                 value_given,
+                                                 attribute_name,
+                                                 number_to_add,
                                                  mode=mode)
 
     return xmltree
 
 
-def set_atomgroup_label(xmltree: XMLLike,
-                        schema_dict: fleur_schema.SchemaDict,
-                        atom_label: str,
-                        attributedict: dict[str, Any],
-                        create: bool = False) -> XMLLike:
+def set_atomgroup_label(xmltree: XMLLike, schema_dict: fleur_schema.SchemaDict, atom_label: str,
+                        changes: dict[str, Any]) -> XMLLike:
     """
     This method calls :func:`~masci_tools.util.xml.xml_setters_names.set_atomgroup()`
     method for a certain atom species that corresponds to an atom with a given label.
@@ -870,21 +867,20 @@ def set_atomgroup_label(xmltree: XMLLike,
     :param xmltree: xml etree of the inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param atom_label: string, a label of the atom which specie will be changed. 'all' to change all the species
-    :param attributedict: a python dict specifying what you want to change.
-    :param create: bool, if species does not exist create it and all subtags?
+    :param changes: a python dict specifying what you want to change.
 
     :returns: xml etree of the new inp.xml
 
-    **attributedict** is a python dictionary containing dictionaries that specify attributes
+    **changes** is a python dictionary containing dictionaries that specify attributes
     to be set inside the certain specie. For example, if one wants to set a beta noco parameter it
     can be done via::
 
-        'attributedict': {'nocoParams': {'beta': val}}
+        'changes': {'nocoParams': {'beta': val}}
 
     """
     from masci_tools.util.schema_dict_util import tag_exists, evaluate_attribute
     if atom_label == 'all':
-        return set_atomgroup(xmltree, schema_dict, attributedict, species='all')
+        return set_atomgroup(xmltree, schema_dict, changes, species='all')
     film = tag_exists(xmltree, schema_dict, 'filmPos')
     label_path = f"/{'filmPos' if film else 'relPos'}/@label"
 
@@ -901,18 +897,17 @@ def set_atomgroup_label(xmltree: XMLLike,
                            optional=True))
 
     for species_name in species_to_set:
-        xmltree = set_atomgroup(xmltree, schema_dict, attributedict, species=species_name)
+        xmltree = set_atomgroup(xmltree, schema_dict, changes, species=species_name)
 
     return xmltree
 
 
 def set_atomgroup(xmltree: XMLLike,
                   schema_dict: fleur_schema.SchemaDict,
-                  attributedict: dict[str, Any],
+                  changes: dict[str, Any],
                   position: int | Literal['all'] | None = None,
                   species: str | None = None,
-                  filters: FilterType | None = None,
-                  create: bool = False) -> XMLLike:
+                  filters: FilterType | None = None) -> XMLLike:
     """
     Method to set parameters of an atom group of the fleur inp.xml file.
 
@@ -921,17 +916,16 @@ def set_atomgroup(xmltree: XMLLike,
     :param attributedict: a python dict specifying what you want to change.
     :param position: position of an atom group to be changed. If equals to 'all', all species will be changed
     :param species: atom groups, corresponding to the given species will be changed
-    :param create: bool, if species does not exist create it and all subtags?
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     :returns: xml etree of the new inp.xml
 
-    **attributedict** is a python dictionary containing dictionaries that specify attributes
+    **changes** is a python dictionary containing dictionaries that specify attributes
     to be set inside the certain specie. For example, if one wants to set a beta noco parameter it
     can be done via::
 
-        'attributedict': {'nocoParams': {'beta': val}}
+        'changes': {'nocoParams': {'beta': val}}
 
     """
     from masci_tools.util.xml.xml_setters_xpaths import xml_set_complex_tag
@@ -950,12 +944,12 @@ def set_atomgroup(xmltree: XMLLike,
         else:
             atomgroup_xpath.add_filter('atomGroup', {'species': {'=': species}})
 
-    species_change = dict(attributedict).pop('species', None)  #dict to avoid mutating attributedict
+    species_change = dict(changes).pop('species', None)  #dict to avoid mutating changes
     if species_change is not None:
-        attributedict = {k: v for k, v in attributedict.items() if k != 'species'}
+        changes = {k: v for k, v in changes.items() if k != 'species'}
         xmltree = switch_species(xmltree, schema_dict, species_change, position=position, species=species)
 
-    return xml_set_complex_tag(xmltree, schema_dict, atomgroup_xpath, atomgroup_base_path, attributedict, create=create)
+    return xml_set_complex_tag(xmltree, schema_dict, atomgroup_xpath, atomgroup_base_path, changes)
 
 
 def switch_species_label(xmltree: XMLLike,
@@ -1066,8 +1060,8 @@ def switch_species(xmltree: XMLLike,
 
 def shift_value(xmltree: XMLLike,
                 schema_dict: fleur_schema.SchemaDict,
-                change_dict: dict[str, Any],
-                mode: Literal['abs', 'rel'] = 'abs',
+                changes: dict[str, Any],
+                mode: Literal['abs', 'absolute', 'rel', 'relative'] = 'absolute',
                 path_spec: dict[str, Any] | None = None) -> XMLLike:
     """
     Shifts numerical values of attributes directly in the inp.xml file.
@@ -1076,15 +1070,17 @@ def shift_value(xmltree: XMLLike,
 
     :param xmltree: xml tree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :param change_dict: a python dictionary with the keys to shift and the shift values.
-    :param mode: 'abs' if change given is absolute, 'rel' if relative
+    :param changes: a python dictionary with the keys to shift and the shift values.
+    :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
+                 `rel`/`relative` multiplies the old value with the given value
+                 `abs`/`absolute` adds the old value and the given value
     :param path_spec: dict, with ggf. necessary further specifications for the path of the attribute
 
     :returns: a xml tree with shifted values
 
-    An example of change_dict::
+    An example of changes::
 
-            change_dict = {'itmax' : 1, 'dVac': -0.123}
+            changes = {'itmax' : 1, 'dVac': -0.123}
     """
     from masci_tools.util.case_insensitive_dict import CaseInsensitiveDict
 
@@ -1092,7 +1088,7 @@ def shift_value(xmltree: XMLLike,
         path_spec = {}
     path_spec_case: CaseInsensitiveDict[str, Any] = CaseInsensitiveDict(path_spec)
 
-    for key, value_given in change_dict.items():
+    for key, value_given in changes.items():
 
         key_spec = path_spec_case.get(key, {})
         #This method only support unique and unique_path attributes
@@ -1104,7 +1100,7 @@ def shift_value(xmltree: XMLLike,
 
 def set_inpchanges(xmltree: XMLLike,
                    schema_dict: fleur_schema.SchemaDict,
-                   change_dict: dict[str, Any],
+                   changes: dict[str, Any],
                    path_spec: dict[str, Any] | None = None) -> XMLLike:
     """
     This method sets all the attribute and texts provided in the change_dict.
@@ -1113,15 +1109,15 @@ def set_inpchanges(xmltree: XMLLike,
 
     :param xmltree: xml tree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :params change_dict: dictionary {attrib_name : value} with all the wanted changes.
+    :params changes: dictionary {attrib_name : value} with all the wanted changes.
     :param path_spec: dict, with ggf. necessary further specifications for the path of the attribute
 
-    An example of change_dict::
+    An example of changes::
 
-            change_dict = {'itmax' : 1,
-                           'l_noco': True,
-                           'ctail': False,
-                           'l_ss': True}
+            changes = {'itmax' : 1,
+                       'l_noco': True,
+                       'ctail': False,
+                       'l_ss': True}
 
     :returns: an xmltree of the inp.xml file with changes.
     """
@@ -1133,7 +1129,7 @@ def set_inpchanges(xmltree: XMLLike,
         path_spec = {}
     path_spec_case: CaseInsensitiveDict[str, Any] = CaseInsensitiveDict(path_spec)
 
-    for key, change_value in change_dict.items():
+    for key, change_value in changes.items():
 
         #Special alias for xcFunctional since name is not a very telling attribute name
         if key == 'xcFunctional':

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -353,8 +353,7 @@ def xml_add_number_to_attrib(xmltree: XMLLike,
                              base_xpath: str,
                              name: str,
                              number_to_add: Any,
-                             mode: Literal['abs', 'absolute',
-                                           'rel', 'relative'] = 'absolute',
+                             mode: Literal['abs', 'absolute', 'rel', 'relative'] = 'absolute',
                              occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
     Adds a given number to the attribute value in a xmltree. By default the attribute will be shifted
@@ -477,7 +476,7 @@ def xml_add_number_to_first_attrib(xmltree: XMLLike,
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param xpath: a path where to set the attributes
     :param base_xpath: path where to place a new tag without complex syntax ([] conditions and so on)
-    :param attributename: the attribute name to change
+    :param name: the attribute name to change
     :param number_to_add: number to add/multiply with the old attribute value
     :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
                  `rel`/`relative` multiplies the old value with `number_to_add`
@@ -518,7 +517,7 @@ def xml_set_simple_tag(xmltree: XMLLike,
     :param base_xpath: path where to place a new tag without complex syntax ([] conditions and so on)
     :param tag_name: name of the tag to set
     :param changes: list of dicts or dict with the changes. Elements in list describe multiple tags.
-                    Keys in the dictionary correspond to {'attributename': attributevalue}
+                    Keys in the dictionary correspond to {'name': value}
     :param create_parents: bool optional (default False), if True and the path, where the simple tags are
                            set does not exist it is created
 

--- a/tests/io/test_fleurxmlmodifier.py
+++ b/tests/io/test_fleurxmlmodifier.py
@@ -413,3 +413,17 @@ def test_fleurxmlmodifier_nmmpmat(test_file):
 
     assert xmltree is not None
     assert nmmpmat is not None
+
+
+def test_fleurxmlmodifier_deprecated_validate():
+    """Check that the deprecated _validate_signature is working correctly"""
+    #pylint: disable=protected-access
+    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier
+
+    fm = FleurXMLModifier()
+    with pytest.deprecated_call():
+        fm._validate_signature('delete_att', 'test')
+
+    with pytest.deprecated_call():
+        with pytest.raises(TypeError):
+            fm._validate_signature('delete_att', non_existent_arg='test')

--- a/tests/io/test_fleurxmlmodifier.py
+++ b/tests/io/test_fleurxmlmodifier.py
@@ -140,42 +140,43 @@ def test_fleurxml_modifier_from_list(test_file):
     """Tests if fleurinp_modifier with various modifications on species"""
     from masci_tools.io.fleurxmlmodifier import FleurXMLModifier, ModifierTask
 
-    fm = FleurXMLModifier.fromList([('set_inpchanges', {
-        'change_dict': {
+    task_list = [('set_inpchanges', {
+        'changes': {
             'dos': True,
             'Kmax': 3.9
         }
     }), ('shift_value', {
-        'change_dict': {
+        'changes': {
             'Kmax': 0.1
         },
         'mode': 'rel'
     }),
-                                    ('shift_value_species_label', {
-                                        'atom_label': '                 222',
-                                        'attributename': 'radius',
-                                        'value_given': 3,
-                                        'mode': 'abs'
-                                    }), ('set_kpointlist', {
-                                        'kpoints': [[0, 0, 0]],
-                                        'weights': [1]
-                                    }),
-                                    ('set_species', {
-                                        'species_name': 'all',
-                                        'attributedict': {
-                                            'mtSphere': {
-                                                'radius': 3.333
-                                            }
-                                        }
-                                    })])
+                 ('shift_value_species_label', {
+                     'atom_label': '                 222',
+                     'attribute_name': 'radius',
+                     'number_to_add': 3,
+                     'mode': 'abs'
+                 }), ('set_kpointlist', {
+                     'kpoints': [[0, 0, 0]],
+                     'weights': [1]
+                 }), ('set_species', {
+                     'species_name': 'all',
+                     'changes': {
+                         'mtSphere': {
+                             'radius': 3.333
+                         }
+                     }
+                 })]
+
+    fm = FleurXMLModifier.fromList(task_list)
 
     assert fm.changes() == [
-        ModifierTask(name='set_inpchanges', args=(), kwargs={'change_dict': {
+        ModifierTask(name='set_inpchanges', args=(), kwargs={'changes': {
             'dos': True,
             'Kmax': 3.9
         }}),
         ModifierTask(name='shift_value', args=(), kwargs={
-            'change_dict': {
+            'changes': {
                 'Kmax': 0.1
             },
             'mode': 'rel'
@@ -184,8 +185,8 @@ def test_fleurxml_modifier_from_list(test_file):
                      args=(),
                      kwargs={
                          'atom_label': '                 222',
-                         'attributename': 'radius',
-                         'value_given': 3,
+                         'attribute_name': 'radius',
+                         'number_to_add': 3,
                          'mode': 'abs'
                      }),
         ModifierTask(name='set_kpointlist', args=(), kwargs={
@@ -196,7 +197,84 @@ def test_fleurxml_modifier_from_list(test_file):
                      args=(),
                      kwargs={
                          'species_name': 'all',
-                         'attributedict': {
+                         'changes': {
+                             'mtSphere': {
+                                 'radius': 3.333
+                             }
+                         }
+                     })
+    ]
+
+    #The underlying methods are tested in the specific tests for the setters
+    #We only want to ensure that the procedure finishes without error
+    xmltree = fm.modify_xmlfile(test_file(TEST_INPXML_PATH))
+
+    assert xmltree is not None
+
+
+def test_fleurxml_modifier_from_list_deprecated_arguments(test_file):
+    """Tests if fleurinp_modifier with various modifications on species"""
+    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier, ModifierTask
+
+    task_list = [('set_inpchanges', {
+        'change_dict': {
+            'dos': True,
+            'Kmax': 3.9
+        }
+    }), ('shift_value', {
+        'change_dict': {
+            'Kmax': 0.1
+        },
+        'mode': 'rel'
+    }),
+                 ('shift_value_species_label', {
+                     'atom_label': '                 222',
+                     'attributename': 'radius',
+                     'value_given': 3,
+                     'mode': 'abs'
+                 }), ('set_kpointlist', {
+                     'kpoints': [[0, 0, 0]],
+                     'weights': [1]
+                 }), ('set_species', {
+                     'species_name': 'all',
+                     'attributedict': {
+                         'mtSphere': {
+                             'radius': 3.333
+                         }
+                     }
+                 })]
+
+    with pytest.deprecated_call():
+        fm = FleurXMLModifier.fromList(task_list)
+
+    assert fm.changes() == [
+        ModifierTask(name='set_inpchanges', args=(), kwargs={'changes': {
+            'dos': True,
+            'Kmax': 3.9
+        }}),
+        ModifierTask(name='shift_value', args=(), kwargs={
+            'changes': {
+                'Kmax': 0.1
+            },
+            'mode': 'rel'
+        }),
+        ModifierTask(name='shift_value_species_label',
+                     args=(),
+                     kwargs={
+                         'atom_label': '                 222',
+                         'attribute_name': 'radius',
+                         'number_to_add': 3,
+                         'mode': 'abs'
+                     }),
+        ModifierTask(name='set_kpointlist', args=(), kwargs={
+            'kpoints': [[0, 0, 0]],
+            'weights': [1]
+        }),
+        ModifierTask(name='set_species',
+                     args=(),
+                     kwargs={
+                         'species_name': 'all',
+                         'changes': {
                              'mtSphere': {
                                  'radius': 3.333
                              }

--- a/tests/io/test_fleurxmlmodifier.py
+++ b/tests/io/test_fleurxmlmodifier.py
@@ -2,6 +2,7 @@
 Test for the FleurXMLModifier class
 """
 import pytest
+from masci_tools.io.fleurxmlmodifier import ModifierTask
 
 TEST_INPXML_PATH = 'fleur/Max-R5/FePt_film_SSFT_LO/files/inp2.xml'
 TEST_INPXML_LDAU_PATH = 'fleur/Max-R5/GaAsMultiUForceXML/files/inp.xml'
@@ -12,7 +13,7 @@ def test_fleurxmlmodifier_facade_methods():
     """
     Make sure that adding all facade methods results in the right task list
     """
-    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier, ModifierTask
+    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier
     from masci_tools.util.xml.collect_xml_setters import XPATH_SETTERS, SCHEMA_DICT_SETTERS, NMMPMAT_SETTERS
 
     fm = FleurXMLModifier(validate_signatures=False)
@@ -55,7 +56,7 @@ def test_fleurxmlmodifier_facade_methods_validation():
 
 def test_fleurxml_modifier_modify_xmlfile_simple(test_file):
     """Tests if fleurinp_modifier with various modifications on species"""
-    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier, ModifierTask
+    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier
 
     fm = FleurXMLModifier()
     fm.set_inpchanges({'dos': True, 'Kmax': 3.9})
@@ -102,7 +103,7 @@ def test_fleurxml_modifier_modify_xmlfile_simple(test_file):
 
 def test_fleurxml_modifier_modify_xmlfile_undo(test_file):
     """Tests if fleurinp_modifier with various modifications on species"""
-    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier, ModifierTask
+    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier
 
     fm = FleurXMLModifier()
     fm.set_inpchanges({'dos': True, 'Kmax': 3.9})
@@ -138,7 +139,7 @@ def test_fleurxml_modifier_modify_xmlfile_undo(test_file):
 
 def test_fleurxml_modifier_from_list(test_file):
     """Tests if fleurinp_modifier with various modifications on species"""
-    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier, ModifierTask
+    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier
 
     task_list = [('set_inpchanges', {
         'changes': {
@@ -212,81 +213,160 @@ def test_fleurxml_modifier_from_list(test_file):
     assert xmltree is not None
 
 
-def test_fleurxml_modifier_from_list_deprecated_arguments(test_file):
-    """Tests if fleurinp_modifier with various modifications on species"""
-    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier, ModifierTask
-
-    task_list = [('set_inpchanges', {
+@pytest.mark.parametrize('name, kwargs, expected_task', [
+    ('set_inpchanges', {
         'change_dict': {
             'dos': True,
             'Kmax': 3.9
         }
-    }), ('shift_value', {
+    }, ModifierTask(name='set_inpchanges', kwargs={'changes': {
+        'dos': True,
+        'Kmax': 3.9
+    }})),
+    ('shift_value', {
         'change_dict': {
             'Kmax': 0.1
         },
         'mode': 'rel'
-    }),
-                 ('shift_value_species_label', {
-                     'atom_label': '                 222',
-                     'attributename': 'radius',
-                     'value_given': 3,
-                     'mode': 'abs'
-                 }), ('set_kpointlist', {
-                     'kpoints': [[0, 0, 0]],
-                     'weights': [1]
-                 }), ('set_species', {
-                     'species_name': 'all',
-                     'attributedict': {
-                         'mtSphere': {
-                             'radius': 3.333
-                         }
-                     }
-                 })]
+    }, ModifierTask(name='shift_value', kwargs={
+        'changes': {
+            'Kmax': 0.1
+        },
+        'mode': 'rel'
+    })),
+    ('set_species', {
+        'species_name': 'all',
+        'attributedict': {
+            'element': 'T'
+        }
+    }, ModifierTask(name='set_species', kwargs={
+        'species_name': 'all',
+        'changes': {
+            'element': 'T'
+        }
+    })),
+    ('set_species_label', {
+        'atom_label': 'all',
+        'attributedict': {
+            'element': 'T'
+        }
+    }, ModifierTask(name='set_species_label', kwargs={
+        'atom_label': 'all',
+        'changes': {
+            'element': 'T'
+        }
+    })),
+    ('shift_value_species_label', {
+        'atom_label': '                 222',
+        'attributename': 'radius',
+        'value_given': 3,
+        'mode': 'abs'
+    },
+     ModifierTask(name='shift_value_species_label',
+                  kwargs={
+                      'atom_label': '                 222',
+                      'attribute_name': 'radius',
+                      'number_to_add': 3,
+                      'mode': 'abs'
+                  })),
+    ('set_atomgroup', {
+        'species': 'all',
+        'attributedict': {
+            'species': 'T'
+        },
+        'create': True,
+    }, ModifierTask(name='set_atomgroup', kwargs={
+        'species': 'all',
+        'changes': {
+            'species': 'T'
+        },
+    })),
+    ('set_atomgroup_label', {
+        'atom_label': '                 222',
+        'attributedict': {
+            'species': 'T'
+        },
+        'create': True,
+    },
+     ModifierTask(name='set_atomgroup_label',
+                  kwargs={
+                      'atom_label': '                 222',
+                      'changes': {
+                          'species': 'T'
+                      },
+                  })),
+    ('delete_att', {
+        'attrib_name': 'test'
+    }, ModifierTask(name='delete_att', kwargs={'name': 'test'})),
+    ('replace_tag', {
+        'tag_name': 'test',
+        'newelement': 'NEW'
+    }, ModifierTask(name='replace_tag', kwargs={
+        'tag_name': 'test',
+        'element': 'NEW'
+    })),
+    ('set_attrib_value', {
+        'attributename': 'test',
+        'attribv': 'NEW'
+    }, ModifierTask(name='set_attrib_value', kwargs={
+        'name': 'test',
+        'value': 'NEW'
+    })),
+    ('set_first_attrib_value', {
+        'attributename': 'test',
+        'attribv': 'NEW'
+    }, ModifierTask(name='set_first_attrib_value', kwargs={
+        'name': 'test',
+        'value': 'NEW'
+    })),
+    ('add_number_to_attrib', {
+        'attributename': 'test',
+        'add_number': 1.0
+    }, ModifierTask(name='add_number_to_attrib', kwargs={
+        'name': 'test',
+        'number_to_add': 1.0
+    })),
+    ('add_number_to_first_attrib', {
+        'attributename': 'test',
+        'add_number': 1.0
+    }, ModifierTask(name='add_number_to_first_attrib', kwargs={
+        'name': 'test',
+        'number_to_add': 1.0
+    })),
+    ('xml_replace_tag', {
+        'xpath': './test',
+        'newelement': 'NEW'
+    }, ModifierTask(name='xml_replace_tag', kwargs={
+        'xpath': './test',
+        'element': 'NEW'
+    })),
+    ('xml_delete_att', {
+        'xpath': './test',
+        'attributename': 'test'
+    }, ModifierTask(name='xml_delete_att', kwargs={
+        'xpath': './test',
+        'name': 'test'
+    })),
+    ('xml_set_attrib_value_no_create', {
+        'xpath': './test',
+        'attributename': 'test',
+        'attribv': 'NEW'
+    }, ModifierTask(name='xml_set_attrib_value_no_create', kwargs={
+        'xpath': './test',
+        'name': 'test',
+        'value': 'NEW'
+    })),
+])
+def test_fleurxml_modifier_deprecated_arguments(name, kwargs, expected_task):
+    """Test the various deprecations in the fleurxmlmodifier"""
+    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier
 
+    fm = FleurXMLModifier()
+
+    action = fm.get_avail_actions()[name]
     with pytest.deprecated_call():
-        fm = FleurXMLModifier.fromList(task_list)
-
-    assert fm.changes() == [
-        ModifierTask(name='set_inpchanges', args=(), kwargs={'changes': {
-            'dos': True,
-            'Kmax': 3.9
-        }}),
-        ModifierTask(name='shift_value', args=(), kwargs={
-            'changes': {
-                'Kmax': 0.1
-            },
-            'mode': 'rel'
-        }),
-        ModifierTask(name='shift_value_species_label',
-                     args=(),
-                     kwargs={
-                         'atom_label': '                 222',
-                         'attribute_name': 'radius',
-                         'number_to_add': 3,
-                         'mode': 'abs'
-                     }),
-        ModifierTask(name='set_kpointlist', args=(), kwargs={
-            'kpoints': [[0, 0, 0]],
-            'weights': [1]
-        }),
-        ModifierTask(name='set_species',
-                     args=(),
-                     kwargs={
-                         'species_name': 'all',
-                         'changes': {
-                             'mtSphere': {
-                                 'radius': 3.333
-                             }
-                         }
-                     })
-    ]
-
-    #The underlying methods are tested in the specific tests for the setters
-    #We only want to ensure that the procedure finishes without error
-    xmltree = fm.modify_xmlfile(test_file(TEST_INPXML_PATH))
-
-    assert xmltree is not None
+        action(**kwargs)
+    assert fm.changes() == [expected_task]
 
 
 def test_fleurxml_modifier_modify_xmlfile_undo_revert_all(test_file):

--- a/tests/xml/test_xml_setter_signatures/test_xml_setter_signatures.yml
+++ b/tests/xml/test_xml_setter_signatures/test_xml_setter_signatures.yml
@@ -47,16 +47,16 @@ schema_dict:
     - null
   - - schema_dict
     - null
-  - - attributename
+  - - name
     - null
-  - - add_number
+  - - number_to_add
     - null
   - - complex_xpath
     - null
   - - filters
     - null
   - - mode
-    - abs
+    - absolute
   - - occurrences
     - null
   - - kwargs
@@ -66,16 +66,16 @@ schema_dict:
     - null
   - - schema_dict
     - null
-  - - attributename
+  - - name
     - null
-  - - add_number
+  - - number_to_add
     - null
   - - complex_xpath
     - null
   - - filters
     - null
   - - mode
-    - abs
+    - absolute
   - - kwargs
     - null
   clone_species:
@@ -111,7 +111,7 @@ schema_dict:
     - null
   - - schema_dict
     - null
-  - - attrib_name
+  - - name
     - null
   - - complex_xpath
     - null
@@ -143,7 +143,7 @@ schema_dict:
     - null
   - - tag_name
     - null
-  - - newelement
+  - - element
     - null
   - - complex_xpath
     - null
@@ -158,7 +158,7 @@ schema_dict:
     - null
   - - schema_dict
     - null
-  - - attributedict
+  - - changes
     - null
   - - position
     - null
@@ -166,8 +166,6 @@ schema_dict:
     - null
   - - filters
     - null
-  - - create
-    - false
   set_atomgroup_label:
   - - xmltree
     - null
@@ -175,18 +173,16 @@ schema_dict:
     - null
   - - atom_label
     - null
-  - - attributedict
+  - - changes
     - null
-  - - create
-    - false
   set_attrib_value:
   - - xmltree
     - null
   - - schema_dict
     - null
-  - - attributename
+  - - name
     - null
-  - - attribv
+  - - value
     - null
   - - complex_xpath
     - null
@@ -220,9 +216,9 @@ schema_dict:
     - null
   - - schema_dict
     - null
-  - - attributename
+  - - name
     - null
-  - - attribv
+  - - value
     - null
   - - complex_xpath
     - null
@@ -237,9 +233,9 @@ schema_dict:
     - null
   - - schema_dict
     - null
-  - - attributename
+  - - tag_name
     - null
-  - - attribv
+  - - text
     - null
   - - complex_xpath
     - null
@@ -254,7 +250,7 @@ schema_dict:
     - null
   - - schema_dict
     - null
-  - - change_dict
+  - - changes
     - null
   - - path_spec
     - null
@@ -321,7 +317,7 @@ schema_dict:
     - null
   - - species_name
     - null
-  - - attributedict
+  - - changes
     - null
   - - filters
     - null
@@ -334,7 +330,7 @@ schema_dict:
     - null
   - - atom_label
     - null
-  - - attributedict
+  - - changes
     - null
   - - create
     - false
@@ -362,10 +358,10 @@ schema_dict:
     - null
   - - schema_dict
     - null
-  - - change_dict
+  - - changes
     - null
   - - mode
-    - abs
+    - absolute
   - - path_spec
     - null
   shift_value_species_label:
@@ -375,12 +371,12 @@ schema_dict:
     - null
   - - atom_label
     - null
-  - - attributename
+  - - attribute_name
     - null
-  - - value_given
+  - - number_to_add
     - null
   - - mode
-    - abs
+    - absolute
   - - kwargs
     - null
   switch_kpointset:

--- a/tests/xml/test_xml_setter_signatures/test_xml_setter_signatures.yml
+++ b/tests/xml/test_xml_setter_signatures/test_xml_setter_signatures.yml
@@ -443,7 +443,7 @@ xpath:
     - null
   - - xpath
     - null
-  - - attrib
+  - - name
     - null
   - - occurrences
     - null
@@ -459,7 +459,7 @@ xpath:
     - null
   - - xpath
     - null
-  - - newelement
+  - - element
     - null
   - - occurrences
     - null
@@ -468,9 +468,9 @@ xpath:
     - null
   - - xpath
     - null
-  - - attributename
+  - - name
     - null
-  - - attribv
+  - - value
     - null
   - - occurrences
     - null


### PR DESCRIPTION
Cleanup signatures of XML setter signatures. Main changes are

1. `attributedict`/`change_dict` -> `changes`
2. `attributename`/`attribv` -> `name`/`value`
3. Fixed bug , where the signatures of `set_text`/`set_first_text`
   contained `attributename` and `attribv`

These changes with the exception of the bugfix in `set_text` are deprecated when used via the `FleurXMLModifier`