### PR TITLE
Allow XML setters to accept strings for `etree.fromstring` in place of `etree._Element`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Improvements
 - Added `inverse` argument to nmmpmat XML setters. These will correctly produce the inverse rotation operation for the given angles. Also allow setting `orbital='all'` in `rotate_nmmpmat` to rotate all blocks by the given angles [[#140]](https://github.com/JuDFTteam/masci-tools/pull/140)
-
+- The XML setters `create_tag`, `replace_tag` and their low-level equivalents now also accept XML strings, i.e. `<example attribute="1"/>`, as arguments for the elements to create/replace [[#145]](https://github.com/JuDFTteam/masci-tools/pull/145)
 ### Bugfixes
 - Fix for XML setters operating on the DFT+U density matrix file. Previously these functions would not map the density matrix blocks correctly if multiple atomgroups shared the same species containing `ldaU` tags [[#140]](https://github.com/JuDFTteam/masci-tools/pull/140)
 

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -441,3 +441,16 @@ def contains_tag(xpath: XPathLike, tag: str) -> bool:
     #Strip out predicates
     xpath_str = re.sub(r'[\[].*?[\]]', '', xpath_str)
     return tag in xpath_str.split('/')
+
+
+def is_valid_tag(tag: str) -> bool:
+    """
+    Return whether the given string is a valid XML tag name
+
+    :param tag: tag to check
+    """
+    try:
+        etree.QName(tag)
+        return True
+    except ValueError:
+        return False

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -22,7 +22,7 @@ from lxml import etree
 import warnings
 
 from masci_tools.util.typing import XPathLike, XMLLike
-from masci_tools.util.xml.common_functions import eval_xpath
+from masci_tools.util.xml.common_functions import eval_xpath, is_valid_tag
 
 
 def xml_replace_tag(xmltree: XMLLike,
@@ -34,7 +34,7 @@ def xml_replace_tag(xmltree: XMLLike,
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path to the tag to be replaced
-    :param element: an Element to replace the found tags with
+    :param element: an Element or string representing the Element to replace the found tags with
     :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                         By default all nodes are used.
 
@@ -46,6 +46,9 @@ def xml_replace_tag(xmltree: XMLLike,
         root = xmltree.getroot()  #type:ignore[union-attr]
     else:
         root = xmltree
+
+    if not etree.iselement(element):
+        element = etree.fromstring(element)  #type:ignore[arg-type]
 
     nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
 
@@ -189,7 +192,7 @@ def _reorder_tags(node: etree._Element, tag_order: list[str]) -> etree._Element:
 
 def xml_create_tag(xmltree: XMLLike,
                    xpath: XPathLike,
-                   element: str | etree._Element,
+                   element: etree.QName | str | etree._Element,
                    place_index: int | None = None,
                    tag_order: list[str] | None = None,
                    occurrences: int | Iterable[int] | None = None,
@@ -205,7 +208,7 @@ def xml_create_tag(xmltree: XMLLike,
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path where to place a new tag
-    :param element: a tag name or etree Element to be created
+    :param element: a tag name, etree Element or string representing the XML element to be created
     :param place_index: defines the place where to put a created tag
     :param tag_order: defines a tag order
     :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
@@ -223,11 +226,14 @@ def xml_create_tag(xmltree: XMLLike,
     from more_itertools import unique_justseen
 
     if not etree.iselement(element):
-        element_name: str = element  #type:ignore
-        try:
-            element = etree.Element(element_name)
-        except ValueError as exc:
-            raise ValueError(f"Failed to construct etree Element from '{element_name}'") from exc
+        if isinstance(element, etree.QName) or is_valid_tag(element):  #type:ignore[arg-type]
+            element = etree.Element(element)  #type:ignore[arg-type]
+        else:
+            try:
+                element = etree.fromstring(element)  #type:ignore[arg-type]
+            except etree.XMLSyntaxError as exc:
+                raise ValueError(f"Failed to construct etree Element from '{element}'") from exc
+        element_name = element.tag
     else:
         element_name = element.tag
 

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -32,7 +32,7 @@ from lxml import etree
 
 def create_tag(xmltree: XMLLike,
                schema_dict: fleur_schema.SchemaDict,
-               tag: str | etree._Element,
+               tag: etree.QName | str | etree._Element,
                complex_xpath: XPathLike | None = None,
                filters: FilterType | None = None,
                create_parents: bool = False,
@@ -46,7 +46,7 @@ def create_tag(xmltree: XMLLike,
 
     :param xmltree: an xmltree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :param tag: str of the tag to create or etree Element with the same name to insert
+    :param tag: str of the tag to create or etree Element or string representing the XML element with the same name to insert
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
@@ -62,12 +62,19 @@ def create_tag(xmltree: XMLLike,
     :returns: xmltree with created tags
     """
     from masci_tools.util.xml.xml_setters_xpaths import xml_create_tag_schema_dict
-    from masci_tools.util.xml.common_functions import split_off_tag
+    from masci_tools.util.xml.common_functions import split_off_tag, is_valid_tag
 
     if etree.iselement(tag):
         tag_name: str = tag.tag
+    elif isinstance(tag, etree.QName):
+        tag_name = tag.text
+    elif is_valid_tag(tag):  #type:ignore[arg-type]
+        tag_name = tag  #type:ignore[assignment]
     else:
-        tag_name = tag  #type:ignore
+        try:
+            tag_name = etree.fromstring(tag).tag  #type:ignore[arg-type]
+        except etree.XMLSyntaxError as exc:
+            raise ValueError(f"Failed to construct etree Element from '{tag}'") from exc
 
     base_xpath = schema_dict.tag_xpath(tag_name, **kwargs)
     parent_xpath, tag_name = split_off_tag(base_xpath)
@@ -196,7 +203,7 @@ def replace_tag(xmltree: XMLLike,
     :param xmltree: an xmltree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param tag: str of the tag to replace
-    :param element: etree Element to replace the tag
+    :param element: etree Element or string representing the XML element to replace the tag
     :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
     :param filters: Dict specifying constraints to apply on the xpath.
                     See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details

--- a/tests/xml/test_xml_setters_basic.py
+++ b/tests/xml/test_xml_setters_basic.py
@@ -382,6 +382,28 @@ def test_xml_replace_tag_occurrences_multiple(load_inpxml):
     assert nodes.attrib.items() == [('test_attrib', 'test')]
 
 
+def test_xml_replace_tag_single_xmlstring(load_inpxml):
+
+    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.xml_setters_basic import xml_replace_tag
+
+    replace_element = '<test_tag test_attrib="test"/>'
+
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    root = xmltree.getroot()
+
+    assert len(eval_xpath(root, '/fleurInput/calculationSetup/cutoffs', list_return=True)) == 1
+
+    xmltree = xml_replace_tag(xmltree, '/fleurInput/calculationSetup/cutoffs', replace_element)
+
+    assert len(eval_xpath(root, '/fleurInput/calculationSetup/cutoffs', list_return=True)) == 0
+
+    nodes = eval_xpath(root, '/fleurInput/calculationSetup/test_tag', list_return=True)
+
+    assert len(nodes) == 1
+    assert nodes[0].attrib.items() == [('test_attrib', 'test')]
+
+
 def test_xml_create_tag_string_append(load_inpxml):
 
     from masci_tools.util.xml.common_functions import eval_xpath
@@ -415,6 +437,62 @@ def test_xml_create_tag_element_append(load_inpxml):
 
     new_element = etree.Element('test_tag')
     new_element.attrib['test_attrib'] = 'test'
+
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    root = xmltree.getroot()
+
+    tags = [
+        'cutoffs', 'scfLoop', 'coreElectrons', 'xcFunctional', 'magnetism', 'soc', 'prodBasis', 'expertModes',
+        'geometryOptimization', 'ldaU'
+    ]
+
+    node = eval_xpath(root, '/fleurInput/calculationSetup')
+
+    assert [child.tag for child in node.iterchildren()] == tags
+
+    xmltree = xml_create_tag(xmltree, '/fleurInput/calculationSetup', new_element)
+
+    node = eval_xpath(root, '/fleurInput/calculationSetup')
+
+    tags.append('test_tag')
+    assert [child.tag for child in node.iterchildren()] == tags
+    assert [child.attrib.items() for child in node.iterchildren()][-1] == [('test_attrib', 'test')]
+
+
+def test_xml_create_tag_qname_append(load_inpxml):
+
+    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.xml_setters_basic import xml_create_tag
+    from lxml import etree
+
+    new_element = etree.QName('test_tag')
+
+    xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    root = xmltree.getroot()
+
+    tags = [
+        'cutoffs', 'scfLoop', 'coreElectrons', 'xcFunctional', 'magnetism', 'soc', 'prodBasis', 'expertModes',
+        'geometryOptimization', 'ldaU'
+    ]
+
+    node = eval_xpath(root, '/fleurInput/calculationSetup')
+
+    assert [child.tag for child in node.iterchildren()] == tags
+
+    xmltree = xml_create_tag(xmltree, '/fleurInput/calculationSetup', new_element)
+
+    node = eval_xpath(root, '/fleurInput/calculationSetup')
+
+    tags.append('test_tag')
+    assert [child.tag for child in node.iterchildren()] == tags
+
+
+def test_xml_create_tag_xmlstring_append(load_inpxml):
+
+    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.xml_setters_basic import xml_create_tag
+
+    new_element = '<test_tag test_attrib="test"/>'
 
     xmltree, _ = load_inpxml(TEST_INPXML_PATH, absolute=False)
     root = xmltree.getroot()

--- a/tests/xml/test_xml_setters_names.py
+++ b/tests/xml/test_xml_setters_names.py
@@ -53,6 +53,46 @@ def test_create_tag_element(load_inpxml):
     assert [child.tag for child in node.iterchildren()] == tags
 
 
+def test_create_tag_qname(load_inpxml):
+
+    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.xml_setters_names import create_tag
+
+    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    root = xmltree.getroot()
+
+    node = eval_xpath(root, '/fleurInput/calculationSetup')
+
+    tags = [child.tag for child in node.iterchildren()]
+    tags.append('greensFunction')
+
+    create_tag(xmltree, schema_dict, etree.QName('greensFunction'))
+
+    node = eval_xpath(root, '/fleurInput/calculationSetup')
+
+    assert [child.tag for child in node.iterchildren()] == tags
+
+
+def test_create_tag_xmlstring(load_inpxml):
+
+    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.xml_setters_names import create_tag
+
+    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    root = xmltree.getroot()
+
+    node = eval_xpath(root, '/fleurInput/calculationSetup')
+
+    tags = [child.tag for child in node.iterchildren()]
+    tags.append('greensFunction')
+
+    create_tag(xmltree, schema_dict, '<greensFunction/>')
+
+    node = eval_xpath(root, '/fleurInput/calculationSetup')
+
+    assert [child.tag for child in node.iterchildren()] == tags
+
+
 def test_create_tag_specification(load_inpxml):
 
     from masci_tools.util.xml.common_functions import eval_xpath
@@ -457,6 +497,24 @@ def test_replace_tag(load_inpxml):
     root = xmltree.getroot()
 
     new_elem = etree.Element('test_tag')
+
+    assert len(eval_xpath(root, '/fleurInput/atomSpecies/species', list_return=True)) == 2
+
+    replace_tag(xmltree, schema_dict, 'species', new_elem)
+
+    assert len(eval_xpath(root, '/fleurInput/atomSpecies/species', list_return=True)) == 0
+    assert len(eval_xpath(root, '/fleurInput/atomSpecies/test_tag', list_return=True)) == 2
+
+
+def test_replace_tag_xmlstring(load_inpxml):
+
+    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.xml_setters_names import replace_tag
+
+    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    root = xmltree.getroot()
+
+    new_elem = '<test_tag/>'
 
     assert len(eval_xpath(root, '/fleurInput/atomSpecies/species', list_return=True)) == 2
 

--- a/tests/xml/test_xml_setters_xpaths.py
+++ b/tests/xml/test_xml_setters_xpaths.py
@@ -84,6 +84,47 @@ def test_xml_create_tag_schema_dict_element(load_inpxml):
     assert [node.attrib.items() for node in nodes] == [[('test_attrib', 'test')], [('test_attrib', 'test')]]
 
 
+def test_xml_create_tag_schema_dict_xmlstring(load_inpxml):
+
+    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.xml_setters_xpaths import xml_create_tag_schema_dict
+
+    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    root = xmltree.getroot()
+
+    new_element = '<ldaU test_attrib="test"/>'
+
+    assert len(eval_xpath(root, '/fleurInput/atomSpecies/species/ldaU', list_return=True)) == 0
+
+    xml_create_tag_schema_dict(xmltree, schema_dict, '/fleurInput/atomSpecies/species',
+                               '/fleurInput/atomSpecies/species', new_element)
+
+    nodes = eval_xpath(root, '/fleurInput/atomSpecies/species/ldaU', list_return=True)
+
+    assert [node.getparent().attrib['name'] for node in nodes] == ['Fe-1', 'Pt-1']
+    assert [node.attrib.items() for node in nodes] == [[('test_attrib', 'test')], [('test_attrib', 'test')]]
+
+
+def test_xml_create_tag_schema_dict_qname(load_inpxml):
+
+    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.xml_setters_xpaths import xml_create_tag_schema_dict
+
+    xmltree, schema_dict = load_inpxml(TEST_INPXML_PATH, absolute=False)
+    root = xmltree.getroot()
+
+    new_element = etree.QName('ldaU')
+
+    assert len(eval_xpath(root, '/fleurInput/atomSpecies/species/ldaU', list_return=True)) == 0
+
+    xml_create_tag_schema_dict(xmltree, schema_dict, '/fleurInput/atomSpecies/species',
+                               '/fleurInput/atomSpecies/species', new_element)
+
+    nodes = eval_xpath(root, '/fleurInput/atomSpecies/species/ldaU', list_return=True)
+
+    assert [node.getparent().attrib['name'] for node in nodes] == ['Fe-1', 'Pt-1']
+
+
 def test_xml_create_tag_schema_dict_create_parents(load_inpxml):
 
     from masci_tools.util.xml.common_functions import eval_xpath


### PR DESCRIPTION
This is a preparation to allow these kinds of functions in aiida-fleur.
The calcfunction of the FleurinpModifier can't accept the elements
directly since they go through a json serialization. The idea would be
to convert elements into strings and then reconstructing them once inside
the XML setters in masci-tools