### PR TITLE
Add `task_list` property to FleurXMLModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 - New XML setter `align_nmmpmat_to_sqa` to rotate the density matrix file according to SQAs specified either for noco or second variation SOC [[#140]](https://github.com/JuDFTteam/masci-tools/pull/140)
-- Added `task_list` property to `FleurXMLModifier` to construct a list which can be used to replicate the same `FleurXMLModifier` with the `fromList()` classmethod [[#missing]](https://github.com/JuDFTteam/masci-tools/pull/missing)
+- Added `task_list` property to `FleurXMLModifier` to construct a list which can be used to replicate the same `FleurXMLModifier` with the `fromList()` classmethod [[#149]](https://github.com/JuDFTteam/masci-tools/pull/#149)
 
 ### Improvements
 - Added `inverse` argument to nmmpmat XML setters. These will correctly produce the inverse rotation operation for the given angles. Also allow setting `orbital='all'` in `rotate_nmmpmat` to rotate all blocks by the given angles [[#140]](https://github.com/JuDFTteam/masci-tools/pull/140)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Added
 - New XML setter `align_nmmpmat_to_sqa` to rotate the density matrix file according to SQAs specified either for noco or second variation SOC [[#140]](https://github.com/JuDFTteam/masci-tools/pull/140)
+- Added `task_list` property to `FleurXMLModifier` to construct a list which can be used to replicate the same `FleurXMLModifier` with the `fromList()` classmethod [[#missing]](https://github.com/JuDFTteam/masci-tools/pull/missing)
 
 ### Improvements
 - Added `inverse` argument to nmmpmat XML setters. These will correctly produce the inverse rotation operation for the given angles. Also allow setting `orbital='all'` in `rotate_nmmpmat` to rotate all blocks by the given angles [[#140]](https://github.com/JuDFTteam/masci-tools/pull/140)

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -164,7 +164,7 @@ class FleurXMLModifier:
 
         return func, prefix
 
-    def _get_setter_func_kwargs(self, name, args, kwargs):
+    def _get_setter_func_kwargs(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> dict[str, Any]:
         """
         Map the given args and kwargs to just kwargs for the
         setter function with the given name

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -138,6 +138,49 @@ class FleurXMLModifier:
             'Please use _validate_arguments without unpacking args/kwargs instead', DeprecationWarning)
         self._validate_arguments(name, args, kwargs)
 
+    def _get_setter_function_and_prefix(self, name: str) -> tuple[Callable[[Any], Any], tuple[str, ...]]:
+        """
+        Get the setter function and a prefix standing in for the arguments that
+        are substituted when performing the modification
+        """
+        if name in self.xpath_functions:
+            func = self.xpath_functions[name]
+            prefix: tuple[str, ...] = ('xmltree',)
+        elif name in self.schema_dict_functions:
+            func = self.schema_dict_functions[name]
+            prefix = ('xmltree', 'schema_dict')
+        elif name in self.nmmpmat_functions:
+            func = self.nmmpmat_functions[name]
+            prefix = ('xmltree', 'nmmplines', 'schema_dict')
+
+        if func is None:
+            raise ValueError(f'Failed to validate setter {name}. Maybe the function was'
+                             'not registered in masci_tools.util.xml.collect_xml_setters')
+
+        #For functions decorated with the schema_dict_version_dispatch
+        #We check only the default (This function should have a compatible signature for all registered functions)
+        if getattr(func, 'registry', None) is not None:
+            func = func.registry['default']
+
+        return func, prefix
+
+    def _get_setter_func_kwargs(self, name, args, kwargs):
+        """
+        Map the given args and kwargs to just kwargs for the
+        setter function with the given name
+
+        :param name: name of the setter function
+        :param args: positional arguments to the setter function
+        :param kwargs: keyword arguments to the setter function
+        """
+        from inspect import signature
+        func, prefix = self._get_setter_function_and_prefix(name)
+
+        sig = signature(func)
+        bound = sig.bind(*prefix, *args, **kwargs)
+
+        return {k: v for k, v in bound.arguments.items() if k not in ('xmltree', 'nmmplines', 'schema_dict')}
+
     def _validate_arguments(self, name: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> None:
         """
         Validate that the given arguments to the registration
@@ -146,26 +189,7 @@ class FleurXMLModifier:
         from inspect import signature
 
         if self.validate_signatures:
-
-            if name in self.xpath_functions:
-                func = self.xpath_functions[name]
-                prefix: tuple[str, ...] = ('xmltree',)
-            elif name in self.schema_dict_functions:
-                func = self.schema_dict_functions[name]
-                prefix = ('xmltree', 'schema_dict')
-            elif name in self.nmmpmat_functions:
-                func = self.nmmpmat_functions[name]
-                prefix = ('xmltree', 'schema_dict', 'n_mmp_mat')
-
-            if func is None:
-                raise ValueError(f'Failed to validate setter {name}. Maybe the function was'
-                                 'not registered in masci_tools.util.xml.collect_xml_setters')
-
-            #For functions decorated with the schema_dict_version_dispatch
-            #We check only the default (This function should have a compatible signature for all registered functions)
-            if getattr(func, 'registry', None) is not None:
-                func = func.registry['default']
-
+            func, prefix = self._get_setter_function_and_prefix(name)
             try:
                 sig = signature(func)
                 sig.bind(*prefix, *args, **kwargs)
@@ -230,6 +254,21 @@ class FleurXMLModifier:
                 raise ValueError(msg) from exc
 
         return xmltree, nmmp_lines
+
+    @property
+    def task_list(self) -> list[tuple[str, dict[str, Any]]]:
+        """
+        Return the current changes in a format accepted by :py:meth:`add_task_list()`
+        and :py:meth:`fromList()` 
+        """
+
+        tasks = []
+        for change in self._tasks:
+            #Here we already validated the arguments so we know we can just get the kwargs
+            kwargs = self._get_setter_func_kwargs(change.name, change.args, change.kwargs)
+            tasks.append((change.name, kwargs))
+
+        return tasks
 
     def get_avail_actions(self) -> dict[str, Callable]:
         """

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -259,7 +259,7 @@ class FleurXMLModifier:
     def task_list(self) -> list[tuple[str, dict[str, Any]]]:
         """
         Return the current changes in a format accepted by :py:meth:`add_task_list()`
-        and :py:meth:`fromList()` 
+        and :py:meth:`fromList()`
         """
 
         tasks = []

--- a/tests/io/test_fleurxmlmodifier.py
+++ b/tests/io/test_fleurxmlmodifier.py
@@ -213,6 +213,42 @@ def test_fleurxml_modifier_from_list(test_file):
     assert xmltree is not None
 
 
+def test_fleurxml_modifier_task_list_construction(test_file):
+    """Tests if fleurxmlmodifier can produce the task list"""
+    from masci_tools.io.fleurxmlmodifier import FleurXMLModifier
+
+    fm = FleurXMLModifier()
+    fm.set_inpchanges({'dos': True, 'Kmax': 3.9})
+    fm.shift_value({'Kmax': 0.1}, 'rel')
+    fm.shift_value_species_label('                 222', 'radius', 3, mode='abs')
+    fm.set_species('all', {'mtSphere': {'radius': 3.333}})
+
+    assert fm.task_list == [('set_inpchanges', {
+        'changes': {
+            'dos': True,
+            'Kmax': 3.9
+        }
+    }), ('shift_value', {
+        'changes': {
+            'Kmax': 0.1
+        },
+        'mode': 'rel'
+    }),
+                            ('shift_value_species_label', {
+                                'atom_label': '                 222',
+                                'attribute_name': 'radius',
+                                'number_to_add': 3,
+                                'mode': 'abs'
+                            }), ('set_species', {
+                                'species_name': 'all',
+                                'changes': {
+                                    'mtSphere': {
+                                        'radius': 3.333
+                                    }
+                                }
+                            })]
+
+
 @pytest.mark.parametrize('name, kwargs, expected_task', [
     ('set_inpchanges', {
         'change_dict': {

--- a/tests/io/test_fleurxmlmodifier.py
+++ b/tests/io/test_fleurxmlmodifier.py
@@ -403,6 +403,7 @@ def test_fleurxml_modifier_deprecated_arguments(name, kwargs, expected_task):
     with pytest.deprecated_call():
         action(**kwargs)
     assert fm.changes() == [expected_task]
+    assert fm.task_list == [(name, expected_task.kwargs)]
 
 
 def test_fleurxml_modifier_modify_xmlfile_undo_revert_all(test_file):


### PR DESCRIPTION
This property produces output compatible with the `fromList` classmethod (which is importantly the method used to read the `inpxml_changes` input)

This is a small step towards making the construction of `inpxml_changes` inputs in `aiida-fleur`
easier