### PR TITLE
Cleanup references in docs

### DIFF
--- a/docs/source/devel_guide/fleur_parser.rst
+++ b/docs/source/devel_guide/fleur_parser.rst
@@ -1,30 +1,45 @@
 Updating or adapting the Fleur Parsers
 ++++++++++++++++++++++++++++++++++++++++++++++++
 
+.. currentmodule:: masci_tools.io.parsers.fleur_schema
+
 Each input and output file for Fleur has a correspong XML-Schema, where the structure
 of these files are defined.
 
-To be able to parse such files efficiently and without hardcoding their structure we extract all necessary information about the schemas in the modules under :py:mod:`~masci_tools.io.parsers.fleur_schema`. The resulting python dictionaries can be accessed via the classes :py:class:`~masci_tools.io.parsers.fleur_schema.InputSchemaDict` and :py:class:`~masci_tools.io.parsers.fleur_schema.OutputSchemaDict`. The easiest way to instantiate one of these objects is to use the :py:meth:`~masci_tools.io.parsers.fleur_schema.InputSchemaDict.fromVersion()` or :py:meth:`~masci_tools.io.parsers.fleur_schema.OutputSchemaDict.fromVersion()` methods by providing the desired version string.
+To be able to parse such files efficiently and without hardcoding their structure
+we extract all necessary information about the schemas in the modules under
+:py:mod:`~masci_tools.io.parsers.fleur_schema`. The resulting python dictionaries
+can be accessed via the classes :py:class:`InputSchemaDict` and :py:class:`OutputSchemaDict`.
+The easiest way to instantiate one of these objects is to use the
+:py:meth:`InputSchemaDict.fromVersion()` or :py:meth:`OutputSchemaDict.fromVersion()` methods
+by providing the desired version string.
 
 Adding/modifying a Fleur Schema:
 ---------------------------------
 
-The command ``masci-tools fleur-schema add <path-to-schema-file>`` can be used to add the schema to the repository. If the schema for the specified version already exists an error is raised. To ignore this error the option ``--overwrite`` can be used.
+The command ``masci-tools fleur-schema add <path-to-schema-file>`` can be used to add
+the schema to the repository. If the schema for the specified version already exists
+an error is raised. To ignore this error the option ``--overwrite`` can be used.
 
 Adapting the outxml_parser:
 ----------------------------
 
-In contrast to the input file parser :py:func:`~masci_tools.io.parsers.fleur.inpxml_parser()`, which parses all information available,
-the :py:func:`~masci_tools.io.parsers.fleur.outxml_parser()` has to be more flexible. The out file has much more information which might
+.. currentmodule:: masci_tools.io.parsers.fleur
+
+In contrast to the input file parser :py:func:`inpxml_parser()`, which parses all information available,
+the :py:func:`outxml_parser()` has to be more flexible. The out file has much more information which might
 not be always useful for users. Therefore the selection of what is parsed has to be much more specific.
 
 This selection is expressed in the context of tasks. In general this corresponds to things like:
-  - Total energy
-  - Charge density distances
-  - Magnetic moments
-  - and so on ...
+- Total energy
+- Charge density distances
+- Magnetic moments
+- and so on ...
 
-These are expressed in a definition in form of a dictionary. Below a simple example (Total energy) is shown, which parses the ```value``` and ```units``` attribute of the ```totalEnergy``` tag. The hardcoded known parsing tasks can be found in :py:mod:`~masci_tools.io.parsers.fleur.default_parse_tasks`
+These are expressed in a definition in form of a dictionary. Below a simple example
+(Total energy) is shown, which parses the ``value`` and ``units`` attribute of the
+``totalEnergy`` tag. The hardcoded known parsing tasks can be found in
+:py:mod:`~masci_tools.io.parsers.fleur.default_parse_tasks`.
 
 .. code-block:: python
 
@@ -37,7 +52,10 @@ These are expressed in a definition in form of a dictionary. Below a simple exam
       },
   }
 
-The definition of a task can consist of multiple keys (in this case only ```energy_hartree```), which by default correspond to the keys in the resulting output dictionary. Each key has to contain the ```parse_type``` and ```path_spec``` key. The ```parse_type``` defines the method used to extract the information.
+The definition of a task can consist of multiple keys (in this case only ``energy_hartree``),
+which by default correspond to the keys in the resulting output dictionary. Each key has
+to contain the ``parse_type`` and ``path_spec`` key. The ``parse_type`` defines the
+method used to extract the information.
 
 The following are possible:
   :attrib: Will parse the value of the given attribute
@@ -51,21 +69,23 @@ The following are possible:
                   into a dictionary, but for the parent of the tag
   :singleValue: Special case of allAttribs to parse value and units
                 attribute for the given tag
-  :xmlGetter: Will execute a function in the module `masci_tools.util.xml.xml_getters` given in the `name` entry
+  :xmlGetter: Will execute a function in the module :py:mod:`~masci_tools.util.xml.xml_getters` given in the ``name`` entry
 
-The ```path_spec``` key specifies how the key can be uniquely identified.
+The ``path_spec`` key specifies how the key can be uniquely identified.
 
 It can contain the following specifications:
   :name: Name of the wanted tag/attribute
   :contains: A phrase, which has to occur in the path
   :not_contains: A phrase, which has to not occur in the path
   :exclude: list of str. Only valid for attributes (these are sorted into different categories
-            ```unique```, ```unique_path``` and ```other```). This attribute can exclude one or more
+            ``unique``, ``unique_path`` and ``other``). This attribute can exclude one or more
             of these categories
 
-All except the ```name``` key are optional and should be constructed so that there is only one
+All except the ``name`` key are optional and should be constructed so that there is only one
 possible choice. Otherwise an exception is raised. There are other keywords, which can be entered
-here. These control how the parsed data is entered into the output dictionary. For a definition of these keywords, please refer to :py:mod:`~masci_tools.io.parsers.fleur.default_parse_tasks`.
+here. These control how the parsed data is entered into the output dictionary.
+For a definition of these keywords, please refer to
+:py:mod:`~masci_tools.io.parsers.fleur.default_parse_tasks`.
 
 Each task can also contain a number of control keys, determining when to perform the tasks.
 Each of these keys begins with an underscore. All of these are optional.
@@ -73,19 +93,23 @@ The following are valid:
 
   :_general: bool, if True (default False) the task is not performed for each iteration but once
              on the root of the file
-  :_minimal: bool, if True the task is performed even when ```minimal_mode = True``` is given
-  :_modes: list of tuples specifying requirements on the ```fleur_modes``` for the task.
-           For example ```[('jspins', 2), ('soc', True)]``` will only perform the task for a
+  :_minimal: bool, if True the task is performed even when ``minimal_mode = True`` is given
+  :_modes: list of tuples specifying requirements on the ``fleur_modes`` for the task.
+           For example ``[('jspins', 2), ('soc', True)]`` will only perform the task for a
            magnetic SOC calculation
   :_conversions: list of str, giving the names of functions to call after this task. Functions
-                 given here have to be decorated with the :py:func:`~masci_tools.io.parsers.fleur.conversion_function()` decorator
+                 given here have to be decorated with the :py:func:`conversion_function()` decorator
   :_special: bool, if True (default False) this task is NEVER added automatically and has to be added
              by hand
 
 Migrating the parsing tasks
 ----------------------------
 
-These task definitions might have to be adapted for new fleur versions. Some changes might be possible to make in :py:mod:`~masci_tools.io.parsers.fleur.default_parse_tasks` directly without breaking backwards compatibility. If this is not possible there is a decorator :py:func:`~masci_tools.io.parsers.fleur.register_migration()` to define a function that is recognized by the :py:func:`~masci_tools.io.parsers.fleur.outxml_parser()` to convert between versions. A usage example is shown below.
+These task definitions might have to be adapted for new fleur versions. Some changes
+might be possible to make in :py:mod:`~masci_tools.io.parsers.fleur.default_parse_tasks`
+directly without breaking backwards compatibility. If this is not possible there is
+a decorator :py:func:`register_migration()` to define a function that is recognized
+by the :py:func:`outxml_parser()` to convert between versions. A usage example is shown below.
 
 .. code-block:: python
 

--- a/docs/source/devel_guide/fleur_parser.rst
+++ b/docs/source/devel_guide/fleur_parser.rst
@@ -1,3 +1,5 @@
+.. _devguidefleurxml:
+
 Updating or adapting the Fleur Parsers
 ++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/docs/source/devel_guide/plot_data.rst
+++ b/docs/source/devel_guide/plot_data.rst
@@ -1,6 +1,7 @@
 .. _devguideplotdata:
+.. currentmodule:: masci_tools.vis.data
 
-Using the :py:class:`~masci_tools.vis.data.PlotData` class
+Using the :py:class:`PlotData` class
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. _matplotlib: https://matplotlib.org/stable/index.html
@@ -9,11 +10,16 @@ Using the :py:class:`~masci_tools.vis.data.PlotData` class
 Description
 ------------
 
-The :py:class:`~masci_tools.vis.data.PlotData` class simplifies supporting data to plotting functions in multiple ways, while keeping the plotting functions themselves simple and easy to understand.
+The :py:class:`PlotData` class simplifies supporting data to plotting functions in
+multiple ways, while keeping the plotting functions themselves simple and easy to
+understand.
 
-The basic idea of :py:class:`~masci_tools.vis.data.PlotData` is to mimic the behaviour of the ``data`` argument in `matplotlib`_ or the ``source`` argument in `bokeh`_. Suppose we have our data for a plot in a dictionary ``d``, which has the keys ``x``, ``y1`` and ``y2``. If we now want to plot both ``y`` keys against ``x`` we can do this in the following way.
+The basic idea of :py:class:`PlotData` is to mimic the behaviour of the ``data``
+argument in `matplotlib`_ or the ``source`` argument in `bokeh`_. Suppose we have our
+data for a plot in a dictionary ``d``, which has the keys ``x``, ``y1`` and ``y2``. If
+we now want to plot both ``y`` keys against ``x`` we can do this in the following way.
 
-.. code-block::
+.. code-block:: python
 
    from masci_tools.vis.data import PlotData
 
@@ -28,26 +34,34 @@ The basic idea of :py:class:`~masci_tools.vis.data.PlotData` is to mimic the beh
       #Now we can plot the data
       #for example plt.plot(entry.x, entry.y, data=source)
 
-The keys are automatically expanded to be of the same length, if this is possible. There are three iteration modes, with the same names as for dicts:
+The keys are automatically expanded to be of the same length, if this is possible.
+There are three iteration modes, with the same names as for dicts:
 
-   - ``keys``: Yields ``namedtuple`` with the keys for each plot
-   - ``values``: Yields ``namedtuple`` with the values corresponding to the keys for each plot
-   - ``items``: Yields the ``keys`` and their corresponding mapping for each plot
+- ``keys``: Yields ``namedtuple`` with the keys for each plot
+- ``values``: Yields ``namedtuple`` with the values corresponding to the keys for each plot
+- ``items``: Yields the ``keys`` and their corresponding mapping for each plot
 
-All of these functions have an argument ``first``, which will only return the first element if it is given as ``True``.
+All of these functions have an argument ``first``, which will only return the first element
+if it is given as ``True``.
 
 .. note::
-   The names ``x`` and ``y`` in the example above are completely arbitrary. The names for the columns and the fields on the ``namedtuple`` are determined by the keyword arguments given to :py:class:`~masci_tools.vis.data.PlotData` at initialization
+   The names ``x`` and ``y`` in the example above are completely arbitrary.
+   The names for the columns and the fields on the ``namedtuple`` are determined by the
+   keyword arguments given to :py:class:`PlotData` at initialization
 
 .. note::
-   At the moment the types of mappings accepted in the :py:class:`~masci_tools.vis.data.PlotData` class are limited to ``dict``, ``pd.DataFrame`` and ``ColumnDataSource`` (`bokeh`_) objects
+   At the moment the types of mappings accepted in the :py:class:`PlotData` class are
+   limited to ``dict``, ``pd.DataFrame`` and ``ColumnDataSource`` (`bokeh`_) objects
 
-Initializing :py:class:`~masci_tools.vis.data.PlotData` without a mapping
+Initializing :py:class:`PlotData` without a mapping
 ----------------------------------------------------------------------------------
 
-Users might want to provide data directly as arrays. If this should be allowed, there is a function :py:func:`~masci_tools.vis.data.process_data_arguments()` to allow for this option. This function can either take a ``data`` argument with a mapping and the same keyword arguments as the :py:class:`~masci_tools.vis.data.PlotData`.
+Users might want to provide data directly as arrays. If this should be allowed, there
+is a function :py:func:`process_data_arguments()` to allow for this option. This
+function can either take a ``data`` argument with a mapping and the same keyword
+arguments as the :py:class:`PlotData`.
 
-.. code-block::
+.. code-block:: python
 
    from masci_tools.vis.data import process_data_arguments
 
@@ -55,40 +69,57 @@ Users might want to provide data directly as arrays. If this should be allowed, 
 
 Or you can provide the arrays directly without a ``data`` argument
 
-.. code-block::
+.. code-block:: python
 
    from masci_tools.vis.data import process_data_arguments
 
    #x,y1,y2 are the actual arrays
    plot_data = process_data_arguments(x=x, y=[y1,y2])
 
-If no ``data`` argument is given the keyword arguments are assumed to contain the data and they will be processed according to three rules:
-   1. If the data is a multidimensional array (list of lists, etc.) and it is not forbidden by the given argument the first dimension of the array is iterated over and interpreted as separate entries (if the data was previously split up into multiple sets a length check is performed)
-   2. If the data is a one-dimensional array and of a different length than the number of defined data sets it is added to all previously existing entries
-   3. If the data is a one-dimensional array and of the same length as the number of defined data sets each entry is added to the corresponding data set
+If no ``data`` argument is given the keyword arguments are assumed to contain the data
+and they will be processed according to three rules:
+
+1. If the data is a multidimensional array (list of lists, etc.) and it is not
+   forbidden by the given argument the first dimension of the array is iterated over
+   and interpreted as separate entries (if the data was previously split up into multiple
+   sets a length check is performed)
+2. If the data is a one-dimensional array and of a different length than the number
+   of defined data sets it is added to all previously existing entries
+3. If the data is a one-dimensional array and of the same length as the number of
+   defined data sets each entry is added to the corresponding data set
 
 .. note::
    List or array in this context refers to ``list``, ``np.array`` and ``pd.Series``
 
-Available routines on :py:class:`~masci_tools.vis.data.PlotData`
+Available routines on :py:class:`PlotData`
 ----------------------------------------------------------------------
 
-There are a couple of routines for mutating/copyying or getting information about the data in a :py:class:`~masci_tools.vis.data.PlotData` instance. These are not meant to be used heavily and should be used for typical simple work done for plot data processing, i.e. scaling, shifting, getting limits, ...
+There are a couple of routines for mutating/copyying or getting information about the data
+in a :py:class:`PlotData` instance. These are not meant to be used heavily and should be
+used for typical simple work done for plot data processing, i.e. scaling, shifting,
+getting limits, ...
 
 .. note::
-   The term data key in the following section refers to the keys of the keyword arguments given to :py:class:`~masci_tools.vis.data.PlotData` at initialization or the fields on the namedtuples returned by iterating over an instance
+   The term data key in the following section refers to the keys of the keyword arguments
+   given to :py:class:`PlotData` at initialization or the fields on the namedtuples
+   returned by iterating over an instance
 
-- :py:meth:`~masci_tools.vis.data.PlotData.get_keys()`: Get all the keys for a given data key in a list
-- :py:meth:`~masci_tools.vis.data.PlotData.get_values()`: Get all the values for a given data key in a list
-- :py:meth:`~masci_tools.vis.data.PlotData.min()`: Get the minimum value for a given data key. A mask can be passed to further select the data. If ``separate=True`` is passed a list of minimum values for each plot is returned
-- :py:meth:`~masci_tools.vis.data.PlotData.max()`: Get the maximum value for a given data key. A mask can be passed to further select the data. If ``separate=True`` is passed a list of maximum values for each plot is returned
-- :py:meth:`~masci_tools.vis.data.PlotData.apply()`: Apply a lambda function to transform the data of a given data key (in-place!!)
-- :py:meth:`~masci_tools.vis.data.PlotData.get_function_result()`: Apply a function to a given data key and return the results (Does not change the data)
-- :py:meth:`~masci_tools.vis.data.PlotData.sort_data()`: Sort the data by the given data keys
-- :py:meth:`~masci_tools.vis.data.PlotData.group_data()`: Group the data by the given data keys
-- :py:meth:`~masci_tools.vis.data.PlotData.shift_data()`: Shift the data of a given data key either globally or with different shifts for each plot
-- :py:meth:`~masci_tools.vis.data.PlotData.copy_data()`: Copy data to a of one data key to a new data key
-- :py:meth:`~masci_tools.vis.data.PlotData.distinct_datasets()`: Return how many different datasets exist for a given data key
+- :py:meth:`PlotData.get_keys()`: Get all the keys for a given data key in a list
+- :py:meth:`PlotData.get_values()`: Get all the values for a given data key in a list
+- :py:meth:`PlotData.min()`: Get the minimum value for a given data key. A mask can be
+  passed to further select the data. If ``separate=True`` is passed a list of minimum
+  values for each plot is returned
+- :py:meth:`PlotData.max()`: Get the maximum value for a given data key. A mask can be
+  passed to further select the data. If ``separate=True`` is passed a list of maximum
+  values for each plot is returned
+- :py:meth:`PlotData.apply()`: Apply a lambda function to transform the data of a given data key (in-place!!)
+- :py:meth:`PlotData.get_function_result()`: Apply a function to a given data key and return the results (Does not change the data)
+- :py:meth:`PlotData.sort_data()`: Sort the data by the given data keys
+- :py:meth:`PlotData.group_data()`: Group the data by the given data keys
+- :py:meth:`PlotData.shift_data()`: Shift the data of a given data key either globally or with different shifts for each plot
+- :py:meth:`PlotData.copy_data()`: Copy data to a of one data key to a new data key
+- :py:meth:`PlotData.distinct_datasets()`: Return how many different datasets exist for a given data key
 
 .. warning::
-   The methods :py:meth:`~masci_tools.vis.data.PlotData.sort_data()` and :py:meth:`~masci_tools.vis.data.PlotData.group_data()` will always convert the data sources to ``pd.DataFrame`` objects if they are not already.
+   The methods :py:meth:`PlotData.sort_data()` and :py:meth:`PlotData.group_data()` will
+   always convert the data sources to ``pd.DataFrame`` objects if they are not already.

--- a/docs/source/devel_guide/plotting.rst
+++ b/docs/source/devel_guide/plotting.rst
@@ -1,32 +1,47 @@
 .. _devguideplotting:
+.. currentmodule:: masci_tools.vis.parameters
 
-Using the :py:class:`~masci_tools.vis.parameters.Plotter` class
+Using the :py:class:`Plotter` class
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Description
 ------------
+``
+The :py:class:`Plotter` class aims to provide a framework, which can be used to
+handle default values and collect common codeblocks needed for different plotting
+frameworks. The :py:class:`Plotter` class is a base class that should be subclassed
+for different Plotting backends. See :py:class:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter`
+or :py:class:`~masci_tools.vis.bokeh_plotter.BokehPlotter` for examples.
+The subclass provides a dictionary of all the keys that should be handled by the
+plotter class. The Plotter class provides a hierarchy of overwriting these parameters
+(Higher numbers take precedence).
 
-The :py:class:`~masci_tools.vis.parameters.Plotter` class aims to provide a framework, which can be used to handle default values and collect common codeblocks needed for different plotting frameworks.
+1. Function defaults set with :py:meth:`Plotter.set_defaults()` with ``default_type='function'``
+2. Global defaults set with :py:meth:`Plotter.set_defaults()`
+3. Parameters set with :py:meth:`Plotter.set_parameters()`
 
-The :py:class:`~masci_tools.vis.parameters.Plotter` class is a base class that should be subclassed for different Plotting backends. See :py:class:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter` or :py:class:`~masci_tools.vis.bokeh_plotter.BokehPlotter` for examples. The Subclass provides a dictionary of all the keys that should be handled by the plotter class. The Plotter class provides a hierarchy of overwriting these parameters (Higher numbers take precedence).
+The subclasses should then also provide the plotting backend specific useful code snippets.
+For example showing colorbars, legends, and so on ...
 
-   1. Function defaults set with :py:meth:`~masci_tools.vis.parameters.Plotter.set_defaults()` with ``default_type='function'``
-   2. Global defaults set with :py:meth:`~masci_tools.vis.parameters.Plotter.set_defaults()`
-   3. Parameters set with :py:meth:`~masci_tools.vis.parameters.Plotter.set_parameters()`
-
-The subclasses should then also provide the plotting backend specific useful code snippets. For example showing colorbars, legends, and so on ...
-
-For a list of these functions you can look at the respective documentation (:py:class:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter` or :py:class:`~masci_tools.vis.bokeh_plotter.BokehPlotter`)
+For a list of these functions you can look at the respective documentation
+(:py:class:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter` or
+:py:class:`~masci_tools.vis.bokeh_plotter.BokehPlotter`)
 
 Writing a plotting function
 ----------------------------
 
-In the following we will go through a few examples of how to write a simple plotting function using the :py:class:`~masci_tools.vis.parameters.Plotter` class. We will be focusing on the :py:class:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter`, but all of this is very similar for other plotting backends.
+In the following we will go through a few examples of how to write a simple plotting
+function using the :py:class:`Plotter` class. We will be focusing on the
+:py:class:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter`, but all of this is
+very similar for other plotting backends.
 
 Local instance
 ^^^^^^^^^^^^^^^
 
-Even though the :py:class:`~masci_tools.vis.parameters.Plotter` class is meant to be used globally or on the module level, it can also be useful locally for simplifying simple plotting scripts. Here we have a example of a function producing a single plot with the given data for the x and y coordinates.
+Even though the :py:class:`Plotter` class is meant to be used globally or on the module
+level, it can also be useful locally for simplifying simple plotting scripts. Here we have
+a example of a function producing a single plot with the given data for the x and y
+coordinates.
 
 .. code-block:: python
 
@@ -69,12 +84,19 @@ Even though the :py:class:`~masci_tools.vis.parameters.Plotter` class is meant t
 Global/Module level instance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The local instance already gives us reusable code snippets to avoid common pitfalls when doing matplotlib/bokeh plots. But when instantiating the :py:class:`~masci_tools.vis.parameters.Plotter` class locally we have no way of letting the user modify the global defaults.
+The local instance already gives us reusable code snippets to avoid common pitfalls when
+doing matplotlib/bokeh plots. But when instantiating the :py:class:`Plotter` class locally
+we have no way of letting the user modify the global defaults.
 
-However, when handling global state we need to be careful to not leave the instance of the :py:class:`~masci_tools.vis.parameters.Plotter` class in an inconsistent state. If an error is thrown inside the plotting routine the parameters would stay set and may lead to very unexpected results. For this reason every plotting function using a global or module level instance of these plotters should be decorated with the :py:func:`~masci_tools.vis.parameters.ensure_plotter_consistency()` decorator. This does two  things:
+However, when handling global state we need to be careful to not leave the instance of
+the :py:class:`Plotter` class in an inconsistent state. If an error is thrown inside the
+plotting routine the parameters would stay set and may lead to very unexpected results.
+For this reason every plotting function using a global or module level instance of these
+plotters should be decorated with the :py:func:`ensure_plotter_consistency()` decorator.
+This does two  things:
 
-   1. If an error occurs in the decorated function the parameters will be reset before the error is raised
-   2. It makes sure that nothing inside the plotting routine changed the user defined defaults
+1. If an error occurs in the decorated function the parameters will be reset before the error is raised
+2. It makes sure that nothing inside the plotting routine changed the user defined defaults
 
 Let us take the previous example and convert it to use a global instance
 
@@ -122,15 +144,22 @@ Let us take the previous example and convert it to use a global instance
    plot_with_defaults(x, y, limits={'x': (0,1)})
    plot_with_defaults(x, y)
 
-The :py:meth:`masci_tools.vis.parameters.Plotter.set_defaults()` method is exposed in the two main modules for plotting :py:mod:`masci_tools.vis.plot_methods` :py:mod:`masci_tools.vis.bokeh_plots` as the functions :py:func:`masci_tools.vis.plot_methods.set_mpl_plot_defaults()` and  :py:func:`masci_tools.vis.bokeh_plots.set_bokeh_plot_defaults()` specific to the plotter instance that is used in these modules.
+The :py:meth:`Plotter.set_defaults()` method is exposed in the two main modules for
+plotting :py:mod:`masci_tools.vis.plot_methods` :py:mod:`masci_tools.vis.bokeh_plots` as
+the functions :py:func:`masci_tools.vis.plot_methods.set_mpl_plot_defaults()` and
+:py:func:`masci_tools.vis.bokeh_plots.set_bokeh_plot_defaults()` specific to the plotter
+instance that is used in these modules.
 
 Function defaults
 ^^^^^^^^^^^^^^^^^^
 
-Some functions may want to set function specific defaults, that make sense inside the function, but may not be useful globally. The following example sets the default ``linewidth`` for our function to ``6``.
+Some functions may want to set function specific defaults, that make sense inside the
+function, but may not be useful globally. The following example sets the default
+``linewidth`` for our function to ``6``.
 
 .. note::
-   Function defaults are also reset by the :py:func:`~masci_tools.vis.parameters.ensure_plotter_consistency()` decorator, when the plotting function terminates successfully or in an error
+   Function defaults are also reset by the :py:func:`ensure_plotter_consistency()`
+   decorator, when the plotting function terminates successfully or in an error
 
 .. code-block:: python
 
@@ -183,12 +212,21 @@ Some functions may want to set function specific defaults, that make sense insid
 Passing keyword arguments directly to plot calls
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The plotter classes have a restricted set of keys that they recognize as valid parameters. This set is of course not complete, since there is a vast number of parameters you can set for all plotting backends. In our previous examples unknown keys will immediately lead to an error in the call to :py:meth:`~masci_tools.vis.parameters.Plotter.set_parameters()`. To enable this functionality we can provide the ``continue_on_error=True`` as an argument to this method.
+The plotter classes have a restricted set of keys that they recognize as valid parameters.
+This set is of course not complete, since there is a vast number of parameters you can set
+for all plotting backends. In our previous examples unknown keys will immediately lead to
+an error in the call to :py:meth:`Plotter.set_parameters()`. To enable this functionality
+we can provide the ``continue_on_error=True`` as an argument to this method.
 
-Then the unknown keys are ignored and are returned in a dictionary. Additionally you can explicitly bypass the plotter object if you provide arguments in a dictionary with the name ``extra_kwargs`` it will be ignored, unpacked and returned along with the unknown keys
+Then the unknown keys are ignored and are returned in a dictionary. Additionally you can
+explicitly bypass the plotter object if you provide arguments in a dictionary with the
+name ``extra_kwargs`` it will be ignored, unpacked and returned along with the unknown
+keys
 
 .. warning::
-   Be careful with the this feature and especially the ``extra_kwargs``, since there is no check for name clashes with this argument. You might also run into situations, where arguments of different names collide with arguments provided by the :py:class:`~masci_tools.vis.parameters.Plotter`
+   Be careful with the this feature and especially the ``extra_kwargs``, since there is
+   no check for name clashes with this argument. You might also run into situations, where
+   arguments of different names collide with arguments provided by the :py:class:`Plotter`
 
 .. code-block:: python
 
@@ -237,15 +275,21 @@ Then the unknown keys are ignored and are returned in a dictionary. Additionally
 Multiple plotting calls
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The plotter classes also provide support for multiple plotting calls with different data sets in a single plotting function. To enable this feature we need to set two properties on the :py:class:`masci_tools.vis.parameters.Plotter`; ``single_plot`` to `False`` and ``num_plots`` to the number of plot calls made in this function. The plot specific parameters can then be specified in two ways. Shown behind the two ways is the way to set the color of the second data set to ``red``.
+The plotter classes also provide support for multiple plotting calls with different data
+sets in a single plotting function. To enable this feature we need to set two properties
+on the :py:class:`.Plotter`; ``single_plot`` to ``False`` and ``num_plots`` to the number 
+of plot calls made in this function. The plot specific parameters can then be specified
+in two ways. Shown behind the two ways is the way to set the color of the second data set
+to ``red``.
 
-   1. List of values (``None`` for unspecified values) ``[None,'red']``
-   2. Dict with integer indices for the specified values ``{1: 'red'}``
+1. List of values (``None`` for unspecified values) ``[None,'red']``
+2. Dict with integer indices for the specified values ``{1: 'red'}``
 
 Unspecified values are replaced with the previously set defaults.
 
 .. note::
-   The ``num_plots`` and ``single_plot`` properties are also reset by the :py:func:`~masci_tools.vis.parameters.ensure_plotter_consistency()`
+   The ``num_plots`` and ``single_plot`` properties are also reset by the
+   :py:func:`ensure_plotter_consistency()`
 
 .. code-block:: python
 
@@ -303,14 +347,23 @@ Unspecified values are replaced with the previously set defaults.
 Custom function specific parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You might have situations, where you want to have some function specific parameters, that should pull from the previously set defaults or even a custom default value.
+You might have situations, where you want to have some function specific parameters,
+that should pull from the previously set defaults or even a custom default value.
 
-The :py:meth:`~masci_tools.vis.parameters.Plotter.add_parameter()` method is implemented exactly for this purpose. It creates a new key to be handled by the plotter class and with the arguments ``default_from`` or ``default_value`` we can specify what the defaults should be. ``default_value`` sets a specific value, ``default_from`` specifies a key from the plotter class from which to take the default value.
+The :py:meth:`Plotter.add_parameter()` method is implemented exactly for this purpose.
+It creates a new key to be handled by the plotter class and with the arguments
+``default_from`` or ``default_value`` we can specify what the defaults should be.
+``default_value`` sets a specific value, ``default_from`` specifies a key from the
+plotter class from which to take the default value.
 
-The :py:meth:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter.plot_kwargs()` method then can take keyword arguments to replace the arguments to take with your custom parameters
+The :py:meth:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter.plot_kwargs()` method
+then can take keyword arguments to replace the arguments to take with your custom
+parameters
 
 .. note::
-   These added parameters live on the function defaults and parameters level, meaning they will be removed by the :py:func:`~masci_tools.vis.parameters.ensure_plotter_consistency()` decorator after the function finishes
+   These added parameters live on the function defaults and parameters level, meaning
+   they will be removed by the :py:func:`ensure_plotter_consistency()` decorator after
+   the function finishes
 
 .. code-block:: python
 
@@ -367,9 +420,18 @@ The :py:meth:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter.plot_kwargs(
 Nested plotting functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-More complex plotting routines might want to call other plotting routines to simplify their structure. However, this has a side-effect when working with the :py:class:`~masci_tools.vis.parameters.Plotter` class and the :py:func:`~masci_tools.vis.parameters.ensure_plotter_consistency()` decorator. Since the decorator resets the parameters and function defaults after a plotting function has been called you lose everything that you might have modified in the enclosing plotting function.
+More complex plotting routines might want to call other plotting routines to simplify their
+structure. However, this has a side-effect when working with the :py:class:`Plotter`
+class and the :py:func:`ensure_plotter_consistency()` decorator. Since the decorator
+resets the parameters and function defaults after a plotting function has been called
+you lose everything that you might have modified in the enclosing plotting function.
 
-If you do need access to these parameters after calling a nested plotting function the :py:func:`~masci_tools.vis.parameters.NestedPlotParameters()` contextmanager is implemented. It defines a local scope, in which a plotting function can change the parameters and function defaults. After exiting the local scope the parameters and function defaults are always in the same state as when the ``with`` block was entered (Even if an error is raised). The nested plotting function will also start with the state that was set before.
+If you do need access to these parameters after calling a nested plotting function
+the :py:func:`NestedPlotParameters()` contextmanager is implemented. It defines a
+local scope, in which a plotting function can change the parameters and function defaults.
+After exiting the local scope the parameters and function defaults are always in the same
+state as when the ``with`` block was entered (Even if an error is raised). The nested
+plotting function will also start with the state that was set before.
 
 Usage is shown here:
 

--- a/docs/source/devel_guide/plotting.rst
+++ b/docs/source/devel_guide/plotting.rst
@@ -6,7 +6,7 @@ Using the :py:class:`Plotter` class
 
 Description
 ------------
-``
+
 The :py:class:`Plotter` class aims to provide a framework, which can be used to
 handle default values and collect common codeblocks needed for different plotting
 frameworks. The :py:class:`Plotter` class is a base class that should be subclassed

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,3 @@
-.. fleur_fleur documentation master file, created by
-   sphinx-quickstart on Wed Aug 10 10:20:55 2016.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to the `Masci-tools`_'s documentation!
 ##############################################
 
@@ -16,7 +11,8 @@ Welcome to the `Masci-tools`_'s documentation!
 .. _juDFT: http://judft.de
 
 This package was developed in the process of developing the `AiiDA-FLEUR`_ and `AiiDA_KKR`_ plugins to `AiiDA`_.
-It contains helper functions that can help with common pre- and postprocessing steps of the `FLEUR`_ and `KKR`_ codes developed at the Forschungszentrum Jülich (see also the `juDFT`_ website for more information).
+It contains helper functions that can help with common pre- and postprocessing steps of the `FLEUR`_ and `KKR`_ codes
+developed at the Forschungszentrum Jülich (see also the `juDFT`_ website for more information).
 
 If you use this package please cite: ...
 
@@ -24,27 +20,39 @@ If you use this package please cite: ...
 Requirements to use this code:
 ------------------------------
 
-* lxml
-* h5py
-* ase
-* pymatgen
-* numpy
-* scipy
-* more_itertools
+* ``lxml``
+* ``h5py``
+* ``numpy``
+* ``matplotlib``
+* ``bokeh`` (optional)
+* ``seaborn``
+* ``ase``
+* ``mendeleev``
+* ``click``
+* ``click-completion``
+* ``PyYAML``
+* ``tabulate``
+* ``deepdiff``
+* ``humanfriendly``
+* ``more_itertools``
 
 Installation Instructions:
 --------------------------
 
-Install from pypi the latest release::
+Install from pypi the latest release
 
-    $ pip install masci-tools
+.. code-block:: bash
+
+   pip install masci-tools
 
 
-or from the masci-tools source folder any branch::
+or from the masci-tools source folder any branch
 
-    $ pip install .
-    # or which is very useful to keep track of the changes (developers)
-    $ pip install -e . 
+.. code-block:: bash
+
+   pip install .
+   # or which is very useful to keep track of the changes (developers)
+   pip install -e . 
 
 Acknowledgments:
 ----------------

--- a/docs/source/user_guide/fleur_parser.rst
+++ b/docs/source/user_guide/fleur_parser.rst
@@ -6,12 +6,17 @@ Using the Fleur input/output parsers
 
 .. contents::
 
+.. currentmodule:: masci_tools.io.parsers.fleur
+
 Parser for the Fleur inp.xml file
 ----------------------------------
 
-The fleur ```inp.xml``` contains all the information about the setup of a fleur calculation. To use this information in external scripts or aiida-fleur, the information needs to be parsed from the ```.xml``` format somehow.
+The fleur `inp.xml` contains all the information about the setup of a fleur calculation.
+To use this information in external scripts or aiida-fleur, the information needs to be
+parsed from the `.xml` format somehow.
 
-For this purpose the :py:func:`~masci_tools.io.parsers.fleur.inpxml_parser()` is implemented. The usage is shown below. The input file is parsed recursively and all information is put into the dictionary.
+For this purpose the :py:func:`inpxml_parser()` is implemented. The usage is shown below.
+The input file is parsed recursively and all information is put into the dictionary.
 
 .. code-block:: python
 
@@ -23,7 +28,9 @@ For this purpose the :py:func:`~masci_tools.io.parsers.fleur.inpxml_parser()` is
    warnings = {'parser_warnings': []}
    input_dict = inpxml_parser('/path/to/random/inp.xml', parser_info_out=warnings)
 
-The conversion of each attribute or text is done according to the FleurInputSchema for the same version, which is stored in this repository for versions from ```0.27``` to ```0.34```. The following table shows the version compatibility of the input parser.
+The conversion of each attribute or text is done according to the FleurInputSchema for the
+same version, which is stored in this repository for versions from `0.27` to `0.35`. 
+The following table shows the version compatibility of the input parser.
 
 +------------------+------------------------------------------------------------------------------+
 | File version     | Compatible?                                                                  |
@@ -37,7 +44,9 @@ The conversion of each attribute or text is done according to the FleurInputSche
 Parser for the Fleur out.xml file
 ----------------------------------
 
-For the ```out.xml``` file a similar parser is implemented. However, since the output file contains a lot more information, which is not always useful the :py:func:`~masci_tools.io.parsers.fleur.outxml_parser()` is defined a lot more selectively. But the usage is almost completely identical to the input file.
+For the `out.xml` file a similar parser is implemented. However, since the output file
+contains a lot more information, which is not always useful the :py:func:`outxml_parser()`
+is defined a lot more selectively. But the usage is almost completely identical to the input file.
 
 .. code-block:: python
 
@@ -56,9 +65,13 @@ For the ```out.xml``` file a similar parser is implemented. However, since the o
    warnings = {'parser_warnings': []}
    output_dict = outxml_parser('/path/to/random/out.xml', parser_info_out=warnings)
 
-For each iteration the parser decides based on the type of fleur calculation, what things should be parsed. For a more detailed explanation refer to the :doc:`../../devel_guide/index`.
+For each iteration the parser decides based on the type of fleur calculation,
+what things should be parsed. For a more detailed explanation refer to the 
+:doc:`../../devel_guide/index`.
 
-The following table shows the version compatibility of the output parser. For versions before `0.34` the file version corresponds to the input version, since the output version is `0.27` for all versions before this point.
+The following table shows the version compatibility of the output parser.
+For versions before `0.34` the file version corresponds to the input version,
+since the output version is `0.27` for all versions before this point.
 
 +------------------+-----------------------------------------------------------------------------------------------------+
 | File version     | Compatible?                                                                                         |
@@ -78,7 +91,7 @@ The following table shows the version compatibility of the output parser. For ve
 
 .. note:: Using File handles
 
-   Both the :py:func:`~masci_tools.io.parsers.fleur.inpxml_parser()` and :py:func:`~masci_tools.io.parsers.fleur.outxml_parser()`
+   Both the :py:func:`inpxml_parser()` and :py:func:`outxml_parser()`
    can also be used with file handles like shown below.
 
    .. code-block::python
@@ -93,18 +106,27 @@ The following table shows the version compatibility of the output parser. For ve
 XML getter functions
 ---------------------
 
-There are a number of functions for extracting specific parts of the XML files in the :py:mod:`~masci_tools.util.xml.xml_getters` module. The following are available:
+There are a number of functions for extracting specific parts of the XML files
+in the :py:mod:`~masci_tools.util.xml.xml_getters` module. The following are available:
 
-   * :py:func:`~masci_tools.util.xml.xml_getters.get_fleur_modes()`: Get information about the mode of the fleur calculation
-   * :py:func:`~masci_tools.util.xml.xml_getters.get_nkpts()`: Get the (for older versions approximate if not `kPointList` is used) number of kpoints to be used in the calculation
-   * :py:func:`~masci_tools.util.xml.xml_getters.get_cell()`: Get the Bravais matrix of the system
-   * :py:func:`~masci_tools.util.xml.xml_getters.get_parameter_data()`: Get the information about the calculation parameters needed to reproduce a calculation starting from the inpgen
-   * :py:func:`~masci_tools.util.xml.xml_getters.get_structure_data()`: Get the structure from the xml file (atom positions + unit cell)
-   * :py:func:`~masci_tools.util.xml.xml_getters.get_kpoints_data()`: Get the defined kpoint sets (single/multiple) from the xml file (kpoints + weights + unit cell)
-   * :py:func:`~masci_tools.util.xml.xml_getters.get_relaxation_information()`: Get the relaxation history and current displacements
-   * :py:func:`~masci_tools.util.xml.xml_getters.get_symmetry_information()`: Get the symmetry operations used in the calculation
+.. currentmodule:: masci_tools.util.xml.xml_getters
 
-All of these are used in the same way::
+* :py:func:`get_fleur_modes()`: Get information about the mode of the fleur calculation
+* :py:func:`get_nkpts()`: Get the (for older versions approximate if not `kPointList` is
+  used) number of kpoints to be used in the calculation
+* :py:func:`get_cell()`: Get the Bravais matrix of the system
+* :py:func:`get_parameter_data()`: Get the information about the calculation parameters
+  needed to reproduce a calculation starting from the inpgen
+* :py:func:`get_structure_data()`: Get the structure from the xml file 
+  (atom positions + unit cell)
+* :py:func:`get_kpoints_data()`: Get the defined kpoint sets (single/multiple) 
+  from the xml file (kpoints + weights + unit cell)
+* :py:func:`get_relaxation_information()`: Get the relaxation history and current displacements
+* :py:func:`get_symmetry_information()`: Get the symmetry operations used in the calculation
+
+All of these are used in the same way
+
+.. code-block:: python
 
    from masci_tools.io.fleur_xml import load_inpxml
    from masci_tools.util.xml.xml_getters import get_fleur_modes
@@ -117,7 +139,11 @@ All of these are used in the same way::
 Using the :py:mod:`~masci_tools.util.schema_dict_util` functions
 -----------------------------------------------------------------
 
-If only a small amount of information is required from the input or output files of fleur the full parsers might be overkill. But there are a number of utility functions allowing easy access to information from the ```.xml``` files without knowing the exact xpath expressions for each version of the input/output. A code example extracting information from a input file is given below.
+If only a small amount of information is required from the input or output files
+of fleur the full parsers might be overkill. But there are a number of utility
+functions allowing easy access to information from the `.xml` files without knowing
+the exact XPath expressions for each version of the input/output. A code example extracting
+information from a input file is given below.
 
 .. code-block:: python
 

--- a/docs/source/user_guide/fleur_parser.rst
+++ b/docs/source/user_guide/fleur_parser.rst
@@ -11,9 +11,9 @@ Using the Fleur input/output parsers
 Parser for the Fleur inp.xml file
 ----------------------------------
 
-The fleur `inp.xml` contains all the information about the setup of a fleur calculation.
+The fleur ``inp.xml`` contains all the information about the setup of a fleur calculation.
 To use this information in external scripts or aiida-fleur, the information needs to be
-parsed from the `.xml` format somehow.
+parsed from the ``.xml`` format somehow.
 
 For this purpose the :py:func:`inpxml_parser()` is implemented. The usage is shown below.
 The input file is parsed recursively and all information is put into the dictionary.
@@ -29,7 +29,7 @@ The input file is parsed recursively and all information is put into the diction
    input_dict = inpxml_parser('/path/to/random/inp.xml', parser_info_out=warnings)
 
 The conversion of each attribute or text is done according to the FleurInputSchema for the
-same version, which is stored in this repository for versions from `0.27` to `0.35`. 
+same version, which is stored in this repository for versions from ``0.27`` to ``0.35``. 
 The following table shows the version compatibility of the input parser.
 
 +------------------+------------------------------------------------------------------------------+
@@ -44,7 +44,7 @@ The following table shows the version compatibility of the input parser.
 Parser for the Fleur out.xml file
 ----------------------------------
 
-For the `out.xml` file a similar parser is implemented. However, since the output file
+For the ``out.xml`` file a similar parser is implemented. However, since the output file
 contains a lot more information, which is not always useful the :py:func:`outxml_parser()`
 is defined a lot more selectively. But the usage is almost completely identical to the input file.
 
@@ -70,8 +70,8 @@ what things should be parsed. For a more detailed explanation refer to the
 :doc:`../../devel_guide/index`.
 
 The following table shows the version compatibility of the output parser.
-For versions before `0.34` the file version corresponds to the input version,
-since the output version is `0.27` for all versions before this point.
+For versions before ``0.34`` the file version corresponds to the input version,
+since the output version is ``0.27`` for all versions before this point.
 
 +------------------+-----------------------------------------------------------------------------------------------------+
 | File version     | Compatible?                                                                                         |
@@ -141,7 +141,7 @@ Using the :py:mod:`~masci_tools.util.schema_dict_util` functions
 
 If only a small amount of information is required from the input or output files
 of fleur the full parsers might be overkill. But there are a number of utility
-functions allowing easy access to information from the `.xml` files without knowing
+functions allowing easy access to information from the ``.xml`` files without knowing
 the exact XPath expressions for each version of the input/output. A code example extracting
 information from a input file is given below.
 

--- a/docs/source/user_guide/fleur_parser.rst
+++ b/docs/source/user_guide/fleur_parser.rst
@@ -67,7 +67,7 @@ is defined a lot more selectively. But the usage is almost completely identical 
 
 For each iteration the parser decides based on the type of fleur calculation,
 what things should be parsed. For a more detailed explanation refer to the 
-:doc:`../../devel_guide/index`.
+:ref:`devguidefleurxml`.
 
 The following table shows the version compatibility of the output parser.
 For versions before ``0.34`` the file version corresponds to the input version,

--- a/docs/source/user_guide/fleur_plots.rst
+++ b/docs/source/user_guide/fleur_plots.rst
@@ -38,7 +38,7 @@ Compatible Recipes for the :py:class:`reader.HDF5Reader`:
 * ``FleurSimpleBands``: Reads in only the kpoints and eigenvalues and now weights
 * ``FleurOrbcompBands``: In addition to the eigenvalues the weights from an orbital decomposition calculation are read in
 * ``FleurjDOSBands``: In addition to the eigenvalues the weights from a jDOS calculation are read in
-* ``FleurMCDBands`: In addition to the eigenvalues the weights from a MCD calculation are read in
+* ``FleurMCDBands``: In addition to the eigenvalues the weights from a MCD calculation are read in
 * :py:func:`recipes.get_fleur_bands_specific_weights()`: Function to generate a recipe for reading in the eigenvalues+a provided list of weights
 
 .. currentmodule:: masci_tools.vis.fleur

--- a/docs/source/user_guide/fleur_plots.rst
+++ b/docs/source/user_guide/fleur_plots.rst
@@ -3,7 +3,7 @@ Plotting Fleur DOS/bandstructures
 
 .. currentmodule:: masci_tools.io.parsers.hdf5
 
-This section discusses how to obtain plots of data in the `banddos.hdf` for
+This section discusses how to obtain plots of data in the ``banddos.hdf`` for
 density of states and bandstructure calculations.
 
 The process here is divided in two parts. First we extract and transform the data in a
@@ -34,11 +34,11 @@ Bandstructures
 
 Compatible Recipes for the :py:class:`reader.HDF5Reader`:
 
-* `FleurBands`: Default recipe reading in the kpoints, eignevalues and weights for atom and orbital contributions
-* `FleurSimpleBands`: Reads in only the kpoints and eigenvalues and now weights
-* `FleurOrbcompBands`: In addition to the eigenvalues the weights from an orbital decomposition calculation are read in
-* `FleurjDOSBands`: In addition to the eigenvalues the weights from a jDOS calculation are read in
-* `FleurMCDBands`: In addition to the eigenvalues the weights from a MCD calculation are read in
+* ``FleurBands``: Default recipe reading in the kpoints, eignevalues and weights for atom and orbital contributions
+* ``FleurSimpleBands``: Reads in only the kpoints and eigenvalues and now weights
+* ``FleurOrbcompBands``: In addition to the eigenvalues the weights from an orbital decomposition calculation are read in
+* ``FleurjDOSBands``: In addition to the eigenvalues the weights from a jDOS calculation are read in
+* ``FleurMCDBands`: In addition to the eigenvalues the weights from a MCD calculation are read in
 * :py:func:`recipes.get_fleur_bands_specific_weights()`: Function to generate a recipe for reading in the eigenvalues+a provided list of weights
 
 .. currentmodule:: masci_tools.vis.fleur
@@ -95,8 +95,8 @@ Bandstructure with weights
 
 To plot a simple bandstructure with weighting we do the same procedure as above, but we
 pass in the entry we want to use for weights. These correspond to the entries in the
-`banddos.hdf` file (for example the weight for the s-orbital on the first atom type is
-called `MT:1s`). The weights will be used to change the size and color (according to a colormap) to
+``banddos.hdf`` file (for example the weight for the s-orbital on the first atom type is
+called ``MT:1s``). The weights will be used to change the size and color (according to a colormap) to
 indicate regions of high weight.
 
 The two examples below show the resulting plots for a non-psinpolarized system (bulk Si)
@@ -140,10 +140,10 @@ Density of States
 
 Compatible Recipes for the :py:class:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader`:
 
-* `FleurDOS`: Default recipe reading in the total, interstitial, vacuum, atom and l-channle resolved DOS
-* `FleurORBCOMP`: Read in the DOS from an orbital decomposition calculation
-* `FleurJDOS`: Read in the DOS from a jDOS calculation
-* `FleurMCD`: Read in the DOS from a MCD calculation
+* ``FleurDOS``: Default recipe reading in the total, interstitial, vacuum, atom and l-channle resolved DOS
+* ``FleurORBCOMP```: Read in the DOS from an orbital decomposition calculation
+* ``FleurJDOS``: Read in the DOS from a jDOS calculation
+* ``FleurMCD``: Read in the DOS from a MCD calculation
 
 The dos visualization :py:func:`plot_fleur_dos()` can be used to plot
 non spinpolarized and spinpolarized DOS, with selection of which components to plot.
@@ -184,7 +184,7 @@ Plotting options for DOS plots
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :py:func:`plot_fleur_dos()` function has a couple of options to modify, what is being
-displayed from the `banddos.hdf` file. Below we show a few examples of ways to use these
+displayed from the ``banddos.hdf`` file. Below we show a few examples of ways to use these
 options, together with examples of resulting plots.
 
 DOS with atom components scaled with equivalent atoms
@@ -192,11 +192,11 @@ DOS with atom components scaled with equivalent atoms
 
 When you look at the example plot for the non spin-polarized DOS, you might notice that the
 interstitial component and the atom projected components do not add up to the total density
-of states. This system has two symmetry equivalent `Si` atoms. By default the atom projected
+of states. This system has two symmetry equivalent ``Si`` atoms. By default the atom projected
 density of states corresponds to only one of these atoms.
 
 If you wish to show the atom projected components of the DOS scaled with the number of
-symmetry equivalent atoms you can provide the option `multiply_by_equiv_atoms=True` option
+symmetry equivalent atoms you can provide the option ``multiply_by_equiv_atoms=True`` option
 to the plotting function.
 
 .. code-block:: python
@@ -215,16 +215,16 @@ The DOS is made up of a lot of contributions that can be displayed separately.
 Here we list the options that are available and show example plots for only selecting
 the atom projected compinents of the density of states
 
-- `plot_keys`: Can be used to provide a explicit list of keys you want to display (Same format as in the `banddos.hdf`)
-- `show_total`: Control, whether to show the total density of states (default `True`)
-- `show_interstitial`: Control, whether to show the interstitial contribution of the density of states (default `True`)
-- `show_atoms`: Control, which total atom projected DOS to show. Can be either the string
-  `all` (All components are shown), the value `None` (no components are shown) or a list
-  of the integer indices of the atom types that should be displayed (default `all`)
-- `show_lresolved`: Control, on which atoms to show the orbital projected DOS. Can be
-  either the string `all` (All components are shown), the value `None`
+- ``plot_keys``: Can be used to provide a explicit list of keys you want to display (Same format as in the ``banddos.hdf``)
+- ``show_total``: Control, whether to show the total density of states (default ``True``)
+- ``show_interstitial``: Control, whether to show the interstitial contribution of the density of states (default ``True``)
+- ``show_atoms``: Control, which total atom projected DOS to show. Can be either the string
+  ``all`` (All components are shown), the value ``None`` (no components are shown) or a list
+  of the integer indices of the atom types that should be displayed (default ``all``)
+- ``show_lresolved``: Control, on which atoms to show the orbital projected DOS. Can be
+  either the string ``all`` (All components are shown), the value ``None``
   (no components are shown) or a list of the integer indices of the atom types for
-  which to display the orbital components (default `None`)
+  which to display the orbital components (default ``None``)
 
 Below an example of only displaying the atom projected DOS together with their orbital contributions is shown.
 

--- a/docs/source/user_guide/fleur_plots.rst
+++ b/docs/source/user_guide/fleur_plots.rst
@@ -1,9 +1,15 @@
 Plotting Fleur DOS/bandstructures
 ++++++++++++++++++++++++++++++++++
 
-This section discusses how to obtain plots of data in the ``banddos.hdf`` for density of states and bandstructure calculations.
+.. currentmodule:: masci_tools.io.parsers.hdf5
 
-The process here is divided in two parts. First we extract and transform the data in a way to make it easy to plot via the :py:class:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader`. For a detailed explanation of the capabilities of this tool refer to :ref:`hdf5_parser`. Here we show the basic usage:
+This section discusses how to obtain plots of data in the `banddos.hdf` for
+density of states and bandstructure calculations.
+
+The process here is divided in two parts. First we extract and transform the data in a
+way to make it easy to plot via the :py:class:`reader.HDF5Reader`. For a detailed
+explanation of the capabilities of this tool refer to :ref:`hdf5_parser`.
+Here we show the basic usage:
 
 .. code-block:: python
 
@@ -15,33 +21,44 @@ The process here is divided in two parts. First we extract and transform the dat
    with HDF5Reader('/path/to/banddos.hdf') as h5reader:
       data, attributes = h5reader.read(recipe=FleurBands)
 
-In the following bandstructure and DOS plots are explained. Each section leads with the names of the recipes from the :py:mod:`~masci_tools.io.parsers.hdf5.recipes` module that can be used with the explained visualization function.
+In the following bandstructure and DOS plots are explained. Each section leads with the
+names of the recipes from the :py:mod:`~masci_tools.io.parsers.hdf5.recipes` module that
+can be used with the explained visualization function.
 
-All Fleur specific plotting routines are found in :py:mod:`~masci_tools.vis.fleur` have implementations for both the matplotlib and bokeh plotting libraries and can be customized heavily. For an explanation on customizing plots refer to :ref:`plotting`.
+All Fleur specific plotting routines are found in :py:mod:`~masci_tools.vis.fleur` have
+implementations for both the matplotlib and bokeh plotting libraries and can be customized
+heavily. For an explanation on customizing plots refer to :ref:`plotting`.
 
 Bandstructures
 ---------------
 
-Compatible Recipes for the :py:class:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader`:
+Compatible Recipes for the :py:class:`reader.HDF5Reader`:
 
-   * ``FleurBands``: Default recipe reading in the kpoints, eignevalues and weights for atom and orbital contributions
-   * ``FleurSimpleBands``: Reads in only the kpoints and eigenvalues and now weights
-   * ``FleurOrbcompBands``: In addition to the eigenvalues the weights from an orbital decomposition calculation are read in
-   * ``FleurjDOSBands``: In addition to the eigenvalues the weights from a jDOS calculation are read in
-   * ``FleurMCDBands``: In addition to the eigenvalues the weights from a MCD calculation are read in
-   * :py:func:`~masci_tools.io.parsers.hdf5.recipes.get_fleur_bands_specific_weights()`: Function to generate a recipe for reading in the eigenvalues+a provided list of weights
+* `FleurBands`: Default recipe reading in the kpoints, eignevalues and weights for atom and orbital contributions
+* `FleurSimpleBands`: Reads in only the kpoints and eigenvalues and now weights
+* `FleurOrbcompBands`: In addition to the eigenvalues the weights from an orbital decomposition calculation are read in
+* `FleurjDOSBands`: In addition to the eigenvalues the weights from a jDOS calculation are read in
+* `FleurMCDBands`: In addition to the eigenvalues the weights from a MCD calculation are read in
+* :py:func:`recipes.get_fleur_bands_specific_weights()`: Function to generate a recipe for reading in the eigenvalues+a provided list of weights
 
-The bandstructure visualization :py:func:`~masci_tools.vis.fleur.plot_fleur_bands()` can be used to plot
+.. currentmodule:: masci_tools.vis.fleur
 
-   1. Non-spinpolarized/spinpolarized bandstructures
-   2. Bandstructures with emphasized weights on all eigenvalues (Also non-spinpolarized and spinpolarized)
+The bandstructure visualization :py:func:`plot_fleur_bands()` can be used to plot
+
+1. Non-spinpolarized/spinpolarized bandstructures
+2. Bandstructures with emphasized weights on all eigenvalues (Also non-spinpolarized and spinpolarized)
 
 Standard bandstructure
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-To plot a simple bandstructure without any weighting we just have to pass the data, that the :py:class:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader` provided to the :py:func:`~masci_tools.vis.fleur.plot_fleur_bands()`
+To plot a simple bandstructure without any weighting we just have to pass the data, that
+the :py:class:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader` provided to the
+:py:func:`plot_fleur_bands()`.
 
-The two examples below show the resulting plots for a non-psinpolarized system (bulk Si) and a spin-polarized system (Fe fcc). For both systems the necessary code is exactly the same and is shown above the plots. The shown plots are the ones for the matplotlib plotting backend:
+The two examples below show the resulting plots for a non-psinpolarized system (bulk Si)
+and a spin-polarized system (Fe fcc). For both systems the necessary code is exactly the
+same and is shown above the plots. The shown plots are the ones for the matplotlib plotting
+backend:
 
 .. code-block:: python
 
@@ -76,11 +93,17 @@ Spinpolarized bandstructure
 Bandstructure with weights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To plot a simple bandstructure with weighting we do the same procedure as above, but we pass in the entry we want to use for weights. These correspond to the entries in the ``banddos.hdf`` file (for example the weight for the s-orbital on the first atom type is called ``MT:1s``)
+To plot a simple bandstructure with weighting we do the same procedure as above, but we
+pass in the entry we want to use for weights. These correspond to the entries in the
+`banddos.hdf` file (for example the weight for the s-orbital on the first atom type is
+called `MT:1s`). The weights will be used to change the size and color (according to a colormap) to
+indicate regions of high weight.
 
-The weights will be used to change the size and color (according to a colormap) to indicate regions of high weight.
-
-The two examples below show the resulting plots for a non-psinpolarized system (bulk Si) weighted for the s-orbital on the first atom and a spin-polarized system (Fe fcc) with weights for the d-orbital on the first atom type. For both systems the necessary code is exactly the same and is shown above the plots. The shown plots are the ones for the matplotlib plotting backend:
+The two examples below show the resulting plots for a non-psinpolarized system (bulk Si)
+weighted for the s-orbital on the first atom and a spin-polarized system (Fe fcc) with
+weights for the d-orbital on the first atom type. For both systems the necessary code
+is exactly the same and is shown above the plots. The shown plots are the ones for the
+matplotlib plotting backend:
 
 .. code-block:: python
 
@@ -117,12 +140,12 @@ Density of States
 
 Compatible Recipes for the :py:class:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader`:
 
-   * ``FleurDOS``: Default recipe reading in the total, interstitial, vacuum, atom and l-channle resolved DOS
-   * ``FleurORBCOMP``: Read in the DOS from an orbital decomposition calculation
-   * ``FleurJDOS``: Read in the DOS from a jDOS calculation
-   * ``FleurMCD``: Read in the DOS from a MCD calculation
+* `FleurDOS`: Default recipe reading in the total, interstitial, vacuum, atom and l-channle resolved DOS
+* `FleurORBCOMP`: Read in the DOS from an orbital decomposition calculation
+* `FleurJDOS`: Read in the DOS from a jDOS calculation
+* `FleurMCD`: Read in the DOS from a MCD calculation
 
-The dos visualization :py:func:`~masci_tools.vis.fleur.plot_fleur_dos()` can be used to plot
+The dos visualization :py:func:`plot_fleur_dos()` can be used to plot
 non spinpolarized and spinpolarized DOS, with selection of which components to plot.
 
 Standard density of states plot
@@ -160,14 +183,21 @@ Spinpolarized DOS
 Plotting options for DOS plots
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:func:`~masci_tools.vis.fleur.plot_fleur_dos()` function has a couple of options to modify, what is being displayed from the ``banddos.hdf`` file. Below we show a few examples of ways to use these options, together with examples of resulting plots.
+The :py:func:`plot_fleur_dos()` function has a couple of options to modify, what is being
+displayed from the `banddos.hdf` file. Below we show a few examples of ways to use these
+options, together with examples of resulting plots.
 
 DOS with atom components scaled with equivalent atoms
 """"""""""""""""""""""""""""""""""""""""""""""""""""""
 
-When you look at the example plot for the non spin-polarized DOS, you might notice that the interstitial component and the atom projected components do not add up to the total density of states. This system has two symmetry equivalent `Si` atoms. By default the atom projected density of states corresponds to only one of these atoms.
+When you look at the example plot for the non spin-polarized DOS, you might notice that the
+interstitial component and the atom projected components do not add up to the total density
+of states. This system has two symmetry equivalent `Si` atoms. By default the atom projected
+density of states corresponds to only one of these atoms.
 
-If you wish to show the atom projected components of the DOS scaled with the number of symmetry equivalent atoms you can provide the option ``multiply_by_equiv_atoms=True`` option to the plotting function.
+If you wish to show the atom projected components of the DOS scaled with the number of
+symmetry equivalent atoms you can provide the option `multiply_by_equiv_atoms=True` option
+to the plotting function.
 
 .. code-block:: python
 
@@ -182,13 +212,19 @@ Selecting specific DOS components
 
 The DOS is made up of a lot of contributions that can be displayed separately.
 
-Here we list the options that are available and show example plots for only selecting the atom projected compinents of the density of states
+Here we list the options that are available and show example plots for only selecting
+the atom projected compinents of the density of states
 
-   - :plot_keys: Can be used to provide a explicit list of keys you want to display (Same format as in the ``banddos.hdf``)
-   - :show_total: Control, whether to show the total density of states (default ``True``)
-   - :show_interstitial: Control, whether to show the interstitial contribution of the density of states (default ``True``)
-   - :show_atoms: Control, which total atom projected DOS to show. Can be either the string ``all`` (All components are shown), the value ``None`` (no components are shown) or a list of the integer indices of the atom types that should be displayed (default ``all``)
-   - :show_lresolved: Control, on which atoms to show the orbital projected DOS. Can be either the string ``all`` (All components are shown), the value ``None`` (no components are shown) or a list of the integer indices of the atom types for which to display the orbital components (default ``None``)
+- `plot_keys`: Can be used to provide a explicit list of keys you want to display (Same format as in the `banddos.hdf`)
+- `show_total`: Control, whether to show the total density of states (default `True`)
+- `show_interstitial`: Control, whether to show the interstitial contribution of the density of states (default `True`)
+- `show_atoms`: Control, which total atom projected DOS to show. Can be either the string
+  `all` (All components are shown), the value `None` (no components are shown) or a list
+  of the integer indices of the atom types that should be displayed (default `all`)
+- `show_lresolved`: Control, on which atoms to show the orbital projected DOS. Can be
+  either the string `all` (All components are shown), the value `None`
+  (no components are shown) or a list of the integer indices of the atom types for
+  which to display the orbital components (default `None`)
 
 Below an example of only displaying the atom projected DOS together with their orbital contributions is shown.
 

--- a/docs/source/user_guide/fleurxmlmodifier.rst
+++ b/docs/source/user_guide/fleurxmlmodifier.rst
@@ -3,22 +3,20 @@
 FleurXMLModifier
 +++++++++++++++++
 
+.. currentmodule:: masci_tools.io.fleurxmlmodifier
+
 Description
 -----------
-The :py:class:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier` class can be
-used if you want to change anything in a `inp.xml` file in an easy and robust way.
-It will validate all the changes you wish to do and apply all these changes to a given
-`inp.xml` and produce a new xmltree.
+The :py:class:`FleurXMLModifier` class can be used if you want to change anything in a
+`inp.xml` file in an easy and robust way. It will validate all the changes you wish
+to do and apply all these changes to a given `inp.xml` and produce a new XML tree.
 
 Usage
 ------
-To modify an existing `inp.xml`, a
-:py:class:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier` instance
-has to be initialised.
-After that, a user should register
-certain modifications which will be cached. They will be applied on
-a given `inp.xml`. However, the provided `inp.xml` will not be changed but only
-a modified xmltree is returned, which you can store in a new `.xml` file.
+To modify an existing `inp.xml`, a :py:class:`FleurXMLModifier` instance has to be initialised.
+After that, a user should register certain modifications which will be cached. 
+They will be applied on a given `inp.xml`. However, the provided `inp.xml` will not be
+changed but only a modified XML tree is returned, which you can store in a new `.xml` file.
 
 .. code-block:: python
 
@@ -34,71 +32,71 @@ User Methods
 General methods
 _______________
 
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.modify_xmlfile()`: Applies the registered changes to a given `inp.xml` (and optional `n_mmp_mat` file)
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.changes()`: Displays the
-      current list of changes.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.undo()`: Removes the
-      last task or all tasks from the list of changes.
+* :py:meth:`FleurXMLModifier.modify_xmlfile()`: Applies the registered changes to a
+  given `inp.xml` (and optional `n_mmp_mat` file)
+* :py:meth:`FleurXMLModifier.changes()`: Displays the current list of changes.
+* :py:meth:`FleurXMLModifier.undo()`: Removes the
+  last task or all tasks from the list of changes.
 
 .. _modify_methods:
 
 Modification registration methods
 _________________________________
 The registration methods can be separated into two groups. First of all,
-there are XML methods that require deeper knowledge about the structure of an ``inp.xml`` file.
+there are XML methods that require deeper knowledge about the structure of an `inp.xml` file.
 All of them require an xpath input and start their method names start with `xml_`:
 
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.xml_set_attrib_value_no_create()`: Set attributes on the result(s) of the given xpath
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.xml_set_text_no_create()`: Set text on the result(s) of the given xpath
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.xml_create_tag()`: Insert
+    * :py:meth:`FleurXMLModifier.xml_set_attrib_value_no_create()`: Set attributes on the result(s) of the given xpath
+    * :py:meth:`FleurXMLModifier.xml_set_text_no_create()`: Set text on the result(s) of the given xpath
+    * :py:meth:`FleurXMLModifier.xml_create_tag()`: Insert
       an xml element in the xml tree on the result(s) of the given xpath.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.xml_delete_tag()`: Delete
+    * :py:meth:`FleurXMLModifier.xml_delete_tag()`: Delete
       an xml element in the xml tree on the result(s) of the given xpath.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.xml_delete_att()`: Delete
+    * :py:meth:`FleurXMLModifier.xml_delete_att()`: Delete
       an attribute in the xml tree on the result(s) of the given xpath.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.xml_replace_tag()`: Replace an xml element on the result(s) of the given xpath.
+    * :py:meth:`FleurXMLModifier.xml_replace_tag()`: Replace an xml element on the result(s) of the given xpath.
 
 On the other hand, there are shortcut methods that already know some paths:
 
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_species()`: Specific
+    * :py:meth:`FleurXMLModifier.set_species()`: Specific
       user-friendly method to change species parameters.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.clone_species()`: Method to
+    * :py:meth:`FleurXMLModifier.clone_species()`: Method to
       create a clone of a given species with optional modifications
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_atomgroup()`:  Specific
+    * :py:meth:`FleurXMLModifier.set_atomgroup()`:  Specific
       method to change atom group parameters.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_species_label()`: Specific
+    * :py:meth:`FleurXMLModifier.set_species_label()`: Specific
       user-friendly method to change a species of an atom with a certain label.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_atomgroup_label()`:  Specific
+    * :py:meth:`FleurXMLModifier.set_atomgroup_label()`:  Specific
       method to change atom group parameters of an atom with a certain label.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.switch_species()`: user-friendly method for switching the atom species of a atom group 
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.switch_species_label()`: user-friendly method for switching the atom species of a atom group with an atom with a certain label.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_nkpts()`: user-friendly method for setting the `kPointCount` (**Only for MaX4 and older**)
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_kpath()`: user-friendly method for setting the path for a bandstructure calculations (**Only for MaX4 and older**)
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_kpointlist()`: user-friendly method for setting/creating a `kPointlist` from lists
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.switch_kpointset()`: user-friendly method for switching the used kpoint set in a calculation (**Only for MaX5 and newer**)
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_inpchanges()`: Specific
+    * :py:meth:`FleurXMLModifier.switch_species()`: user-friendly method for switching the atom species of a atom group 
+    * :py:meth:`FleurXMLModifier.switch_species_label()`: user-friendly method for switching the atom species of a atom group with an atom with a certain label.
+    * :py:meth:`FleurXMLModifier.set_nkpts()`: user-friendly method for setting the `kPointCount` (**Only for MaX4 and older**)
+    * :py:meth:`FleurXMLModifier.set_kpath()`: user-friendly method for setting the path for a bandstructure calculations (**Only for MaX4 and older**)
+    * :py:meth:`FleurXMLModifier.set_kpointlist()`: user-friendly method for setting/creating a `kPointlist` from lists
+    * :py:meth:`FleurXMLModifier.switch_kpointset()`: user-friendly method for switching the used kpoint set in a calculation (**Only for MaX5 and newer**)
+    * :py:meth:`FleurXMLModifier.set_inpchanges()`: Specific
       user-friendly method for easy changes of attribute key value type.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.shift_value()`: Specific
+    * :py:meth:`FleurXMLModifier.shift_value()`: Specific
       user-friendly method to shift value of an attribute.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.shift_value_species_label()`: Specific
+    * :py:meth:`FleurXMLModifier.shift_value_species_label()`: Specific
       user-friendly method to shift value of an attribute of an atom with a certain label.
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_attrib_value()`: user-friendly method for setting attributes in the xml file by specifying their name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_first_attrib_value()`: user-friendly method for setting the first occurrence of an attribute in the xml file by specifying its name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.add_number_to_attrib()`: user-friendly method for adding to or multiplying values of attributes in the xml file by specifying their name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.add_number_to_first_attrib()`: user-friendly method for adding to or multiplying values of the first occurrence of the attribute in the xml file by specifying their name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_text()`: user-friendly method for setting text on xml elements in the xml file by specifying their name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_first_text()`: user-friendly method for setting the text on the first occurrence of an xml element in the xml file by specifying its name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_simple_tag()`: user-friendly method for creating and setting attributes on simple xml elements (only attributes) in the xml file by specifying its name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_complex_tag()`: user-friendly method for creating complex tags in the xml file by specifying its name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.create_tag()`: User-friendly method for inserting a tag in the right place by specifying it's name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.delete_tag()`: User-friendly method for delete a tag by specifying it's name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.delete_att()`: User-friendly method for deleting an attribute from a tag by specifying it's name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.replace_tag()`: User-friendly method for replacing a tag by another by specifying its name
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_nmmpmat()`: Specific 
+    * :py:meth:`FleurXMLModifier.set_attrib_value()`: user-friendly method for setting attributes in the xml file by specifying their name
+    * :py:meth:`FleurXMLModifier.set_first_attrib_value()`: user-friendly method for setting the first occurrence of an attribute in the xml file by specifying its name
+    * :py:meth:`FleurXMLModifier.add_number_to_attrib()`: user-friendly method for adding to or multiplying values of attributes in the xml file by specifying their name
+    * :py:meth:`FleurXMLModifier.add_number_to_first_attrib()`: user-friendly method for adding to or multiplying values of the first occurrence of the attribute in the xml file by specifying their name
+    * :py:meth:`FleurXMLModifier.set_text()`: user-friendly method for setting text on xml elements in the xml file by specifying their name
+    * :py:meth:`FleurXMLModifier.set_first_text()`: user-friendly method for setting the text on the first occurrence of an xml element in the xml file by specifying its name
+    * :py:meth:`FleurXMLModifier.set_simple_tag()`: user-friendly method for creating and setting attributes on simple xml elements (only attributes) in the xml file by specifying its name
+    * :py:meth:`FleurXMLModifier.set_complex_tag()`: user-friendly method for creating complex tags in the xml file by specifying its name
+    * :py:meth:`FleurXMLModifier.create_tag()`: User-friendly method for inserting a tag in the right place by specifying it's name
+    * :py:meth:`FleurXMLModifier.delete_tag()`: User-friendly method for delete a tag by specifying it's name
+    * :py:meth:`FleurXMLModifier.delete_att()`: User-friendly method for deleting an attribute from a tag by specifying it's name
+    * :py:meth:`FleurXMLModifier.replace_tag()`: User-friendly method for replacing a tag by another by specifying its name
+    * :py:meth:`FleurXMLModifier.set_nmmpmat()`: Specific 
       method for initializing or modifying the density matrix file for a LDA+U calculation (details see below)
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.rotate_nmmpmat()`: Specific 
+    * :py:meth:`FleurXMLModifier.rotate_nmmpmat()`: Specific 
       method for rotating a block/blocks of the density matrix file for a LDA+U calculation (details see below) in real space
-    * :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.align_nmmpmat_to_sqa()`: Specific 
+    * :py:meth:`FleurXMLModifier.align_nmmpmat_to_sqa()`: Specific 
       method for aligning a block/blocks of the density matrix file for a LDA+U calculation (details see below) in real space with the SQA already specified in the `inp.xml`
 
 .. The figure below shows a comparison between the use of XML and shortcut methods.
@@ -110,12 +108,12 @@ On the other hand, there are shortcut methods that already know some paths:
 Modifying the density matrix for LDA+U calculations
 ---------------------------------------------------
 
-The above mentioned :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.set_nmmpmat()`, 
-:py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.rotate_nmmpmat()` and 
-:py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.align_nmmpmat_to_sqa()` take a special
+The above mentioned :py:meth:`FleurXMLModifier.set_nmmpmat()`, 
+:py:meth:`FleurXMLModifier.rotate_nmmpmat()` and 
+:py:meth:`FleurXMLModifier.align_nmmpmat_to_sqa()` take a special
 role in the modification registration methods, as the modifications are not done on the ``inp.xml`` file but the
 density matrix file ``n_mmp_mat`` used by Fleur for LDA+U calculations. The resulting new `n_mmp_mat` file is returned next to the new `inp.xml` by
-the :py:func:`~masci_tools.io.fleurxmlmodifier.FleurXMLModifier.modify_xmlfile()`.
+the :py:meth:`FleurXMLModifier.modify_xmlfile()`.
 
 The code example below shows how to use this method to add a LDA+U procedure to an atom species and provide
 an initial guess for the density matrix.
@@ -133,8 +131,8 @@ an initial guess for the density matrix.
   new_xmltree, nmmp_content = fm.modify_xmlfile('/path/to/original/inp.xml')         # Apply
 
 .. note::
-    The ``n_mmp_mat`` file is a simple text file with no knowledge of which density matrix block corresponds to which
-    LDA+U procedure. They are read in the same order as they appear in the ``inp.xml``. For this reason the ``n_mmp_mat``
-    file can become invalid if one adds/removes a LDA+U procedure to the ``inp.xml`` after the ``n_mmp_mat`` file was 
+    The `n_mmp_mat` file is a simple text file with no knowledge of which density matrix block corresponds to which
+    LDA+U procedure. They are read in the same order as they appear in the `inp.xml`. For this reason the `n_mmp_mat`
+    file can become invalid if one adds/removes a LDA+U procedure to the `inp.xml` after the `n_mmp_mat` file was 
     initialized. Therefore any modifications to the `n_mmp_mat` file should be done after adding/removing or modifying the LDA+U configuration.
     

--- a/docs/source/user_guide/fleurxmlmodifier.rst
+++ b/docs/source/user_guide/fleurxmlmodifier.rst
@@ -46,58 +46,58 @@ The registration methods can be separated into two groups. First of all,
 there are XML methods that require deeper knowledge about the structure of an ``inp.xml`` file.
 All of them require an xpath input and start their method names start with ``xml_``:
 
-    * :py:meth:`FleurXMLModifier.xml_set_attrib_value_no_create()`: Set attributes on the result(s) of the given xpath
-    * :py:meth:`FleurXMLModifier.xml_set_text_no_create()`: Set text on the result(s) of the given xpath
-    * :py:meth:`FleurXMLModifier.xml_create_tag()`: Insert
-      an xml element in the xml tree on the result(s) of the given xpath.
-    * :py:meth:`FleurXMLModifier.xml_delete_tag()`: Delete
-      an xml element in the xml tree on the result(s) of the given xpath.
-    * :py:meth:`FleurXMLModifier.xml_delete_att()`: Delete
-      an attribute in the xml tree on the result(s) of the given xpath.
-    * :py:meth:`FleurXMLModifier.xml_replace_tag()`: Replace an xml element on the result(s) of the given xpath.
+* :py:meth:`FleurXMLModifier.xml_set_attrib_value_no_create()`: Set attributes on the result(s) of the given xpath
+* :py:meth:`FleurXMLModifier.xml_set_text_no_create()`: Set text on the result(s) of the given xpath
+* :py:meth:`FleurXMLModifier.xml_create_tag()`: Insert
+  an xml element in the xml tree on the result(s) of the given xpath.
+* :py:meth:`FleurXMLModifier.xml_delete_tag()`: Delete
+  an xml element in the xml tree on the result(s) of the given xpath.
+* :py:meth:`FleurXMLModifier.xml_delete_att()`: Delete
+  an attribute in the xml tree on the result(s) of the given xpath.
+* :py:meth:`FleurXMLModifier.xml_replace_tag()`: Replace an xml element on the result(s) of the given xpath.
 
 On the other hand, there are shortcut methods that already know some paths:
 
-    * :py:meth:`FleurXMLModifier.set_species()`: Specific
-      user-friendly method to change species parameters.
-    * :py:meth:`FleurXMLModifier.clone_species()`: Method to
-      create a clone of a given species with optional modifications
-    * :py:meth:`FleurXMLModifier.set_atomgroup()`:  Specific
-      method to change atom group parameters.
-    * :py:meth:`FleurXMLModifier.set_species_label()`: Specific
-      user-friendly method to change a species of an atom with a certain label.
-    * :py:meth:`FleurXMLModifier.set_atomgroup_label()`:  Specific
-      method to change atom group parameters of an atom with a certain label.
-    * :py:meth:`FleurXMLModifier.switch_species()`: user-friendly method for switching the atom species of a atom group 
-    * :py:meth:`FleurXMLModifier.switch_species_label()`: user-friendly method for switching the atom species of a atom group with an atom with a certain label.
-    * :py:meth:`FleurXMLModifier.set_nkpts()`: user-friendly method for setting the ``kPointCount`` (**Only for MaX4 and older**)
-    * :py:meth:`FleurXMLModifier.set_kpath()`: user-friendly method for setting the path for a bandstructure calculations (**Only for MaX4 and older**)
-    * :py:meth:`FleurXMLModifier.set_kpointlist()`: user-friendly method for setting/creating a ``kPointlist`` from lists
-    * :py:meth:`FleurXMLModifier.switch_kpointset()`: user-friendly method for switching the used kpoint set in a calculation (**Only for MaX5 and newer**)
-    * :py:meth:`FleurXMLModifier.set_inpchanges()`: Specific
-      user-friendly method for easy changes of attribute key value type.
-    * :py:meth:`FleurXMLModifier.shift_value()`: Specific
-      user-friendly method to shift value of an attribute.
-    * :py:meth:`FleurXMLModifier.shift_value_species_label()`: Specific
-      user-friendly method to shift value of an attribute of an atom with a certain label.
-    * :py:meth:`FleurXMLModifier.set_attrib_value()`: user-friendly method for setting attributes in the xml file by specifying their name
-    * :py:meth:`FleurXMLModifier.set_first_attrib_value()`: user-friendly method for setting the first occurrence of an attribute in the xml file by specifying its name
-    * :py:meth:`FleurXMLModifier.add_number_to_attrib()`: user-friendly method for adding to or multiplying values of attributes in the xml file by specifying their name
-    * :py:meth:`FleurXMLModifier.add_number_to_first_attrib()`: user-friendly method for adding to or multiplying values of the first occurrence of the attribute in the xml file by specifying their name
-    * :py:meth:`FleurXMLModifier.set_text()`: user-friendly method for setting text on xml elements in the xml file by specifying their name
-    * :py:meth:`FleurXMLModifier.set_first_text()`: user-friendly method for setting the text on the first occurrence of an xml element in the xml file by specifying its name
-    * :py:meth:`FleurXMLModifier.set_simple_tag()`: user-friendly method for creating and setting attributes on simple xml elements (only attributes) in the xml file by specifying its name
-    * :py:meth:`FleurXMLModifier.set_complex_tag()`: user-friendly method for creating complex tags in the xml file by specifying its name
-    * :py:meth:`FleurXMLModifier.create_tag()`: User-friendly method for inserting a tag in the right place by specifying it's name
-    * :py:meth:`FleurXMLModifier.delete_tag()`: User-friendly method for delete a tag by specifying it's name
-    * :py:meth:`FleurXMLModifier.delete_att()`: User-friendly method for deleting an attribute from a tag by specifying it's name
-    * :py:meth:`FleurXMLModifier.replace_tag()`: User-friendly method for replacing a tag by another by specifying its name
-    * :py:meth:`FleurXMLModifier.set_nmmpmat()`: Specific 
-      method for initializing or modifying the density matrix file for a LDA+U calculation (details see below)
-    * :py:meth:`FleurXMLModifier.rotate_nmmpmat()`: Specific 
-      method for rotating a block/blocks of the density matrix file for a LDA+U calculation (details see below) in real space
-    * :py:meth:`FleurXMLModifier.align_nmmpmat_to_sqa()`: Specific 
-      method for aligning a block/blocks of the density matrix file for a LDA+U calculation (details see below) in real space with the SQA already specified in the ``inp.xml``
+* :py:meth:`FleurXMLModifier.set_species()`: Specific
+  user-friendly method to change species parameters.
+* :py:meth:`FleurXMLModifier.clone_species()`: Method to
+  create a clone of a given species with optional modifications
+* :py:meth:`FleurXMLModifier.set_atomgroup()`:  Specific
+  method to change atom group parameters.
+* :py:meth:`FleurXMLModifier.set_species_label()`: Specific
+  user-friendly method to change a species of an atom with a certain label.
+* :py:meth:`FleurXMLModifier.set_atomgroup_label()`:  Specific
+  method to change atom group parameters of an atom with a certain label.
+* :py:meth:`FleurXMLModifier.switch_species()`: user-friendly method for switching the atom species of a atom group 
+* :py:meth:`FleurXMLModifier.switch_species_label()`: user-friendly method for switching the atom species of a atom group with an atom with a certain label.
+* :py:meth:`FleurXMLModifier.set_nkpts()`: user-friendly method for setting the ``kPointCount`` (**Only for MaX4 and older**)
+* :py:meth:`FleurXMLModifier.set_kpath()`: user-friendly method for setting the path for a bandstructure calculations (**Only for MaX4 and older**)
+* :py:meth:`FleurXMLModifier.set_kpointlist()`: user-friendly method for setting/creating a ``kPointlist`` from lists
+* :py:meth:`FleurXMLModifier.switch_kpointset()`: user-friendly method for switching the used kpoint set in a calculation (**Only for MaX5 and newer**)
+* :py:meth:`FleurXMLModifier.set_inpchanges()`: Specific
+  user-friendly method for easy changes of attribute key value type.
+* :py:meth:`FleurXMLModifier.shift_value()`: Specific
+  user-friendly method to shift value of an attribute.
+* :py:meth:`FleurXMLModifier.shift_value_species_label()`: Specific
+  user-friendly method to shift value of an attribute of an atom with a certain label.
+* :py:meth:`FleurXMLModifier.set_attrib_value()`: user-friendly method for setting attributes in the xml file by specifying their name
+* :py:meth:`FleurXMLModifier.set_first_attrib_value()`: user-friendly method for setting the first occurrence of an attribute in the xml file by specifying its name
+* :py:meth:`FleurXMLModifier.add_number_to_attrib()`: user-friendly method for adding to or multiplying values of attributes in the xml file by specifying their name
+* :py:meth:`FleurXMLModifier.add_number_to_first_attrib()`: user-friendly method for adding to or multiplying values of the first occurrence of the attribute in the xml file by specifying their name
+* :py:meth:`FleurXMLModifier.set_text()`: user-friendly method for setting text on xml elements in the xml file by specifying their name
+* :py:meth:`FleurXMLModifier.set_first_text()`: user-friendly method for setting the text on the first occurrence of an xml element in the xml file by specifying its name
+* :py:meth:`FleurXMLModifier.set_simple_tag()`: user-friendly method for creating and setting attributes on simple xml elements (only attributes) in the xml file by specifying its name
+* :py:meth:`FleurXMLModifier.set_complex_tag()`: user-friendly method for creating complex tags in the xml file by specifying its name
+* :py:meth:`FleurXMLModifier.create_tag()`: User-friendly method for inserting a tag in the right place by specifying it's name
+* :py:meth:`FleurXMLModifier.delete_tag()`: User-friendly method for delete a tag by specifying it's name
+* :py:meth:`FleurXMLModifier.delete_att()`: User-friendly method for deleting an attribute from a tag by specifying it's name
+* :py:meth:`FleurXMLModifier.replace_tag()`: User-friendly method for replacing a tag by another by specifying its name
+* :py:meth:`FleurXMLModifier.set_nmmpmat()`: Specific 
+  method for initializing or modifying the density matrix file for a LDA+U calculation (details see below)
+* :py:meth:`FleurXMLModifier.rotate_nmmpmat()`: Specific 
+  method for rotating a block/blocks of the density matrix file for a LDA+U calculation (details see below) in real space
+* :py:meth:`FleurXMLModifier.align_nmmpmat_to_sqa()`: Specific 
+  method for aligning a block/blocks of the density matrix file for a LDA+U calculation (details see below) in real space with the SQA already specified in the ``inp.xml``
 
 .. The figure below shows a comparison between the use of XML and shortcut methods.
 
@@ -108,11 +108,10 @@ On the other hand, there are shortcut methods that already know some paths:
 Modifying the density matrix for LDA+U calculations
 ---------------------------------------------------
 
-The above mentioned :py:meth:``FleurXMLModifier.set_nmmpmat()`, 
-:py:meth:`FleurXMLModifier.rotate_nmmpmat()` and 
-:py:meth:`FleurXMLModifier.align_nmmpmat_to_sqa()` take a special
-role in the modification registration methods, as the modifications are not done on the ``inp.xml`` file but the
-density matrix file ``n_mmp_mat`` used by Fleur for LDA+U calculations. The resulting new ``n_mmp_mat`` file is returned next to the new ``inp.xml`` by
+The above mentioned :py:meth:`FleurXMLModifier.set_nmmpmat()`, :py:meth:`FleurXMLModifier.rotate_nmmpmat()` and 
+:py:meth:`FleurXMLModifier.align_nmmpmat_to_sqa()` take a special role in the modification registration methods,
+as the modifications are not done on the ``inp.xml`` file but the density matrix file ``n_mmp_mat`` used by Fleur
+for LDA+U calculations. The resulting new ``n_mmp_mat`` file is returned next to the new ``inp.xml`` by
 the :py:meth:`FleurXMLModifier.modify_xmlfile()`.
 
 The code example below shows how to use this method to add a LDA+U procedure to an atom species and provide
@@ -122,13 +121,13 @@ an initial guess for the density matrix.
 
   from masci_tools.io.fleurxmlmodifier import FleurXMLModifier
 
-  fm = FleurXMLModifier()                                              # Initialise FleurXMLModifier class
-  fm.set_species('Nd-1', {'ldaU':                                      # Add LDA+U procedure
-                         {'l': 3, 'U': 6.76, 'J': 0.76, 'l_amf': 'F'}}) 
-  fm.set_nmmpmat('Nd-1', orbital=3, spin=1, state_occupations=[1,1,1,1,0,0,0]) # Initialize n_mmp_mat file with the states
-                                                                       # m = -3 to m = 0 occupied for spin up
-                                                                       # spin down is initialized with 0 by default
-  new_xmltree, nmmp_content = fm.modify_xmlfile('/path/to/original/inp.xml')         # Apply
+  fm = FleurXMLModifier()
+  # Add LDA+U procedure
+  fm.set_species('Nd-1', {'ldaU':{'l': 3, 'U': 6.76, 'J': 0.76, 'l_amf': 'F'}})
+  # Initialize n_mmp_mat file with the states m = -3 to m = 0 occupied for spin up
+  # spin down is initialized with 0 by default, since no n_mmp_mat file is provided
+  fm.set_nmmpmat('Nd-1', orbital=3, spin=1, state_occupations=[1,1,1,1,0,0,0]) 
+  new_xmltree, nmmp_content = fm.modify_xmlfile('/path/to/original/inp.xml')
 
 .. note::
     The ``n_mmp_mat`` file is a simple text file with no knowledge of which density matrix block corresponds to which

--- a/docs/source/user_guide/fleurxmlmodifier.rst
+++ b/docs/source/user_guide/fleurxmlmodifier.rst
@@ -8,15 +8,15 @@ FleurXMLModifier
 Description
 -----------
 The :py:class:`FleurXMLModifier` class can be used if you want to change anything in a
-`inp.xml` file in an easy and robust way. It will validate all the changes you wish
-to do and apply all these changes to a given `inp.xml` and produce a new XML tree.
+``inp.xml`` file in an easy and robust way. It will validate all the changes you wish
+to do and apply all these changes to a given ``inp.xml`` and produce a new XML tree.
 
 Usage
 ------
-To modify an existing `inp.xml`, a :py:class:`FleurXMLModifier` instance has to be initialised.
+To modify an existing ``inp.xml``, a :py:class:`FleurXMLModifier` instance has to be initialised.
 After that, a user should register certain modifications which will be cached. 
-They will be applied on a given `inp.xml`. However, the provided `inp.xml` will not be
-changed but only a modified XML tree is returned, which you can store in a new `.xml` file.
+They will be applied on a given ``inp.xml``. However, the provided ``inp.xml`` will not be
+changed but only a modified XML tree is returned, which you can store in a new ``.xml`` file.
 
 .. code-block:: python
 
@@ -33,7 +33,7 @@ General methods
 _______________
 
 * :py:meth:`FleurXMLModifier.modify_xmlfile()`: Applies the registered changes to a
-  given `inp.xml` (and optional `n_mmp_mat` file)
+  given ``inp.xml`` (and optional ``n_mmp_mat`` file)
 * :py:meth:`FleurXMLModifier.changes()`: Displays the current list of changes.
 * :py:meth:`FleurXMLModifier.undo()`: Removes the
   last task or all tasks from the list of changes.
@@ -43,8 +43,8 @@ _______________
 Modification registration methods
 _________________________________
 The registration methods can be separated into two groups. First of all,
-there are XML methods that require deeper knowledge about the structure of an `inp.xml` file.
-All of them require an xpath input and start their method names start with `xml_`:
+there are XML methods that require deeper knowledge about the structure of an ``inp.xml`` file.
+All of them require an xpath input and start their method names start with ``xml_``:
 
     * :py:meth:`FleurXMLModifier.xml_set_attrib_value_no_create()`: Set attributes on the result(s) of the given xpath
     * :py:meth:`FleurXMLModifier.xml_set_text_no_create()`: Set text on the result(s) of the given xpath
@@ -70,9 +70,9 @@ On the other hand, there are shortcut methods that already know some paths:
       method to change atom group parameters of an atom with a certain label.
     * :py:meth:`FleurXMLModifier.switch_species()`: user-friendly method for switching the atom species of a atom group 
     * :py:meth:`FleurXMLModifier.switch_species_label()`: user-friendly method for switching the atom species of a atom group with an atom with a certain label.
-    * :py:meth:`FleurXMLModifier.set_nkpts()`: user-friendly method for setting the `kPointCount` (**Only for MaX4 and older**)
+    * :py:meth:`FleurXMLModifier.set_nkpts()`: user-friendly method for setting the ``kPointCount`` (**Only for MaX4 and older**)
     * :py:meth:`FleurXMLModifier.set_kpath()`: user-friendly method for setting the path for a bandstructure calculations (**Only for MaX4 and older**)
-    * :py:meth:`FleurXMLModifier.set_kpointlist()`: user-friendly method for setting/creating a `kPointlist` from lists
+    * :py:meth:`FleurXMLModifier.set_kpointlist()`: user-friendly method for setting/creating a ``kPointlist`` from lists
     * :py:meth:`FleurXMLModifier.switch_kpointset()`: user-friendly method for switching the used kpoint set in a calculation (**Only for MaX5 and newer**)
     * :py:meth:`FleurXMLModifier.set_inpchanges()`: Specific
       user-friendly method for easy changes of attribute key value type.
@@ -97,7 +97,7 @@ On the other hand, there are shortcut methods that already know some paths:
     * :py:meth:`FleurXMLModifier.rotate_nmmpmat()`: Specific 
       method for rotating a block/blocks of the density matrix file for a LDA+U calculation (details see below) in real space
     * :py:meth:`FleurXMLModifier.align_nmmpmat_to_sqa()`: Specific 
-      method for aligning a block/blocks of the density matrix file for a LDA+U calculation (details see below) in real space with the SQA already specified in the `inp.xml`
+      method for aligning a block/blocks of the density matrix file for a LDA+U calculation (details see below) in real space with the SQA already specified in the ``inp.xml``
 
 .. The figure below shows a comparison between the use of XML and shortcut methods.
 
@@ -108,11 +108,11 @@ On the other hand, there are shortcut methods that already know some paths:
 Modifying the density matrix for LDA+U calculations
 ---------------------------------------------------
 
-The above mentioned :py:meth:`FleurXMLModifier.set_nmmpmat()`, 
+The above mentioned :py:meth:``FleurXMLModifier.set_nmmpmat()`, 
 :py:meth:`FleurXMLModifier.rotate_nmmpmat()` and 
 :py:meth:`FleurXMLModifier.align_nmmpmat_to_sqa()` take a special
 role in the modification registration methods, as the modifications are not done on the ``inp.xml`` file but the
-density matrix file ``n_mmp_mat`` used by Fleur for LDA+U calculations. The resulting new `n_mmp_mat` file is returned next to the new `inp.xml` by
+density matrix file ``n_mmp_mat`` used by Fleur for LDA+U calculations. The resulting new ``n_mmp_mat`` file is returned next to the new ``inp.xml`` by
 the :py:meth:`FleurXMLModifier.modify_xmlfile()`.
 
 The code example below shows how to use this method to add a LDA+U procedure to an atom species and provide
@@ -131,8 +131,8 @@ an initial guess for the density matrix.
   new_xmltree, nmmp_content = fm.modify_xmlfile('/path/to/original/inp.xml')         # Apply
 
 .. note::
-    The `n_mmp_mat` file is a simple text file with no knowledge of which density matrix block corresponds to which
-    LDA+U procedure. They are read in the same order as they appear in the `inp.xml`. For this reason the `n_mmp_mat`
-    file can become invalid if one adds/removes a LDA+U procedure to the `inp.xml` after the `n_mmp_mat` file was 
-    initialized. Therefore any modifications to the `n_mmp_mat` file should be done after adding/removing or modifying the LDA+U configuration.
+    The ``n_mmp_mat`` file is a simple text file with no knowledge of which density matrix block corresponds to which
+    LDA+U procedure. They are read in the same order as they appear in the ``inp.xml`. For this reason the ``n_mmp_mat`
+    file can become invalid if one adds/removes a LDA+U procedure to the ``inp.xml`` after the ``n_mmp_mat`` file was 
+    initialized. Therefore any modifications to the ``n_mmp_mat`` file should be done after adding/removing or modifying the LDA+U configuration.
     

--- a/docs/source/user_guide/hdf5_parser.rst
+++ b/docs/source/user_guide/hdf5_parser.rst
@@ -1,14 +1,20 @@
 .. _hdf5_parser:
 
-General ``HDF5`` file reader
+.. currentmodule:: masci_tools.io.parsers.hdf5
+
+General `HDF5` file reader
 +++++++++++++++++++++++++++++
 
-Fleur uses the HDF5 library for output files containing large datasets. The masci-tools library provides the :py:class:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader` class to extract and transform information from these files. The ``h5py`` library is used to get information from ``.hdf`` files
+Fleur uses the HDF5 library for output files containing large datasets.
+The masci-tools library provides the :py:class:`reader.HDF5Reader` class to extract and transform
+information from these files. The `h5py` library is used to get information from `.hdf` files.
 
 Basic Usage
 ------------
 
-The specifications of what to extract and how to transform the data are given in the form of a python dictionary. Let us look at a usage example; extracting data for a bandstructure calculation from the ``banddos.hdf`` file produced by Fleur.
+The specifications of what to extract and how to transform the data are given in the form
+of a python dictionary. Let us look at a usage example; extracting data for a bandstructure
+calculation from the `banddos.hdf` file produced by Fleur.
 
 .. code-block:: python
 
@@ -20,44 +26,52 @@ The specifications of what to extract and how to transform the data are given in
    with HDF5Reader('/path/to/banddos.hdf') as h5reader:
       datasets, attributes = h5reader.read(recipe=FleurBands)
 
-The method :py:meth:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader.read` produces two python dictionaries. In the case of the ``FleurBands`` recipe these contain the following information.
+The method :py:meth:`reader.HDF5Reader.read` produces two python dictionaries.
+In the case of the `FleurBands` recipe these contain the following information.
 
-   - `datasets`
-      - Eigenvalues converted to eV shited to ``E_F=0`` (if available in the ``banddos.hdf``) and split up into spin-up/down and flattened to one dimension
-      - The kpath projected to 1D and reshaped to same length as weights/eigenvalues
-      - The weights (flattened) of the interstitial region, each atom, each orbital on each atom for all eigenvalues
-   - `attributes`
-      - The coordinates of the used kpoints
-      - Positions, atomic symbols and indices of symmetry equivalent atoms
-      - Dimensions of eigenvalues (``nkpts`` and ``nbands``)
-      - Bravais matrix/Reciprocal cell of the system
-      - Indices and labels of special k-points
-      - Fermi energy
-      - Number of spins in the calculation
+- `datasets`
+   - Eigenvalues converted to eV shited to `E_F=0` (if available in the `banddos.hdf`)
+     and split up into spin-up/down and flattened to one dimension
+   - The kpath projected to 1D and reshaped to same length as weights/eigenvalues
+   - The weights (flattened) of the interstitial region, each atom, each orbital on
+     each atom for all eigenvalues
+- `attributes`
+   - The coordinates of the used kpoints
+   - Positions, atomic symbols and indices of symmetry equivalent atoms
+   - Dimensions of eigenvalues (`nkpts` and `nbands`)
+   - Bravais matrix/Reciprocal cell of the system
+   - Indices and labels of special k-points
+   - Fermi energy
+   - Number of spins in the calculation
 
-The following pre-defined recipes are stored in :py:mod:`~masci_tools.io.parsers.hdf5.recipes`:
+The following pre-defined recipes are stored in :py:mod:`masci_tools.io.parsers.hdf5.recipes`:
 
-   - Recipe for ``banddos.hdf`` for bandstructure calculations
-   - Recipe for ``banddos.hdf`` for standard density of states calculations
-   - Different DOS modes are also supported (``jDOS``, ``orbcomp``, ``mcd``)
+ - Recipe for `banddos.hdf` for bandstructure calculations
+ - Recipe for `banddos.hdf` for standard density of states calculations
+ - Different DOS modes are also supported (`jDOS`, `orbcomp`, `mcd`)
 
-If no recipe is provided to the :py:class:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader`, it will create the ``datasets`` and ``attributes`` as two nested dictionaries, exactly mirroring the structure of the ``.hdf`` file and converting datasets into numpy arrays.
+If no recipe is provided to the :py:class:`reader.HDF5Reader`, it will create the `datasets`
+and `attributes` as two nested dictionaries, exactly mirroring the structure of the `.hdf`
+file and converting datasets into numpy arrays.
 
-For big datasets it might be useful to keep the dataset as a reference to the file and not load the
-dataset into memory. To achieve this you can pass ``move_to_memory=False``, when initializing the reader.
-Notice that most of the transformations will still implicitly create numpy arrays and after the hdf file is closed the datasets will no longer be available.
+For big datasets it might be useful to keep the dataset as a reference to the file and not 
+load the dataset into memory. To achieve this you can pass `move_to_memory=False`, when
+initializing the reader. Notice that most of the transformations will still implicitly
+create numpy arrays and after the hdf file is closed the datasets will no longer be
+available.
 
-Structure of recipes for the :py:class:`~masci_tools.io.parsers.hdf5.reader.HDF5Reader`
--------------------------------------------------------------------------------------------
+Structure of recipes for the :py:class:`reader.HDF5Reader`
+-----------------------------------------------------------
 
-The recipe for extracting bandstructure information form the ``banddos.hdf`` looks like this:
+The recipe for extracting bandstructure information form the `banddos.hdf` looks like this:
 
 .. literalinclude:: ../../../masci_tools/io/parsers/hdf5/recipes.py
    :language: python
    :lines: 168-333
    :linenos:
 
-Each recipe can define the `datasets` and `attributes` entry (if one is not defined, a empty dict is returned in its place). Each entry in these sections has the same structure.
+Each recipe can define the `datasets` and `attributes` entry (if one is not defined,
+a empty dict is returned in its place). Each entry in these sections has the same structure.
 
 .. code-block:: python
 
@@ -74,41 +88,64 @@ Each recipe can define the `datasets` and `attributes` entry (if one is not defi
             ]
         }
 
-All entries must define the key ``h5path``. This gives the initial dataset for this key, which will be extracted from the given ``.hdf`` file. The key of the entry corresponds to the key under which the result will be saved to the output dictionary.
+All entries must define the key `h5path`. This gives the initial dataset for this key,
+which will be extracted from the given `.hdf` file. The key of the entry corresponds to
+the key under which the result will be saved to the output dictionary.
 
-If the dataset should be transformed in some way after reading it, there are a number of defined transformations in :py:mod:`~masci_tools.io.parsers.hdf5.transforms`. These are added to an entry by adding a list of namedtuples (:py:class:`~masci_tools.io.parsers.hdf5.reader.Transformation` for general transformations; :py:class:`~masci_tools.io.parsers.hdf5.reader.AttribTransformation` for attribute transformations) under the key ``transforms``. General Transformations can be used in all entries, while transformations using an attribute value can only be used in the ``datasets`` entries. Each namedtuple takes the ``name`` of the transformation function and the positional (``args``), and keyword arguments (``kwargs``) for the transformation. Attribute transformations also take the name of the attribute, whose value should be passed to the transformation in ``attrib_name``.
+If the dataset should be transformed in some way after reading it, there are a number
+of defined transformations in :py:mod:`masci_tools.io.parsers.hdf5.transforms`.
+These are added to an entry by adding a list of namedtuples
+(:py:class:`reader.Transformation` for general transformations;
+:py:class:`reader.AttribTransformation` for attribute transformations) under the key
+`transforms`. General Transformations can be used in all entries, while transformations
+using an attribute value can only be used in the `datasets` entries. Each namedtuple takes
+the `name` of the transformation function and the positional (`args`),
+and keyword arguments (`kwargs`) for the transformation. Attribute transformations
+also take the name of the attribute, whose value should be passed to the transformation
+in `attrib_name`.
 
 At the moment the following transformation functions are pre-defined:
 
+.. currentmodule:: masci_tools.io.parsers.hdf5.transforms
+
 General Transformations:
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.get_first_element()`: Get the index ``0`` of the dataset
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.index_dataset()`: Get the index ``index`` of the dataset
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.slice_dataset()`: Slice the given dataset with the given argument
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.get_shape()`: Get the shape of the dataset
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.tile_array()`: Use np.tile to repeat dataset a given amount of times
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.repeat_array()`: Use np.repeat to repeat each element in the dataset a given amount of times
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.get_all_child_datasets()`: extract all datasets contained in the current hdf group and enter them into a dict
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.merge_subgroup_datasets()`: extract all datasets contained in the subgroups of the current hdf group and enter them into a dict in a list (or one numpy array)
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.stack_datasets()`: Stack the given datasets in the dictionary along a given axis
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.shift_dataset()`: Shift the given dataset with a scalar value
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.multiply_scalar()`: Multiply the given dataset with a scalar value
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.multiply_array()`: Multiply the given dataset with a given array
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.convert_to_complex_array()`: Convert real dataset to complex array
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.calculate_norm()`: Calculate norm of list of vectors (either absolute or difference between subsequent entries)
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.cumulative_sum()`: Calculative cumulative sum of dataset
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.get_attribute()`: Get the value of one given attribute on the dataset
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.attributes()`: Get all defined attributes on the dataset as a dict
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.move_to_memory()`: Convert dataset to numpy array (if not already done implicitly)
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.flatten_array()`: Create copy of dataset flattened into one dimension
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.split_array()`: Split the given dataset along its first index and store result in a dictionary with keys with suffixes
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.convert_to_str()`: Convert datatype of dataset to string
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.periodic_elements()`: Convert atomic numbers to their atomic symbols
+
+- :py:func:`get_first_element()`: Get the index `0` of the dataset
+- :py:func:`index_dataset()`: Get the index `index` of the dataset
+- :py:func:`slice_dataset()`: Slice the given dataset with the given argument
+- :py:func:`get_shape()`: Get the shape of the dataset
+- :py:func:`tile_array()`: Use np.tile to repeat dataset a given amount of times
+- :py:func:`repeat_array()`: Use np.repeat to repeat each element in the dataset a given amount of times
+- :py:func:`get_all_child_datasets()`: extract all datasets contained in the current hdf
+  group and enter them into a dict
+- :py:func:`merge_subgroup_datasets()`: extract all datasets contained in the subgroups of
+  the current hdf group and enter them into a dict in a list (or one numpy array)
+- :py:func:`stack_datasets()`: Stack the given datasets in the dictionary along a given axis
+- :py:func:`shift_dataset()`: Shift the given dataset with a scalar value
+- :py:func:`multiply_scalar()`: Multiply the given dataset with a scalar value
+- :py:func:`multiply_array()`: Multiply the given dataset with a given array
+- :py:func:`convert_to_complex_array()`: Convert real dataset to complex array
+- :py:func:`calculate_norm()`: Calculate norm of list of vectors (either absolute or difference between subsequent entries)
+- :py:func:`cumulative_sum()`: Calculative cumulative sum of dataset
+- :py:func:`get_attribute()`: Get the value of one given attribute on the dataset
+- :py:func:`attributes()`: Get all defined attributes on the dataset as a dict
+- :py:func:`move_to_memory()`: Convert dataset to numpy array (if not already done implicitly)
+- :py:func:`flatten_array()`: Create copy of dataset flattened into one dimension
+- :py:func:`split_array()`: Split the given dataset along its first index and store result in a dictionary with keys with suffixes
+- :py:func:`convert_to_str()`: Convert datatype of dataset to string
+- :py:func:`periodic_elements()`: Convert atomic numbers to their atomic symbols
 
 Transformations using an attribute:
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.multiply_by_attribute()`: Multiply dataset by value of attribute (both scalar and matrix)
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.shift_by_attribute()`: Shift the given dataset with the value of an attribute
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.repeat_array_by_attribute()`: Call :py:func:`~masci_tools.io.parsers.hdf5.transforms.repeat_array()` with the value of an attribute as argument
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.tile_array_by_attribute()`: Call :py:func:`~masci_tools.io.parsers.hdf5.transforms.tile_array()` with the value of an attribute as argument
-   - :py:func:`~masci_tools.io.parsers.hdf5.transforms.add_partial_sums()`: Sum over entries in dictionary datasets with given patterns in the key (Pattern is formatted with given attribute value)
 
-Custom transformation functions can also be defined using the :py:func:`~masci_tools.io.parsers.hdf5.transforms.hdf5_transformation()` decorator. For some transformation, e.g. :py:func:`~masci_tools.io.parsers.hdf5.transforms.get_all_child_datasets()`, the result will be a subdictionary in the ``datasets`` or ``attributes`` dictionary. If this is not desired the entry can include ``'unpack_dict': True``. With this all keys from the resulting dict will be extracted after all transformations and put into the root dictionary.
+- :py:func:`multiply_by_attribute()`: Multiply dataset by value of attribute (both scalar and matrix)
+- :py:func:`shift_by_attribute()`: Shift the given dataset with the value of an attribute
+- :py:func:`repeat_array_by_attribute()`: Call :py:func:`repeat_array()` with the value of an attribute as argument
+- :py:func:`tile_array_by_attribute()`: Call :py:func:`tile_array()` with the value of an attribute as argument
+- :py:func:`add_partial_sums()`: Sum over entries in dictionary datasets with given
+  patterns in the key (Pattern is formatted with given attribute value)
+
+Custom transformation functions can also be defined using the :py:func:`hdf5_transformation()`
+decorator. For some transformation, e.g. :py:func:`get_all_child_datasets()`, the result
+will be a subdictionary in the `datasets` or `attributes` dictionary. If this is not desired
+the entry can include `'unpack_dict': True`. With this all keys from the resulting dict
+will be extracted after all transformations and put into the root dictionary.

--- a/docs/source/user_guide/hdf5_parser.rst
+++ b/docs/source/user_guide/hdf5_parser.rst
@@ -7,14 +7,14 @@ General `HDF5` file reader
 
 Fleur uses the HDF5 library for output files containing large datasets.
 The masci-tools library provides the :py:class:`reader.HDF5Reader` class to extract and transform
-information from these files. The `h5py` library is used to get information from `.hdf` files.
+information from these files. The ``h5py`` library is used to get information from ``.hdf`` files.
 
 Basic Usage
 ------------
 
 The specifications of what to extract and how to transform the data are given in the form
 of a python dictionary. Let us look at a usage example; extracting data for a bandstructure
-calculation from the `banddos.hdf` file produced by Fleur.
+calculation from the ``banddos.hdf`` file produced by Fleur.
 
 .. code-block:: python
 
@@ -27,18 +27,18 @@ calculation from the `banddos.hdf` file produced by Fleur.
       datasets, attributes = h5reader.read(recipe=FleurBands)
 
 The method :py:meth:`reader.HDF5Reader.read` produces two python dictionaries.
-In the case of the `FleurBands` recipe these contain the following information.
+In the case of the ``FleurBands`` recipe these contain the following information.
 
-- `datasets`
-   - Eigenvalues converted to eV shited to `E_F=0` (if available in the `banddos.hdf`)
+- ``datasets``
+   - Eigenvalues converted to eV shited to ``E_F=0`` (if available in the ``banddos.hdf``)
      and split up into spin-up/down and flattened to one dimension
    - The kpath projected to 1D and reshaped to same length as weights/eigenvalues
    - The weights (flattened) of the interstitial region, each atom, each orbital on
      each atom for all eigenvalues
-- `attributes`
+- ``attributes``
    - The coordinates of the used kpoints
    - Positions, atomic symbols and indices of symmetry equivalent atoms
-   - Dimensions of eigenvalues (`nkpts` and `nbands`)
+   - Dimensions of eigenvalues (``nkpts`` and ``nbands``)
    - Bravais matrix/Reciprocal cell of the system
    - Indices and labels of special k-points
    - Fermi energy
@@ -46,16 +46,16 @@ In the case of the `FleurBands` recipe these contain the following information.
 
 The following pre-defined recipes are stored in :py:mod:`masci_tools.io.parsers.hdf5.recipes`:
 
- - Recipe for `banddos.hdf` for bandstructure calculations
- - Recipe for `banddos.hdf` for standard density of states calculations
- - Different DOS modes are also supported (`jDOS`, `orbcomp`, `mcd`)
+ - Recipe for ``banddos.hdf`` for bandstructure calculations
+ - Recipe for ``banddos.hdf`` for standard density of states calculations
+ - Different DOS modes are also supported (``jDOS``, ``orbcomp``, ``mcd``)
 
-If no recipe is provided to the :py:class:`reader.HDF5Reader`, it will create the `datasets`
-and `attributes` as two nested dictionaries, exactly mirroring the structure of the `.hdf`
+If no recipe is provided to the :py:class:`reader.HDF5Reader`, it will create the ``datasets``
+and ``attributes`` as two nested dictionaries, exactly mirroring the structure of the ``.hdf``
 file and converting datasets into numpy arrays.
 
 For big datasets it might be useful to keep the dataset as a reference to the file and not 
-load the dataset into memory. To achieve this you can pass `move_to_memory=False`, when
+load the dataset into memory. To achieve this you can pass ``move_to_memory=False``, when
 initializing the reader. Notice that most of the transformations will still implicitly
 create numpy arrays and after the hdf file is closed the datasets will no longer be
 available.
@@ -63,14 +63,14 @@ available.
 Structure of recipes for the :py:class:`reader.HDF5Reader`
 -----------------------------------------------------------
 
-The recipe for extracting bandstructure information form the `banddos.hdf` looks like this:
+The recipe for extracting bandstructure information form the ``banddos.hdf`` looks like this:
 
 .. literalinclude:: ../../../masci_tools/io/parsers/hdf5/recipes.py
    :language: python
    :lines: 168-333
    :linenos:
 
-Each recipe can define the `datasets` and `attributes` entry (if one is not defined,
+Each recipe can define the ``datasets`` and ``attributes`` entry (if one is not defined,
 a empty dict is returned in its place). Each entry in these sections has the same structure.
 
 .. code-block:: python
@@ -88,8 +88,8 @@ a empty dict is returned in its place). Each entry in these sections has the sam
             ]
         }
 
-All entries must define the key `h5path`. This gives the initial dataset for this key,
-which will be extracted from the given `.hdf` file. The key of the entry corresponds to
+All entries must define the key ``h5path``. This gives the initial dataset for this key,
+which will be extracted from the given ``.hdf`` file. The key of the entry corresponds to
 the key under which the result will be saved to the output dictionary.
 
 If the dataset should be transformed in some way after reading it, there are a number
@@ -97,12 +97,12 @@ of defined transformations in :py:mod:`masci_tools.io.parsers.hdf5.transforms`.
 These are added to an entry by adding a list of namedtuples
 (:py:class:`reader.Transformation` for general transformations;
 :py:class:`reader.AttribTransformation` for attribute transformations) under the key
-`transforms`. General Transformations can be used in all entries, while transformations
-using an attribute value can only be used in the `datasets` entries. Each namedtuple takes
-the `name` of the transformation function and the positional (`args`),
-and keyword arguments (`kwargs`) for the transformation. Attribute transformations
+``transforms``. General Transformations can be used in all entries, while transformations
+using an attribute value can only be used in the ``datasets`` entries. Each namedtuple takes
+the ``name`` of the transformation function and the positional (``args``),
+and keyword arguments (``kwargs``) for the transformation. Attribute transformations
 also take the name of the attribute, whose value should be passed to the transformation
-in `attrib_name`.
+in ``attrib_name``.
 
 At the moment the following transformation functions are pre-defined:
 
@@ -110,8 +110,8 @@ At the moment the following transformation functions are pre-defined:
 
 General Transformations:
 
-- :py:func:`get_first_element()`: Get the index `0` of the dataset
-- :py:func:`index_dataset()`: Get the index `index` of the dataset
+- :py:func:`get_first_element()`: Get the index ``0`` of the dataset
+- :py:func:`index_dataset()`: Get the index ``index`` of the dataset
 - :py:func:`slice_dataset()`: Slice the given dataset with the given argument
 - :py:func:`get_shape()`: Get the shape of the dataset
 - :py:func:`tile_array()`: Use np.tile to repeat dataset a given amount of times
@@ -146,6 +146,6 @@ Transformations using an attribute:
 
 Custom transformation functions can also be defined using the :py:func:`hdf5_transformation()`
 decorator. For some transformation, e.g. :py:func:`get_all_child_datasets()`, the result
-will be a subdictionary in the `datasets` or `attributes` dictionary. If this is not desired
-the entry can include `'unpack_dict': True`. With this all keys from the resulting dict
+will be a subdictionary in the ``datasets`` or ``attributes`` dictionary. If this is not desired
+the entry can include ``'unpack_dict': True``. With this all keys from the resulting dict
 will be extracted after all transformations and put into the root dictionary.

--- a/docs/source/user_guide/plotting.rst
+++ b/docs/source/user_guide/plotting.rst
@@ -6,68 +6,89 @@ General Plotting routines
 .. _matplotlib: https://matplotlib.org/stable/index.html
 .. _bokeh: https://docs.bokeh.org/en/latest/index.html
 
-The plotting of data is always a common task that needs to be performed. However, there is a lot of variation in how someone might want plots to look or be arranged. Some plots might also need to be interactive to be of a real use.
+The plotting of data is always a common task that needs to be performed.
+However, there is a lot of variation in how someone might want plots to look or be arranged.
+Some plots might also need to be interactive to be of a real use.
 
-For these reasons the ``masci_tools`` library provides utility for general plotting and template functions for common plots made when working with DFT methods. There are two plotting backends available:
+For these reasons the `masci_tools` library provides utility for general plotting and
+template functions for common plots made when working with DFT methods.
+There are two plotting backends available:
 
-   - :`matplotlib`_: Mainly used for non-interactive plots
-   - :`bokeh`_: Mainly used for interactive plots
+- :`matplotlib`_: Mainly used for non-interactive plots
+- :`bokeh`_: Mainly used for interactive plots
 
 Available Routines
 -------------------
 
-For both of these there are a lot of plotting routines available (both general or specific to a problem). All of these routines will return the used ``Axes`` object in the case of matplotlib or the ``figure`` produced by bokeh for custom modifications.
+For both of these there are a lot of plotting routines available (both general or specific
+to a problem). All of these routines will return the used `Axes` object in the
+case of matplotlib or the `figure` produced by bokeh for custom modifications.
 
-   - `common` (Can be used for both backends):
-      - :py:func:`~masci_tools.vis.common.scatter()`: Make a scatterplot with varying size and color of the points for multiple sets of data
-      - :py:func:`~masci_tools.vis.common.line()`: Make a lineplot with multiple sets of data
-      - :py:func:`~masci_tools.vis.common.dos()`: Plot a general density of states (non-spinpolarized)
-      - :py:func:`~masci_tools.vis.common.spinpol_dos()`: Plot a general density of states (spinpolarized)
-      - :py:func:`~masci_tools.vis.common.bands()`: Plot a general bandstructure (non-spinpolarized)
-      - :py:func:`~masci_tools.vis.common.spinpol_bands()`: Plot a general bandstructure (spinpolarized)
-   - `matplotlib`:
-      - :py:func:`~masci_tools.vis.plot_methods.single_scatterplot()`: Make a scatterplot with lines for a single set of data
-      - :py:func:`~masci_tools.vis.plot_methods.multiple_scatterplots()`: Make a scatterplot with lines for multiple sets of data
-      - :py:func:`~masci_tools.vis.plot_methods.multi_scatter_plot()`: Make a scatterplot with varying size and color of the points for multiple sets of data
-      - :py:func:`~masci_tools.vis.plot_methods.colormesh_plot()`: Make 2D plot with the data represented as color
-      - :py:func:`~masci_tools.vis.plot_methods.waterfall_plot()`: Make 3D plot with the `scatter3D` function of matplotlib
-      - :py:func:`~masci_tools.vis.plot_methods.surface_plot()`: Make 3D plot with the `plot_surface` function of matplotlib
-      - :py:func:`~masci_tools.vis.plot_methods.multiplot_moved()`: Plot multiple sets of data above each other with a configurable shift
-      - :py:func:`~masci_tools.vis.plot_methods.histogram()`: Make a histogram plot
-      - :py:func:`~masci_tools.vis.plot_methods.barchart()`: Make a barchart plot
-      - :py:func:`~masci_tools.vis.plot_methods.multiaxis_scatterplot()`: Make a plot containing multiple sets of data distributed over multiple subplots in a grid
-      - :py:func:`~masci_tools.vis.plot_methods.plot_convex_hull2d()`: Make a 2D plot of a convex hull
-      - :py:func:`~masci_tools.vis.plot_methods.plot_residuen()`: Make a residual plot for given real and fit data. Can also produce a histogram of the deviations
-      - :py:func:`~masci_tools.vis.plot_methods.plot_convergence_results()`: Plot the convergence behaviour of charge density distances and energies of a single calculation
-      - :py:func:`~masci_tools.vis.plot_methods.plot_convergence_results_m()`: Plot the convergence behaviour of charge density distances and energies of multiple calculations
-      - :py:func:`~masci_tools.vis.plot_methods.plot_lattice_constant()`: Plot the energy curve with changing unit cell volume
-      - :py:func:`~masci_tools.vis.plot_methods.plot_dos()`: Plot a general density of states (non-spinpolarized)
-      - :py:func:`~masci_tools.vis.plot_methods.plot_spinpol_dos()`: Plot a general density of states (spinpolarized)
-      - :py:func:`~masci_tools.vis.plot_methods.plot_bands()`: Plot a general bandstructure (non-spinpolarized)
-      - :py:func:`~masci_tools.vis.plot_methods.plot_spinpol_bands()`: Plot a general bandstructure (spinpolarized)
-   - `bokeh`:
-      - :py:func:`~masci_tools.vis.bokeh_plots.bokeh_scatter()`: Make a scatterplot for a single set of data
-      - :py:func:`~masci_tools.vis.bokeh_plots.bokeh_multi_scatter()`: Make a scatterplot for a multiple sets of data
-      - :py:func:`~masci_tools.vis.bokeh_plots.bokeh_line()`: Make a line plot for multiple sets of data
-      - :py:func:`~masci_tools.vis.bokeh_plots.bokeh_dos()`: Plot a general density of states (non-spinpolarized)
-      - :py:func:`~masci_tools.vis.bokeh_plots.bokeh_spinpol_dos()`: Plot a general density of states (spinpolarized)
-      - :py:func:`~masci_tools.vis.bokeh_plots.bokeh_bands()`: Plot a general bandstructure (non-spinpolarized)
-      - :py:func:`~masci_tools.vis.bokeh_plots.bokeh_spinpol_bands()`: Plot a general bandstructure (spinpolarized)
-      - :py:func:`~masci_tools.vis.bokeh_plots.periodic_table_plot()`: Make a interactive plot of data for the periodic table
+.. currentmodule:: masci_tools.vis.common
 
-If you have ideas for new useful and beautiful plotting routines you are welcome to contribute. Refer to the sections :ref:`devguideplotting` and :ref:`devguideplotdata` for a guide on how to get started.
+- `common` (Can be used for both backends):
+  - :py:func:`scatter()`: Make a scatterplot with varying size and color of the points for multiple sets of data
+  - :py:func:`line()`: Make a lineplot with multiple sets of data
+  - :py:func:`dos()`: Plot a general density of states (non-spinpolarized)
+  - :py:func:`spinpol_dos()`: Plot a general density of states (spinpolarized)
+  - :py:func:`bands()`: Plot a general bandstructure (non-spinpolarized)
+  - :py:func:`spinpol_bands()`: Plot a general bandstructure (spinpolarized)
+
+.. currentmodule:: masci_tools.vis.plot_methods
+
+- `matplotlib`:
+  - :py:func:`single_scatterplot()`: Make a scatterplot with lines for a single set of data
+  - :py:func:`multiple_scatterplots()`: Make a scatterplot with lines for multiple sets of data
+  - :py:func:`multi_scatter_plot()`: Make a scatterplot with varying size and color of the points for multiple sets of data
+  - :py:func:`colormesh_plot()`: Make 2D plot with the data represented as color
+  - :py:func:`waterfall_plot()`: Make 3D plot with the `scatter3D` function of matplotlib
+  - :py:func:`surface_plot()`: Make 3D plot with the `plot_surface` function of matplotlib
+  - :py:func:`multiplot_moved()`: Plot multiple sets of data above each other with a configurable shift
+  - :py:func:`histogram()`: Make a histogram plot
+  - :py:func:`barchart()`: Make a barchart plot
+  - :py:func:`multiaxis_scatterplot()`: Make a plot containing multiple sets of data distributed over multiple subplots in a grid
+  - :py:func:`plot_convex_hull2d()`: Make a 2D plot of a convex hull
+  - :py:func:`plot_residuen()`: Make a residual plot for given real and fit data. Can also produce a histogram of the deviations
+  - :py:func:`plot_convergence()`: Plot the convergence behaviour of charge density distances and energies
+  - :py:func:`plot_lattice_constant()`: Plot the energy curve with changing unit cell volume
+  - :py:func:`plot_dos()`: Plot a general density of states (non-spinpolarized)
+  - :py:func:`plot_spinpol_dos()`: Plot a general density of states (spinpolarized)
+  - :py:func:`plot_bands()`: Plot a general bandstructure (non-spinpolarized)
+  - :py:func:`plot_spinpol_bands()`: Plot a general bandstructure (spinpolarized)
+  - :py:func:`plot_spectral_function`: Plot a spectral function (colormesh along kpath)
+
+.. currentmodule:: masci_tools.vis.bokeh_plots
+
+- `bokeh`:
+  - :py:func:`bokeh_scatter()`: Make a scatterplot for a single set of data
+  - :py:func:`bokeh_multi_scatter()`: Make a scatterplot for a multiple sets of data
+  - :py:func:`bokeh_line()`: Make a line plot for multiple sets of data
+  - :py:func:`bokeh_dos()`: Plot a general density of states (non-spinpolarized)
+  - :py:func:`bokeh_spinpol_dos()`: Plot a general density of states (spinpolarized)
+  - :py:func:`bokeh_bands()`: Plot a general bandstructure (non-spinpolarized)
+  - :py:func:`bokeh_spinpol_bands()`: Plot a general bandstructure (spinpolarized)
+  - :py:func:`bokeh_spectral_function()`: Plot a spectral function (colormesh along kpath)
+  - :py:func:`periodic_table_plot()`: Make a interactive plot of data for the periodic table
+  - :py:func:`plot_lattice_constant()`: Plot the energy curve with changing unit cell volume
+  - :py:func:`plot_convergence()`: Plot the convergence behaviour of charge density distances and energies
+  - :py:func:`matrix_plot()`: Plot a grid of rectangles with color scaling and added text
+
+If you have ideas for new useful and beautiful plotting routines you are welcome to
+contribute. Refer to the sections :ref:`devguideplotting` and :ref:`devguideplotdata` for
+a guide on how to get started.
 
 Providing Data
 --------------
 
 Data can be provided to plotting functions in two main ways:
 
-   1. The first arguments and data arguments are given the keys in a mapping, which should be used. The corresponding mapping is provided via the ``data`` keyword argument
-   2. The first arguments and data arguments are given the data that should be plotted against each other.
+1. The first arguments and data arguments are given the keys in a mapping,
+   which should be used. The corresponding mapping is provided via the `data` keyword argument
+2. The first arguments and data arguments are given the data that should be plotted against each other.
 
 The following two code blocks are equivalent in terms of the provided data.
 
-.. code-block::
+.. code-block:: python
 
    from masci_tools.vis.plot_methods import multiple_scatterplots
    import numpy as np
@@ -80,7 +101,7 @@ The following two code blocks are equivalent in terms of the provided data.
    #The default behaviour is that a list of lists is interpreted as multiple separate plots
    ax = multiple_scatterplots(x, [y1, y2])
 
-.. code-block::
+.. code-block:: python
 
    from masci_tools.vis.plot_methods import multiple_scatterplots
    import numpy as np
@@ -95,26 +116,50 @@ The following two code blocks are equivalent in terms of the provided data.
 Customizing Plots
 ------------------
 
-You might want to change the parameters of your plot. From changing the color, linestyle or shape of the markers there are a million options to tweak.
+.. currentmodule:: masci_tools.vis
 
-These can be set by simply passing the keyword arguments with the desired parameters to the plotting function. The names of these parameters mostly correspond to the same names as in the plotting library that is used in the plotting function. However, there are some deviations and also some special keywords that you can use. We will go over the most important ones in this section accompanied with concrete code examples. For a reference of the defaults defined in the ``masci_tools`` library you can refer to :py:class:`~masci_tools.vis.matplotlib_plotter.MatplotlibPlotter` and :py:class:`~masci_tools.vis.bokeh_plotter.BokehPlotter` for a complete reference.
+You might want to change the parameters of your plot. From changing the color,
+linestyle or shape of the markers there are a million options to tweak.
+These can be set by simply passing the keyword arguments with the desired parameters
+to the plotting function. The names of these parameters mostly correspond to the
+same names as in the plotting library that is used in the plotting function.
+However, there are some deviations and also some special keywords that you can use.
+We will go over the most important ones in this section accompanied with concrete code
+examples. For a reference of the defaults defined in the `masci_tools` library you can
+refer to :py:class:`matplotlib_plotter.MatplotlibPlotter` and
+:py:class:`bokeh_plotter.BokehPlotter` for a complete reference.
 
-The most important special keywords are listed below. If there are deviating names for these in ``matplotlib`` and ``bokeh`` plotting functions both names are written in the order ``matplotlib or bokeh``:
+The most important special keywords are listed below. If there are deviating names for
+these in `matplotlib` and `bokeh` plotting functions both names are written in the
+order `matplotlib or bokeh`:
 
-   - :limits: This is used to set the bounds of the axis specifically. Provided in form of a dictionary. For example passing ``limits={'x': (-5,5)}`` will set the x-axis limits between ``-5`` and ``5`` and ``limits={'x': (-5,5), 'y':(0,10)}`` will set the y-axis limits in addition
-   - :scale: Used to set the scaling of the axis in the plots. Also provided in form of a dictionary. For example passing ``scale={'x': 'log', 'y': 'log'}`` will set both axis to logarithmic scaling ``scale={'y': 'log'}`` will only to it for the y-axis
-   - :lines or straight_lines: Easy way to draw help lines into the plot. Provided in form of a dictionary. For example passing ``lines={'vertical': 0}`` will draw a vertical line at ``x=0`` ``lines={'horizontal': [1,5,10]}`` will draw three horizontal lines at ``y=1, 5 or 10`` respectively
-   - :plot_labels or legend_labels: Defines labels for the legend of a plot
-   - :labels for axis: Normally called ``xlabel`` or ``ylabel``, but specialized plot routines might have different names
-   - :title: Title for the produced plot
-   - :saving options: ``show=True`` call the plotting library specific show routines (default). For matplotlib you can also specify ``saveas='filename'`` and ``save_plots=True`` to save the plot to file
+- `limits`: This is used to set the bounds of the axis specifically. Provided in form
+  of a dictionary. For example passing `limits={'x': (-5,5)}` will set the x-axis limits
+  between `-5` and `5` and `limits={'x': (-5,5), 'y':(0,10)}` will set the y-axis limits 
+  in addition
+- `scale`: Used to set the scaling of the axis in the plots. Also provided in form
+  of a dictionary. For example passing `scale={'x': 'log', 'y': 'log'}` will set both
+  axis to logarithmic scaling `scale={'y': 'log'}` will only to it for the y-axis
+- `lines` or `straight_lines`: Easy way to draw help lines into the plot. Provided in form
+  of a dictionary. For example passing `lines={'vertical': 0}` will draw a vertical line
+  at `x=0` `lines={'horizontal': [1,5,10]}` will draw three horizontal lines
+  at `y=1, 5 or 10` respectively
+- `plot_labels`` or `legend_labels``: Defines labels for the legend of a plot
+- `labels for axis`: Normally called `xlabel` or `ylabel`, but specialized plot routines might have different names
+- `title`: Title for the produced plot
+- `saving options`: `show=True` call the plotting library specific show routines (default).
+  For matplotlib you can also specify `saveas='filename'` and `save_plots=True` to save the plot to file
 
-In the following we will look at examples using the matplotlib plotting functions in :py:mod:`~masci_tools.vis.plot_methods`. The options are the same for the bokeh plotting routines in :py:mod:`~masci_tools.vis.bokeh_plots`.
+In the following we will look at examples using the matplotlib plotting functions in
+:py:mod:`~masci_tools.vis.plot_methods`. The options are the same for the bokeh
+plotting routines in :py:mod:`~masci_tools.vis.bokeh_plots`.
 
 Single plots
 ^^^^^^^^^^^^^
 
-We start from the default result of calling the :py:func:`~masci_tools.vis.plot_methods.single_scatterplot()` function with an exponential function. Afterwards we go through examples of modifying this call in one particular way. All of these can be combined to customize the plot to your desire
+We start from the default result of calling the :py:func:`plot_methods.single_scatterplot()` function
+with an exponential function. Afterwards we go through examples of modifying this call in
+one particular way. All of these can be combined to customize the plot to your desire
 
 .. code-block:: python
 
@@ -203,12 +248,18 @@ See the `matplotlib`_ documentation for complete references of possible options
 Setting user defaults
 ^^^^^^^^^^^^^^^^^^^^^^
 
-If you wish to change some parameters for all the plots you want to do, you can use the functions :py:func:`~masci_tools.vis.plot_methods.set_mpl_plot_defaults()` or :py:func:`~masci_tools.vis.bokeh_plots.set_bokeh_plot_defaults()` for the matplotlib and bokeh plotting library respectively. These functions accept the same keyword arguments as above and they will be applied to all the next plots that you do.
+If you wish to change some parameters for all the plots you want to do, you can use the
+functions :py:func:`plot_methods.set_mpl_plot_defaults()` or
+:py:func:`bokeh_plots.set_bokeh_plot_defaults()` for the matplotlib and bokeh plotting
+library respectively. These functions accept the same keyword arguments as above and
+they will be applied to all the next plots that you do.
 
-You can reset the changes to the defaults with :py:func:`~masci_tools.vis.plot_methods.reset_mpl_plot_defaults()` or :py:func:`~masci_tools.vis.bokeh_plots.reset_bokeh_plot_defaults()`
+You can reset the changes to the defaults with :py:func:`plot_methods.reset_mpl_plot_defaults()`
+or :py:func:`bokeh_plots.reset_bokeh_plot_defaults()`
 
 .. note::
-   You can still override these defaults by simply passing in another value for the parameter you wish to overwrite in the call to a plotting function
+   You can still override these defaults by simply passing in another value for the
+   parameter you wish to overwrite in the call to a plotting function
 
 .. code-block:: python
 
@@ -229,13 +280,21 @@ You can reset the changes to the defaults with :py:func:`~masci_tools.vis.plot_m
 Multiple plots
 ^^^^^^^^^^^^^^^
 
-Many plotting routines accept multiple sets of data to plot. An example of this is the :py:func:`~masci_tools.vis.plot_methods.multiple_scatterplots()` function. The usage of these is essentially the same. However, some parameters can be changed for each data set to plot. These include but are not limited to ``linestyle``, ``linewidth``, ``marker``, ``markersize`` and ``color``. These parameters can either be set to a single value applying it to all data sets, or can be specified for some/all data sets with unspecified values being replaced with the current defaults. This second way can be done in two ways (Both of the below examples have the same effect):
+Many plotting routines accept multiple sets of data to plot. An example of this is the
+:py:func:`plot_methods.multiple_scatterplots()` function. The usage of these is essentially
+the same. However, some parameters can be changed for each data set to plot. These
+include but are not limited to `linestyle`, `linewidth`, `marker`, `markersize` and `color`.
+These parameters can either be set to a single value applying it to all data sets, or can
+be specified for some/all data sets with unspecified values being replaced with the current
+defaults. This second way can be done in two ways (Both of the below examples have the same
+effect):
 
-   1. List of values (``None`` for unspecified values) Example: ``linestyle=['-', None, '--']``
-   2. Dictionary with integer indices Example: ``linestyle={0:'-', 2:'--'}``
+1. List of values (`None` for unspecified values) Example: `linestyle=['-', None, '--']`
+2. Dictionary with integer indices Example: `linestyle={0:'-', 2:'--'}`
 
 .. warning::
-   Specifying parameters for multiple data sets is only valid for the parameters passed into the function. Setting defaults with values for multiple data sets is not supported
+   Specifying parameters for multiple data sets is only valid for the parameters passed
+   into the function. Setting defaults with values for multiple data sets is not supported
 
 Default plot
 """""""""""""

--- a/docs/source/user_guide/plotting.rst
+++ b/docs/source/user_guide/plotting.rst
@@ -27,7 +27,6 @@ case of matplotlib or the ``figure`` produced by bokeh for custom modifications.
 .. currentmodule:: masci_tools.vis.common
 
 ``common`` (Can be used for both backends):
-
 - :py:func:`scatter()`: Make a scatterplot with varying size and color of the points for multiple sets of data
 - :py:func:`line()`: Make a lineplot with multiple sets of data
 - :py:func:`dos()`: Plot a general density of states (non-spinpolarized)
@@ -38,7 +37,6 @@ case of matplotlib or the ``figure`` produced by bokeh for custom modifications.
 .. currentmodule:: masci_tools.vis.plot_methods
 
 ``matplotlib``:
-
 - :py:func:`single_scatterplot()`: Make a scatterplot with lines for a single set of data
 - :py:func:`multiple_scatterplots()`: Make a scatterplot with lines for multiple sets of data
 - :py:func:`multi_scatter_plot()`: Make a scatterplot with varying size and color of the points for multiple sets of data
@@ -61,8 +59,7 @@ case of matplotlib or the ``figure`` produced by bokeh for custom modifications.
 
 .. currentmodule:: masci_tools.vis.bokeh_plots
 
-`bokeh`:
-
+``bokeh``:
 - :py:func:`bokeh_scatter()`: Make a scatterplot for a single set of data
 - :py:func:`bokeh_multi_scatter()`: Make a scatterplot for a multiple sets of data
 - :py:func:`bokeh_line()`: Make a line plot for multiple sets of data

--- a/docs/source/user_guide/plotting.rst
+++ b/docs/source/user_guide/plotting.rst
@@ -10,7 +10,7 @@ The plotting of data is always a common task that needs to be performed.
 However, there is a lot of variation in how someone might want plots to look or be arranged.
 Some plots might also need to be interactive to be of a real use.
 
-For these reasons the `masci_tools` library provides utility for general plotting and
+For these reasons the ``masci_tools`` library provides utility for general plotting and
 template functions for common plots made when working with DFT methods.
 There are two plotting backends available:
 
@@ -21,57 +21,60 @@ Available Routines
 -------------------
 
 For both of these there are a lot of plotting routines available (both general or specific
-to a problem). All of these routines will return the used `Axes` object in the
-case of matplotlib or the `figure` produced by bokeh for custom modifications.
+to a problem). All of these routines will return the used ``Axes`` object in the
+case of matplotlib or the ``figure`` produced by bokeh for custom modifications.
 
 .. currentmodule:: masci_tools.vis.common
 
-- `common` (Can be used for both backends):
-  - :py:func:`scatter()`: Make a scatterplot with varying size and color of the points for multiple sets of data
-  - :py:func:`line()`: Make a lineplot with multiple sets of data
-  - :py:func:`dos()`: Plot a general density of states (non-spinpolarized)
-  - :py:func:`spinpol_dos()`: Plot a general density of states (spinpolarized)
-  - :py:func:`bands()`: Plot a general bandstructure (non-spinpolarized)
-  - :py:func:`spinpol_bands()`: Plot a general bandstructure (spinpolarized)
+``common`` (Can be used for both backends):
+
+- :py:func:`scatter()`: Make a scatterplot with varying size and color of the points for multiple sets of data
+- :py:func:`line()`: Make a lineplot with multiple sets of data
+- :py:func:`dos()`: Plot a general density of states (non-spinpolarized)
+- :py:func:`spinpol_dos()`: Plot a general density of states (spinpolarized)
+- :py:func:`bands()`: Plot a general bandstructure (non-spinpolarized)
+- :py:func:`spinpol_bands()`: Plot a general bandstructure (spinpolarized)
 
 .. currentmodule:: masci_tools.vis.plot_methods
 
-- `matplotlib`:
-  - :py:func:`single_scatterplot()`: Make a scatterplot with lines for a single set of data
-  - :py:func:`multiple_scatterplots()`: Make a scatterplot with lines for multiple sets of data
-  - :py:func:`multi_scatter_plot()`: Make a scatterplot with varying size and color of the points for multiple sets of data
-  - :py:func:`colormesh_plot()`: Make 2D plot with the data represented as color
-  - :py:func:`waterfall_plot()`: Make 3D plot with the `scatter3D` function of matplotlib
-  - :py:func:`surface_plot()`: Make 3D plot with the `plot_surface` function of matplotlib
-  - :py:func:`multiplot_moved()`: Plot multiple sets of data above each other with a configurable shift
-  - :py:func:`histogram()`: Make a histogram plot
-  - :py:func:`barchart()`: Make a barchart plot
-  - :py:func:`multiaxis_scatterplot()`: Make a plot containing multiple sets of data distributed over multiple subplots in a grid
-  - :py:func:`plot_convex_hull2d()`: Make a 2D plot of a convex hull
-  - :py:func:`plot_residuen()`: Make a residual plot for given real and fit data. Can also produce a histogram of the deviations
-  - :py:func:`plot_convergence()`: Plot the convergence behaviour of charge density distances and energies
-  - :py:func:`plot_lattice_constant()`: Plot the energy curve with changing unit cell volume
-  - :py:func:`plot_dos()`: Plot a general density of states (non-spinpolarized)
-  - :py:func:`plot_spinpol_dos()`: Plot a general density of states (spinpolarized)
-  - :py:func:`plot_bands()`: Plot a general bandstructure (non-spinpolarized)
-  - :py:func:`plot_spinpol_bands()`: Plot a general bandstructure (spinpolarized)
-  - :py:func:`plot_spectral_function`: Plot a spectral function (colormesh along kpath)
+``matplotlib``:
+
+- :py:func:`single_scatterplot()`: Make a scatterplot with lines for a single set of data
+- :py:func:`multiple_scatterplots()`: Make a scatterplot with lines for multiple sets of data
+- :py:func:`multi_scatter_plot()`: Make a scatterplot with varying size and color of the points for multiple sets of data
+- :py:func:`colormesh_plot()`: Make 2D plot with the data represented as color
+- :py:func:`waterfall_plot()`: Make 3D plot with the ``scatter3D`` function of matplotlib
+- :py:func:`surface_plot()`: Make 3D plot with the ``plot_surface`` function of matplotlib
+- :py:func:`multiplot_moved()`: Plot multiple sets of data above each other with a configurable shift
+- :py:func:`histogram()`: Make a histogram plot
+- :py:func:`barchart()`: Make a barchart plot
+- :py:func:`multiaxis_scatterplot()`: Make a plot containing multiple sets of data distributed over multiple subplots in a grid
+- :py:func:`plot_convex_hull2d()`: Make a 2D plot of a convex hull
+- :py:func:`plot_residuen()`: Make a residual plot for given real and fit data. Can also produce a histogram of the deviations
+- :py:func:`plot_convergence()`: Plot the convergence behaviour of charge density distances and energies
+- :py:func:`plot_lattice_constant()`: Plot the energy curve with changing unit cell volume
+- :py:func:`plot_dos()`: Plot a general density of states (non-spinpolarized)
+- :py:func:`plot_spinpol_dos()`: Plot a general density of states (spinpolarized)
+- :py:func:`plot_bands()`: Plot a general bandstructure (non-spinpolarized)
+- :py:func:`plot_spinpol_bands()`: Plot a general bandstructure (spinpolarized)
+- :py:func:`plot_spectral_function`: Plot a spectral function (colormesh along kpath)
 
 .. currentmodule:: masci_tools.vis.bokeh_plots
 
-- `bokeh`:
-  - :py:func:`bokeh_scatter()`: Make a scatterplot for a single set of data
-  - :py:func:`bokeh_multi_scatter()`: Make a scatterplot for a multiple sets of data
-  - :py:func:`bokeh_line()`: Make a line plot for multiple sets of data
-  - :py:func:`bokeh_dos()`: Plot a general density of states (non-spinpolarized)
-  - :py:func:`bokeh_spinpol_dos()`: Plot a general density of states (spinpolarized)
-  - :py:func:`bokeh_bands()`: Plot a general bandstructure (non-spinpolarized)
-  - :py:func:`bokeh_spinpol_bands()`: Plot a general bandstructure (spinpolarized)
-  - :py:func:`bokeh_spectral_function()`: Plot a spectral function (colormesh along kpath)
-  - :py:func:`periodic_table_plot()`: Make a interactive plot of data for the periodic table
-  - :py:func:`plot_lattice_constant()`: Plot the energy curve with changing unit cell volume
-  - :py:func:`plot_convergence()`: Plot the convergence behaviour of charge density distances and energies
-  - :py:func:`matrix_plot()`: Plot a grid of rectangles with color scaling and added text
+`bokeh`:
+
+- :py:func:`bokeh_scatter()`: Make a scatterplot for a single set of data
+- :py:func:`bokeh_multi_scatter()`: Make a scatterplot for a multiple sets of data
+- :py:func:`bokeh_line()`: Make a line plot for multiple sets of data
+- :py:func:`bokeh_dos()`: Plot a general density of states (non-spinpolarized)
+- :py:func:`bokeh_spinpol_dos()`: Plot a general density of states (spinpolarized)
+- :py:func:`bokeh_bands()`: Plot a general bandstructure (non-spinpolarized)
+- :py:func:`bokeh_spinpol_bands()`: Plot a general bandstructure (spinpolarized)
+- :py:func:`bokeh_spectral_function()`: Plot a spectral function (colormesh along kpath)
+- :py:func:`periodic_table_plot()`: Make a interactive plot of data for the periodic table
+- :py:func:`plot_lattice_constant()`: Plot the energy curve with changing unit cell volume
+- :py:func:`plot_convergence()`: Plot the convergence behaviour of charge density distances and energies
+- :py:func:`matrix_plot()`: Plot a grid of rectangles with color scaling and added text
 
 If you have ideas for new useful and beautiful plotting routines you are welcome to
 contribute. Refer to the sections :ref:`devguideplotting` and :ref:`devguideplotdata` for
@@ -83,7 +86,7 @@ Providing Data
 Data can be provided to plotting functions in two main ways:
 
 1. The first arguments and data arguments are given the keys in a mapping,
-   which should be used. The corresponding mapping is provided via the `data` keyword argument
+   which should be used. The corresponding mapping is provided via the ``data`` keyword argument
 2. The first arguments and data arguments are given the data that should be plotted against each other.
 
 The following two code blocks are equivalent in terms of the provided data.
@@ -125,30 +128,30 @@ to the plotting function. The names of these parameters mostly correspond to the
 same names as in the plotting library that is used in the plotting function.
 However, there are some deviations and also some special keywords that you can use.
 We will go over the most important ones in this section accompanied with concrete code
-examples. For a reference of the defaults defined in the `masci_tools` library you can
+examples. For a reference of the defaults defined in the ``masci_tools`` library you can
 refer to :py:class:`matplotlib_plotter.MatplotlibPlotter` and
 :py:class:`bokeh_plotter.BokehPlotter` for a complete reference.
 
 The most important special keywords are listed below. If there are deviating names for
-these in `matplotlib` and `bokeh` plotting functions both names are written in the
-order `matplotlib or bokeh`:
+these in ``matplotlib`` and ``bokeh`` plotting functions both names are written in the
+order ``matplotlib`` or ``bokeh``:
 
-- `limits`: This is used to set the bounds of the axis specifically. Provided in form
-  of a dictionary. For example passing `limits={'x': (-5,5)}` will set the x-axis limits
-  between `-5` and `5` and `limits={'x': (-5,5), 'y':(0,10)}` will set the y-axis limits 
+- ``limits``: This is used to set the bounds of the axis specifically. Provided in form
+  of a dictionary. For example passing ``limits={'x': (-5,5)}`` will set the x-axis limits
+  between ``-5`` and ``5`` and ``limits={'x': (-5,5), 'y':(0,10)}`` will set the y-axis limits 
   in addition
-- `scale`: Used to set the scaling of the axis in the plots. Also provided in form
-  of a dictionary. For example passing `scale={'x': 'log', 'y': 'log'}` will set both
-  axis to logarithmic scaling `scale={'y': 'log'}` will only to it for the y-axis
-- `lines` or `straight_lines`: Easy way to draw help lines into the plot. Provided in form
-  of a dictionary. For example passing `lines={'vertical': 0}` will draw a vertical line
-  at `x=0` `lines={'horizontal': [1,5,10]}` will draw three horizontal lines
-  at `y=1, 5 or 10` respectively
-- `plot_labels`` or `legend_labels``: Defines labels for the legend of a plot
-- `labels for axis`: Normally called `xlabel` or `ylabel`, but specialized plot routines might have different names
-- `title`: Title for the produced plot
-- `saving options`: `show=True` call the plotting library specific show routines (default).
-  For matplotlib you can also specify `saveas='filename'` and `save_plots=True` to save the plot to file
+- ``scale``: Used to set the scaling of the axis in the plots. Also provided in form
+  of a dictionary. For example passing ``scale={'x': 'log', 'y': 'log'}`` will set both
+  axis to logarithmic scaling ``scale={'y': 'log'}`` will only to it for the y-axis
+- ``lines`` or ``straight_lines``: Easy way to draw help lines into the plot. Provided in form
+  of a dictionary. For example passing ``lines={'vertical': 0}`` will draw a vertical line
+  at ``x=0`` ``lines={'horizontal': [1,5,10]}`` will draw three horizontal lines
+  at ``y=1, 5 or 10`` respectively
+- ``plot_labels``` or ``legend_labels```: Defines labels for the legend of a plot
+- ``labels for axis``: Normally called ``xlabel`` or ``ylabel``, but specialized plot routines might have different names
+- ``title``: Title for the produced plot
+- ``saving options``: ``show=True`` call the plotting library specific show routines (default).
+  For matplotlib you can also specify ``saveas='filename'`` and ``save_plots=True`` to save the plot to file
 
 In the following we will look at examples using the matplotlib plotting functions in
 :py:mod:`~masci_tools.vis.plot_methods`. The options are the same for the bokeh
@@ -283,14 +286,14 @@ Multiple plots
 Many plotting routines accept multiple sets of data to plot. An example of this is the
 :py:func:`plot_methods.multiple_scatterplots()` function. The usage of these is essentially
 the same. However, some parameters can be changed for each data set to plot. These
-include but are not limited to `linestyle`, `linewidth`, `marker`, `markersize` and `color`.
+include but are not limited to ``linestyle``, ``linewidth``, ``marker``, ``markersize`` and ``color``.
 These parameters can either be set to a single value applying it to all data sets, or can
 be specified for some/all data sets with unspecified values being replaced with the current
 defaults. This second way can be done in two ways (Both of the below examples have the same
 effect):
 
-1. List of values (`None` for unspecified values) Example: `linestyle=['-', None, '--']`
-2. Dictionary with integer indices Example: `linestyle={0:'-', 2:'--'}`
+1. List of values (``None`` for unspecified values) Example: ``linestyle=['-', None, '--']``
+2. Dictionary with integer indices Example: ``linestyle={0:'-', 2:'--'}``
 
 .. warning::
    Specifying parameters for multiple data sets is only valid for the parameters passed


### PR DESCRIPTION
Shorten references in user guide by using `.. currentmodule`. Also introduce explicit linebreaks to make the docs easier to edit. THe last should have no effect on the formatting in the actual webpage