### PR TITLE
Update docs build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3.1.2
       with:
-        python-version: 3.9
+        python-version: '3.10'
 
     - name: Cache python dependencies
       id: cache-pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v3.1.2
       with:
-        python-version: 3.9
+        python-version: '3.10'
 
     - name: Cache python dependencies
       id: cache-pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ formats:
   - pdf
 
 python:
-  version: 3.10
+  version: '3.10'
   install:
     - method: pip
       path: .
@@ -13,4 +13,4 @@ python:
         - docs
 
 build:
-  image: testing
+  os: ubuntu-20.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ formats:
   - pdf
 
 python:
-  version: 3.9
+  version: 3.10
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,6 @@ formats:
   - pdf
 
 python:
-  version: '3.10'
   install:
     - method: pip
       path: .
@@ -14,3 +13,5 @@ python:
 
 build:
   os: ubuntu-20.04
+  tools:
+    python: "3.10"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## latest
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.10.0...develop)
 
-Nothing here yet
+### For Developers
+- Docs: Updated `sphinx` and `sphinx-autodoc-typehints` versions and build docs on python 3.10 [[#156]](https://github.com/JuDFTteam/masci-tools/pull/#156)
 
 ## v0.10.1
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.10.0...v0.10.1)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,8 +36,6 @@ extensions = ['myst_parser',
               'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode',
               'sphinx.ext.intersphinx',
-              'sphinx_toolbox.more_autodoc.typehints',
-              'sphinx_toolbox.more_autodoc.overloads',
               'sphinx_autodoc_typehints',
               'sphinx_click']
 
@@ -255,7 +253,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
         # No sphinx_rtd_theme installed
         pass
 
-autodoc_mock_imports = ['bokeh']
+autodoc_mock_imports = ['bokeh', '_typeshed']
 
 
 # -- Options for manual page output ---------------------------------------
@@ -397,15 +395,10 @@ nitpick_ignore = [
     ('py:obj', 'plum'),
     ('py:class', 'etree._XPathObject'),
     ('py:class', 'h5py._hl.group.Group'),
-    ('py:class', 'etree._Element'),
-    ('py:class', 'etree.XPath'),
     ('py:class', 'TypeAlias'),
-    ('py:class', 'Logger'),
-    ('py:class', 'FilterType'),
-    ('py:class', 'XMLLike'),
-    ('py:class', 'etree.XPathElementEvaluator'),
     ('py:class', 'contextlib._GeneratorContextManager'),
-    ('py:data', 'masci_tools.io.parsers.fleur.fleur_outxml_parser.F')
+    ('py:data', 'masci_tools.io.parsers.fleur.fleur_outxml_parser.F'),
+    ('py:class', 'np.ndarray')
 ]
 
 

--- a/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
+++ b/masci_tools/io/parsers/fleur_schema/fleur_schema_parser_functions.py
@@ -1214,7 +1214,7 @@ def get_text_tags(xmlschema_evaluator: etree.XPathDocumentEvaluator, **kwargs: A
     """
     find all elements, who can contain text
 
-    :param xmlschema: xmltree representing the schema
+    :param xmlschema_evaluator: xmltree representing the schema
 
     :return: dictionary with tags and their corresponding type_definition
              meaning a dictionary with possible base types and evtl. length restriction

--- a/masci_tools/util/xml/converters.py
+++ b/masci_tools/util/xml/converters.py
@@ -14,7 +14,7 @@ Common functions for converting types to and from XML files
 """
 from __future__ import annotations
 
-from typing import Iterable, Any, cast
+from typing import Iterable, Any, cast, Union
 import sys
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -30,7 +30,7 @@ from masci_tools.io.parsers import fleur_schema
 import re
 
 BaseType: TypeAlias = Literal['int', 'switch', 'string', 'float', 'float_expression', 'complex']
-ConvertedType: TypeAlias = 'int | float | bool | str | complex'
+ConvertedType: TypeAlias = Union[int,float,bool,str,complex]
 
 
 def convert_to_xml(value: Any | list[Any],

--- a/masci_tools/util/xml/converters.py
+++ b/masci_tools/util/xml/converters.py
@@ -30,7 +30,7 @@ from masci_tools.io.parsers import fleur_schema
 import re
 
 BaseType: TypeAlias = Literal['int', 'switch', 'string', 'float', 'float_expression', 'complex']
-ConvertedType: TypeAlias = Union[int,float,bool,str,complex]
+ConvertedType: TypeAlias = Union[int, float, bool, str, complex]
 
 
 def convert_to_xml(value: Any | list[Any],

--- a/masci_tools/util/xml/xpathbuilder.py
+++ b/masci_tools/util/xml/xpathbuilder.py
@@ -15,7 +15,7 @@ general attribute conditions from simple XPath expressions
 """
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Dict
 import sys
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -24,7 +24,7 @@ else:
 
 from lxml import etree
 
-FilterType: TypeAlias = 'dict[str, Any]'
+FilterType: TypeAlias = Dict[str, Any]
 """
 Type for filters argument for XPathBuilder
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,10 +54,9 @@ pre-commit = [
     'types-click'
     ]
 docs = [
-    'sphinx~=4.1',
+    'sphinx~=4.5',
     'sphinx_rtd_theme',
     'sphinx-click',
-    'sphinx-toolbox<=2.15.2',
     'sphinx-autodoc-typehints',
     "myst-parser~=0.15.2",
     ]


### PR DESCRIPTION
The docs are now build on python 3.10. The reason for this are some
unsupported things related to the typehints. This switch allows the
simplification of the requirements and dropping the sphinx-toolbox
requirement