### PR TITLE
Add module for tools to use in an ipython/jupyter notebook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,4 +103,5 @@ repos:
             masci_tools/tools/greensfunction.py|
             masci_tools/cmdline/parameters/slice.py|
             masci_tools/vis/parameters.py|
+            masci_tools/util/ipython.py|
         )$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
        type=kpoint_type)
   ```
 - Function `serialize_xml_arguments` to `masci_tools.util.xml.common_functions` to remove XML elements/trees from positional/keyword arguments and replace them with string representations of the XML. Can be used in AiiDA-Fleur
+- Module `masci_tools.util.ipython` and ipython extension (`%load_ext masci_tools`). Adds syntax highlighted XML tree output and creating HTML syntax highlighted diffs of XML trees [[#158]](https://github.com/JuDFTteam/masci-tools/pull/158)
 
 ### Improvements
 - Added `name` entry to `SchemaDict.tag_info` which contains the tag name in the original case [[#159]](https://github.com/JuDFTteam/masci-tools/pull/159)

--- a/masci_tools/__init__.py
+++ b/masci_tools/__init__.py
@@ -25,3 +25,12 @@ __version__ = '0.10.1'
 __authors__ = 'The JuDFT team. Also see AUTHORS.txt file.'
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+
+def load_ipython_extension(ipython):
+    """
+    Load ipython extensions in this package
+    """
+    from masci_tools.util.ipython import register_formatters
+
+    register_formatters(ipython)

--- a/masci_tools/util/ipython.py
+++ b/masci_tools/util/ipython.py
@@ -11,7 +11,7 @@ from pygments.formatters import HtmlFormatter  #pylint: disable=no-name-in-modul
 from masci_tools.util.typing import XMLLike
 from typing import Any
 import difflib
-from IPython.display import HTML
+from IPython.display import HTML #pylint: disable=import-error
 
 
 def display_xml(data: XMLLike) -> str:

--- a/masci_tools/util/ipython.py
+++ b/masci_tools/util/ipython.py
@@ -11,7 +11,7 @@ from pygments.formatters import HtmlFormatter  #pylint: disable=no-name-in-modul
 from masci_tools.util.typing import XMLLike
 from typing import Any
 import difflib
-from IPython.display import HTML #pylint: disable=import-error
+from IPython.display import HTML  #pylint: disable=import-error
 
 
 def display_xml(data: XMLLike) -> str:

--- a/masci_tools/util/ipython.py
+++ b/masci_tools/util/ipython.py
@@ -1,0 +1,31 @@
+"""
+Import this module to activate useful ipython extensions
+"""
+from __future__ import annotations
+
+from lxml import etree
+from pygments import highlight
+from pygments.lexers import XmlLexer  #pylint: disable=no-name-in-module
+from pygments.formatters import HtmlFormatter  #pylint: disable=no-name-in-module
+
+from masci_tools.util.typing import XMLLike
+
+
+def display_xml(data: XMLLike) -> str:
+    """
+    Display the given lxml XML tree as formatted HTML
+
+    :param data: data to show
+
+    :returns: HTML string for presentation in Jupyter notebooks
+    """
+
+    xmlstring = etree.tostring(data, encoding='unicode', pretty_print=True)
+    return highlight(xmlstring, XmlLexer(), HtmlFormatter(noclasses=True))
+
+
+def register_formatters(ipython):
+
+    html_formatter = ipython.display_formatter.formatters['text/html']
+    html_formatter.for_type(etree._Element, display_xml)
+    html_formatter.for_type(etree._ElementTree, display_xml)

--- a/masci_tools/util/ipython.py
+++ b/masci_tools/util/ipython.py
@@ -25,7 +25,7 @@ def display_xml(data: XMLLike) -> str:
     xmlstring = etree.tostring(data, encoding='unicode', pretty_print=True)
     return highlight(xmlstring, XmlLexer(), HtmlFormatter(noclasses=True,nobackground=False, style='monokai'))
 
-def compare_xml_diff(old: XMLLike, new: XMLLike):
+def xml_diff(old: XMLLike, new: XMLLike):
 
     old_lines = etree.tostring(old, encoding='unicode', pretty_print=True).split('\n')
     new_lines = etree.tostring(new, encoding='unicode', pretty_print=True).split('\n')

--- a/masci_tools/util/ipython.py
+++ b/masci_tools/util/ipython.py
@@ -9,6 +9,7 @@ from pygments.lexers import XmlLexer  #pylint: disable=no-name-in-module
 from pygments.formatters import HtmlFormatter  #pylint: disable=no-name-in-module
 
 from masci_tools.util.typing import XMLLike
+from typing import Any
 
 
 def display_xml(data: XMLLike) -> str:
@@ -24,7 +25,7 @@ def display_xml(data: XMLLike) -> str:
     return highlight(xmlstring, XmlLexer(), HtmlFormatter(noclasses=True))
 
 
-def register_formatters(ipython):
+def register_formatters(ipython: Any) -> None:
 
     html_formatter = ipython.display_formatter.formatters['text/html']
     html_formatter.for_type(etree._Element, display_xml)

--- a/masci_tools/util/ipython.py
+++ b/masci_tools/util/ipython.py
@@ -13,6 +13,7 @@ from typing import Any
 import difflib
 from IPython.display import HTML
 
+
 def display_xml(data: XMLLike) -> str:
     """
     Display the given lxml XML tree as formatted HTML
@@ -23,9 +24,29 @@ def display_xml(data: XMLLike) -> str:
     """
 
     xmlstring = etree.tostring(data, encoding='unicode', pretty_print=True)
-    return highlight(xmlstring, XmlLexer(), HtmlFormatter(noclasses=True,nobackground=False, style='monokai'))
+    return highlight(xmlstring, XmlLexer(), HtmlFormatter(noclasses=True, nobackground=False))
 
-def xml_diff(old: XMLLike, new: XMLLike):
+
+def xml_diff(old: XMLLike, new: XMLLike, indent: bool = True) -> HTML:
+    """
+    Create a diff of two lxml trees with HTML with syntax highlighting
+
+    :param old: original XML tree
+    :param new: modified XML tree
+    :param indent: bool, if True etree.indent is called on the trees before diff
+    """
+
+    STYLES = {
+        'control': 'font-weight: bold',
+        'delete': 'background-color: hsla(0, 100%, 74%, 0.5); color: #000000;',
+        'delete-detail': 'background-color: hsla(0, 100%, 74%, 0.5); color: #000000;',
+        'insert': 'background-color: hsla(102, 100%, 74%, 0.5); color: #000000;',
+        'insert-detail': 'background-color: hsla(102, 100%, 74%, 0.5); color: #000000;',
+    }
+
+    if indent:
+        etree.indent(old)
+        etree.indent(new)
 
     old_lines = etree.tostring(old, encoding='unicode', pretty_print=True).split('\n')
     new_lines = etree.tostring(new, encoding='unicode', pretty_print=True).split('\n')
@@ -40,34 +61,8 @@ def xml_diff(old: XMLLike, new: XMLLike):
     lines = lines[first_block:]
     lines.reverse()
 
-    diff_blocks = []
-    current_block = None
-
-    css = """\
-    <style type="text/css">
-        .diff .control {
-            background-color: #eaf2f5;
-            color: #999999;
-        }
-
-        .insert {
-            background-color: hsla(102, 100%, 74%, 0.5);
-            color: #000000;
-        }
-        .insert .detail {
-            background-color: hsla(102, 100%, 50%, 0.5);
-            color: #000000;
-        }
-        .delete {
-            background-color: hsla(0, 100%, 74%, 0.5); //semi-transparent red
-            color: #000000;
-        }
-        .delete .detail {
-            background-color:  hsla(0, 100%, 50%, 0.5);
-            color: #000000;
-        }
-    </style>
-    """
+    diff_blocks: list[str] = []
+    current_block: list[str] = []
 
     def highlight_xml(xmlstring):
         return highlight(xmlstring, XmlLexer(), HtmlFormatter(noclasses=True, nowrap=True)).rstrip('\n')
@@ -78,61 +73,61 @@ def xml_diff(old: XMLLike, new: XMLLike):
         aline = []
         bline = []
         for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(a=a, b=b).get_opcodes():
-            if tag == "equal":
+            if tag == 'equal':
                 aline.append(a[i1:i2])
                 bline.append(b[j1:j2])
                 continue
-            aline.append(f'<span class="detail">{a[i1:i2]}</span>')
-            bline.append(f'<span class="detail">{b[j1:j2]}</span>')
-        return "".join(aline), "".join(bline)
+            aline.append(f'<span style="{STYLES["delete-detail"]}">{a[i1:i2]}</span>')
+            bline.append(f'<span style="{STYLES["insert-detail"]}">{b[j1:j2]}</span>')
+        return ''.join(aline), ''.join(bline)
 
     while lines:
         line = lines.pop()
         if line.startswith('@@') or not lines:
-            line = line.strip('\n@- ').replace(',',' (')
-            print(line)
+            line = line.strip('\n@- ').replace(',', ' (')
             original, _, changed = line.partition('+')
-            line = f'Original: line {original} lines)\n' \
-                f' Changed line {changed} lines)'
+            control_lines = [f'Original: line {original} lines)', f'Changed line {changed} lines)']
 
-            if current_block is None:
-                current_block = [f'<span class="control"> {line}</span>']
+            if len(current_block) == 0:
+                current_block = [f'<span style="{STYLES["control"]}"> {line}</span>' for line in control_lines]
             else:
                 current_block.append('<span></span>')
                 diff_blocks.append('\n'.join(current_block))
-                current_block = [f'<span class="control"> {line}</span>']
+                current_block = [f'<span style="{STYLES["control"]}"> {line}</span>' for line in control_lines]
         elif line.startswith('-'):
             if lines:
-                _next = []
+                _next: list[str] = []
                 while lines and len(_next) < 2:
                     _next.append(lines.pop())
-                if _next[0].startswith("+") and (
-                        len(_next) == 1 or _next[1][0] not in ("+", "-")):
+                if _next[0].startswith('+') and (len(_next) == 1 or _next[1][0] not in ('+', '-')):
                     aline, bline = _line_diff(line[1:], _next.pop(0)[1:])
-                    current_block.append(f'<span class="delete"> {aline}</span>')
-                    current_block.append(f'<span class="insert"> {bline}</span>')
+                    current_block.append(f'<span style="{STYLES["delete"]}"> {aline}</span>')
+                    current_block.append(f'<span style="{STYLES["insert"]}"> {bline}</span>')
                     if _next:
                         lines.append(_next.pop())
                     continue
                 lines.extend(reversed(_next))
-            current_block.append(f'<span class="delete"> {highlight_xml(line[1:])}</span>')
+            current_block.append(f'<span style="{STYLES["delete"]}"> {highlight_xml(line[1:])}</span>')
         elif line.startswith('+'):
-            current_block.append(f'<span class="insert"> {highlight_xml(line[1:])}</span>')
-        elif current_block is not None:
+            current_block.append(f'<span style="{STYLES["insert"]}"> {highlight_xml(line[1:])}</span>')
+        elif len(current_block) > 0:
             current_block.append(highlight_xml(line))
 
-    diff_blocks = '\n'.join(diff_blocks)
-    
-    return HTML(f"""
-    {css}
-    <pre style="line-height: 125%;"><span></span>
-    {diff_blocks}
-    </pre>
-    """ )
+    diff = '\n'.join(diff_blocks)
+
+    formatter = HtmlFormatter()
+
+    return HTML(f"""<div class="{formatter.cssclass}" style="background: {formatter.style.background_color}">
+<pre style="line-height: 125%;">
+{diff}
+</pre></div>
+""")
 
 
 def register_formatters(ipython: Any) -> None:
-
+    """
+    Register formatter of lxml trees in HTML form
+    """
     html_formatter = ipython.display_formatter.formatters['text/html']
     html_formatter.for_type(etree._Element, display_xml)
     html_formatter.for_type(etree._ElementTree, display_xml)

--- a/masci_tools/util/ipython.py
+++ b/masci_tools/util/ipython.py
@@ -10,7 +10,8 @@ from pygments.formatters import HtmlFormatter  #pylint: disable=no-name-in-modul
 
 from masci_tools.util.typing import XMLLike
 from typing import Any
-
+import difflib
+from IPython.display import HTML
 
 def display_xml(data: XMLLike) -> str:
     """
@@ -22,7 +23,112 @@ def display_xml(data: XMLLike) -> str:
     """
 
     xmlstring = etree.tostring(data, encoding='unicode', pretty_print=True)
-    return highlight(xmlstring, XmlLexer(), HtmlFormatter(noclasses=True))
+    return highlight(xmlstring, XmlLexer(), HtmlFormatter(noclasses=True,nobackground=False, style='monokai'))
+
+def compare_xml_diff(old: XMLLike, new: XMLLike):
+
+    old_lines = etree.tostring(old, encoding='unicode', pretty_print=True).split('\n')
+    new_lines = etree.tostring(new, encoding='unicode', pretty_print=True).split('\n')
+
+    lines = list(difflib.unified_diff(old_lines, new_lines))
+
+    for index, line in enumerate(lines):
+        if line.startswith('@@'):
+            first_block = index
+            break
+
+    lines = lines[first_block:]
+    lines.reverse()
+
+    diff_blocks = []
+    current_block = None
+
+    css = """\
+    <style type="text/css">
+        .diff .control {
+            background-color: #eaf2f5;
+            color: #999999;
+        }
+
+        .insert {
+            background-color: hsla(102, 100%, 74%, 0.5);
+            color: #000000;
+        }
+        .insert .detail {
+            background-color: hsla(102, 100%, 50%, 0.5);
+            color: #000000;
+        }
+        .delete {
+            background-color: hsla(0, 100%, 74%, 0.5); //semi-transparent red
+            color: #000000;
+        }
+        .delete .detail {
+            background-color:  hsla(0, 100%, 50%, 0.5);
+            color: #000000;
+        }
+    </style>
+    """
+
+    def highlight_xml(xmlstring):
+        return highlight(xmlstring, XmlLexer(), HtmlFormatter(noclasses=True, nowrap=True)).rstrip('\n')
+
+    def _line_diff(a, b):
+
+        a, b = highlight_xml(a), highlight_xml(b)
+        aline = []
+        bline = []
+        for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(a=a, b=b).get_opcodes():
+            if tag == "equal":
+                aline.append(a[i1:i2])
+                bline.append(b[j1:j2])
+                continue
+            aline.append(f'<span class="detail">{a[i1:i2]}</span>')
+            bline.append(f'<span class="detail">{b[j1:j2]}</span>')
+        return "".join(aline), "".join(bline)
+
+    while lines:
+        line = lines.pop()
+        if line.startswith('@@') or not lines:
+            line = line.strip('\n@- ').replace(',',' (')
+            print(line)
+            original, _, changed = line.partition('+')
+            line = f'Original: line {original} lines)\n' \
+                f' Changed line {changed} lines)'
+
+            if current_block is None:
+                current_block = [f'<span class="control"> {line}</span>']
+            else:
+                current_block.append('<span></span>')
+                diff_blocks.append('\n'.join(current_block))
+                current_block = [f'<span class="control"> {line}</span>']
+        elif line.startswith('-'):
+            if lines:
+                _next = []
+                while lines and len(_next) < 2:
+                    _next.append(lines.pop())
+                if _next[0].startswith("+") and (
+                        len(_next) == 1 or _next[1][0] not in ("+", "-")):
+                    aline, bline = _line_diff(line[1:], _next.pop(0)[1:])
+                    current_block.append(f'<span class="delete"> {aline}</span>')
+                    current_block.append(f'<span class="insert"> {bline}</span>')
+                    if _next:
+                        lines.append(_next.pop())
+                    continue
+                lines.extend(reversed(_next))
+            current_block.append(f'<span class="delete"> {highlight_xml(line[1:])}</span>')
+        elif line.startswith('+'):
+            current_block.append(f'<span class="insert"> {highlight_xml(line[1:])}</span>')
+        elif current_block is not None:
+            current_block.append(highlight_xml(line))
+
+    diff_blocks = '\n'.join(diff_blocks)
+    
+    return HTML(f"""
+    {css}
+    <pre style="line-height: 125%;"><span></span>
+    {diff_blocks}
+    </pre>
+    """ )
 
 
 def register_formatters(ipython: Any) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,8 @@ module = [
     'h5py',
     'humanfriendly',
     'yaml',
-    'lxml.builder'
+    'lxml.builder',
+    'IPython.*'
 ]
 follow_imports = 'skip'
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ pre-commit = [
     'lxml-stubs~=0.4.0',
     'types-pytz',
     'types-tabulate',
-    'types-click'
+    'types-click',
+    'types-pygments'
     ]
 docs = [
     'sphinx~=4.5',


### PR DESCRIPTION
Pulled out of #157 

To use add `%load_ext masci_tools`

For now this includes rendering lxml trees with syntax highlighting
and HTML

Other ideas:
- [x] diffing xml trees

Example from the above mentioned pull request docs

<img width="761" alt="Screenshot 2022-04-25 at 11 09 14" src="https://user-images.githubusercontent.com/11249470/165058059-0ce3072f-9f4d-4eb5-bb13-a9c7abb09709.png">

