### PR TITLE
Autogenerate docstrings in `FleurXMLModifier` via pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,13 @@ repos:
 - repo: local
   hooks:
 
+  #Since this runs after the formatter the docstrings should already satisfy all other hooks
+  - id: make-fleurxmlmodifier-doc
+    name: Generate Docstrings for Setter methods of FleurXMLModifier
+    entry: python ./utils/write_fleurxmlmodifier_docstrings.py
+    language: system
+    pass_filenames: false
+
   - id: pylint-errors
     name: pylint-errors
     entry: pylint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ string of the content. The content no longer has to be manually encoded as bytes
 ### For Developers
 - Docs: Updated `sphinx` and `sphinx-autodoc-typehints` versions and build docs on python 3.10 [[#156]](https://github.com/JuDFTteam/masci-tools/pull/156)
 - Bokeh regression tests now strip out the bokeh version from the test files
+- Added pre-commit hook, which generates the docstrings for the `FleurXMLModifier` registration methods from their XML setter function counterparts [[#166]](https://github.com/JuDFTteam/masci-tools/pull/166)
 
 ## v0.10.1
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.10.0...v0.10.1)

--- a/docs/source/module_guide/tools.rst
+++ b/docs/source/module_guide/tools.rst
@@ -16,6 +16,8 @@ Custom Datatypes
 
 Common XML utility
 ------------------
+.. automodule:: masci_tools.util.xml
+   :members:
 
 .. automodule:: masci_tools.util.xml.common_functions
    :members:

--- a/masci_tools/io/fleurxmlmodifier.py
+++ b/masci_tools/io/fleurxmlmodifier.py
@@ -14,6 +14,11 @@ This module contains a class for organizing and grouping changes to a input file
 of fleur in a robust way.
 
 Essentially a low-level version of the FleurinpModifier in aiida_fleur.
+
+.. note::
+    The docstrings for the setter methods are generated from their actual implementations
+    in the :py:mod:`~masci_tools.util.xml` modules via a pre-commit hook. Changes in the docstrings
+    here will be overwritten
 """
 from __future__ import annotations
 
@@ -371,15 +376,21 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_inpchanges()` to
         the list of tasks that will be done on the xmltree.
 
-        :param changes: a dictionary with changes
+        This method sets all the attribute and texts provided in the change_dict.
+
+        The first occurrence of the attribute/tag is set
+
+        :param changes: dictionary {attrib_name : value} with all the wanted changes.
         :param path_spec: dict, with ggf. necessary further specifications for the path of the attribute
 
         An example of changes::
 
-            changes = {'itmax' : 1,
-                       'l_noco': True,
-                       'ctail': False,
-                       'l_ss': True}
+            changes = {
+                'itmax' : 1,
+                'l_noco': True,
+                'ctail': False,
+                'l_ss': True
+            }
         """
         if 'change_dict' in kwargs:
             warnings.warn('The argument change_dict is deprecated. Use changes instead', DeprecationWarning)
@@ -392,11 +403,16 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.shift_value()` to
         the list of tasks that will be done on the xmltree.
 
+        Shifts numerical values of attributes directly in the inp.xml file.
+
+        The first occurrence of the attribute is shifted
+
         :param changes: a python dictionary with the keys to shift and the shift values.
         :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
                      `rel`/`relative` multiplies the old value with the given value
                      `abs`/`absolute` adds the old value and the given value
         :param path_spec: dict, with ggf. necessary further specifications for the path of the attribute
+
 
         An example of changes::
 
@@ -413,11 +429,19 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_species()` to
         the list of tasks that will be done on the xmltree.
 
+        Method to set parameters of a species tag of the fleur inp.xml file.
+
         :param species_name: string, name of the specie you want to change
                              Can be name of the species, 'all' or 'all-<string>' (sets species with the string in the species name)
         :param changes: a python dict specifying what you want to change.
+        :param create: bool, if species does not exist create it and all subtags?
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
+        :raises ValueError: if species name is non existent in inp.xml and should not be created.
+                            also if other given tags are garbage. (errors from eval_xpath() methods)
+
+        :return xmltree: xml etree of the new inp.xml
 
         **changes** is a python dictionary containing dictionaries that specify attributes
         to be set inside the certain specie. For example, if one wants to set a MT radius it
@@ -445,9 +469,12 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_species_label()` to
         the list of tasks that will be done on the xmltree.
 
+        This method calls :func:`~masci_tools.util.xml.xml_setters_names.set_species()`
+        method for a certain atom species that corresponds to an atom with a given label
+
         :param atom_label: string, a label of the atom which specie will be changed. 'all' to change all the species
         :param changes: a python dict specifying what you want to change.
-
+        :param create: bool, if species does not exist create it and all subtags?
         """
         if 'attributedict' in kwargs:
             warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
@@ -460,8 +487,12 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.clone_species()` to
         the list of tasks that will be done on the xmltree.
 
+        Method to create a new species from an existing one with evtl. modifications
+
+        For reference of the changes dictionary look at :py:func:`set_species()`
+
         :param species_name: string, name of the specie you want to clone
-                            Has to correspond to one single species (no 'all'/'all-<search_string>')
+                             Has to correspond to one single species (no 'all'/'all-<search_string>')
         :param new_name: new name of the cloned species
         :param changes: a optional python dict specifying what you want to change.
         """
@@ -473,14 +504,16 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.switch_species()` to
         the list of tasks that will be done on the xmltree.
 
+        Method to switch the species of an atom group of the fleur inp.xml file.
+
         :param new_species_name: name of the species to switch to
         :param position: position of an atom group to be changed. If equals to 'all', all species will be changed
         :param species: atom groups, corresponding to the given species will be changed
         :param clone: if True and the new species name does not exist and it corresponds to changing
-                  from one species the species will be cloned with :py:func:`clone_species()`
+                      from one species the species will be cloned with :py:func:`clone_species()`
         :param changes: changes to do if the species is cloned
         :param filters: Dict specifying constraints to apply on the xpath.
-                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details`
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         """
         self._validate_arguments('switch_species', args, kwargs)
         self._tasks.append(ModifierTask('switch_species', args, kwargs))
@@ -490,10 +523,13 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.switch_species_label()` to
         the list of tasks that will be done on the xmltree.
 
+        Method to switch the species of an atom group of the fleur inp.xml file based on a label
+        of a contained atom
+
         :param atom_label: string, a label of the atom which group will be changed. 'all' to change all the groups
         :param new_species_name: name of the species to switch to
         :param clone: if True and the new species name does not exist and it corresponds to changing
-                  from one species the species will be cloned with :py:func:`clone_species()`
+                      from one species the species will be cloned with :py:func:`clone_species()`
         :param changes: changes to do if the species is cloned
         """
         self._validate_arguments('switch_species_label', args, kwargs)
@@ -504,17 +540,19 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.shift_value_species_label()` to
         the list of tasks that will be done on the xmltree.
 
+        Shifts the value of an attribute on a species by label
+        if atom_label contains 'all' then applies to all species
+
         :param atom_label: string, a label of the atom which specie will be changed. 'all' if set up all species
         :param attribute_name: name of the attribute to change
         :param number_to_add: value to add or to multiply by
         :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
-                    `rel`/`relative` multiplies the old value with `number_to_add`
-                    `abs`/`absolute` adds the old value and `number_to_add`
+                     `rel`/`relative` multiplies the old value with `number_to_add`
+                     `abs`/`absolute` adds the old value and `number_to_add`
 
         Kwargs if the attribute_name does not correspond to a unique path:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
-
         """
         if 'attributename' in kwargs:
             warnings.warn('The argument attributename is deprecated. Use attribute_name instead', DeprecationWarning)
@@ -530,18 +568,20 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_atomgroup()` to
         the list of tasks that will be done on the xmltree.
 
+        Method to set parameters of an atom group of the fleur inp.xml file.
+
         :param changes: a python dict specifying what you want to change.
         :param position: position of an atom group to be changed. If equals to 'all', all species will be changed
         :param species: atom groups, corresponding to the given species will be changed
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
+
         **changes** is a python dictionary containing dictionaries that specify attributes
         to be set inside the certain specie. For example, if one wants to set a beta noco parameter it
         can be done via::
 
             'changes': {'nocoParams': {'beta': val}}
-
         """
         if 'attributedict' in kwargs:
             warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
@@ -557,15 +597,18 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_atomgroup_label()` to
         the list of tasks that will be done on the xmltree.
 
+        This method calls :func:`~masci_tools.util.xml.xml_setters_names.set_atomgroup()`
+        method for a certain atom species that corresponds to an atom with a given label.
+
         :param atom_label: string, a label of the atom which specie will be changed. 'all' to change all the species
         :param changes: a python dict specifying what you want to change.
+
 
         **changes** is a python dictionary containing dictionaries that specify attributes
         to be set inside the certain specie. For example, if one wants to set a beta noco parameter it
         can be done via::
 
             'changes': {'nocoParams': {'beta': val}}
-
         """
         if 'attributedict' in kwargs:
             warnings.warn('The argument attributedict is deprecated. Use changes instead', DeprecationWarning)
@@ -581,15 +624,19 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.create_tag()` to
         the list of tasks that will be done on the xmltree.
 
-        :param tag: str of the tag to create or etree Element with the same name
+        This method creates a tag with a uniquely identified xpath under the nodes of its parent.
+        If there are no nodes evaluated the subtags can be created with `create_parents=True`
+
+        The tag is always inserted in the correct place if a order is enforced by the schema
+
+        :param tag: str of the tag to create or etree Element or string representing the XML element with the same name to insert
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
+        :param filters: Dict specifying constraints to apply on the xpath.
+                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
         :param create_parents: bool optional (default False), if True and the given xpath has no results the
                                the parent tags are created recursively
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
-        :param filters: Dict specifying constraints to apply on the xpath.
-                        See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -603,13 +650,14 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.delete_tag()` to
         the list of tasks that will be done on the xmltree.
 
+        This method deletes a tag with a uniquely identified xpath.
+
         :param tag: str of the tag to delete
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param occurrences: int or list of int. Which occurrence of the parent nodes to delete a tag.
-                            By default all nodes are used.
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param occurrences: int or list of int. Which occurrence of the parent nodes to delete a tag.
+                            By default all nodes are used.
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -623,13 +671,14 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.delete_att()` to
         the list of tasks that will be done on the xmltree.
 
+        This method deletes a attribute with a uniquely identified xpath.
+
         :param name: str of the attribute to delete
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param occurrences: int or list of int. Which occurrence of the parent nodes to delete a attribute.
-                            By default all nodes are used.
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param occurrences: int or list of int. Which occurrence of the parent nodes to delete a attribute.
+                            By default all nodes are used.
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -649,14 +698,15 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.replace_tag()` to
         the list of tasks that will be done on the xmltree.
 
+        This method deletes a tag with a uniquely identified xpath.
+
         :param tag: str of the tag to replace
-        :param element: a new tag
+        :param element: etree Element or string representing the XML element to replace the tag
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param occurrences: int or list of int. Which occurrence of the parent nodes to replace a tag.
-                            By default all nodes are used.
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param occurrences: int or list of int. Which occurrence of the parent nodes to replace a tag.
+                            By default all nodes are used.
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -673,20 +723,30 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_complex_tag()` to
         the list of tasks that will be done on the xmltree.
 
+        Function to correctly set tags/attributes for a given tag.
+        Goes through the attributedict and decides based on the schema_dict, how the corresponding
+        key has to be handled.
+        The tag is specified via its name and evtl. further specification
+
+        Supports:
+
+            - attributes
+            - tags with text only
+            - simple tags, i.e. only attributes (can be optional single/multiple)
+            - complex tags, will recursively create/modify them
+
         :param tag_name: name of the tag to set
         :param changes: Keys in the dictionary correspond to names of tags and the values are the modifications
                         to do on this tag (attributename, subdict with changes to the subtag, ...)
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param create: bool optional (default False), if True and the path, where the complex tag is
-                       set does not exist it is created
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param create: bool optional (default False), if True and the path, where the complex tag is
+                       set does not exist it is created
 
         Kwargs:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
-
         """
         self._validate_arguments('set_complex_tag', args, kwargs)
         self._tasks.append(ModifierTask('set_complex_tag', args, kwargs))
@@ -696,15 +756,19 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_simple_tag()` to
         the list of tasks that will be done on the xmltree.
 
+        Sets one or multiple `simple` tag(s) in an xmltree. A simple tag can only hold attributes and has no
+        subtags. The tag is specified by its name and further specification
+        If the tag can occur multiple times all existing tags are DELETED and new ones are written.
+        If the tag only occurs once it will automatically be created if its missing.
+
         :param tag_name: str name of the tag to modify/set
         :param changes: list of dicts or dict with the changes. Elements in list describe multiple tags.
                         Keys in the dictionary correspond to {'attributename': attributevalue}
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param create_parents: bool optional (default False), if True and the path, where the simple tags are
-                               set does not exist it is created
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param create_parents: bool optional (default False), if True and the path, where the simple tags are
+                               set does not exist it is created
 
         Kwargs:
             :param contains: str, this string has to be in the final path
@@ -718,19 +782,24 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_text()` to
         the list of tasks that will be done on the xmltree.
 
+        Sets the text on tags in a xmltree to a given value, specified by the name of the tag and
+        further specifications. By default the text will be set on all nodes returned for the specified xpath.
+        If there are no nodes under the specified xpath a tag can be created with `create=True`.
+        The text values are converted automatically according to the types
+        with :py:func:`~masci_tools.util.xml.converters.convert_to_xml()` if they
+        are not `str` already.
+
         :param tag_name: str name of the tag, where the text should be set
         :param text: value or list of values to set
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
-        :param create: bool optional (default False), if True the tag is created if is missing
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
+        :param create: bool optional (default False), if True the tag is created if is missing
 
         Kwargs:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
-
         """
         self._validate_arguments('set_text', args, kwargs)
         self._tasks.append(ModifierTask('set_text', args, kwargs))
@@ -740,18 +809,23 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_first_text()` to
         the list of tasks that will be done on the xmltree.
 
+        Sets the text the first occurrence of a tag in a xmltree to a given value, specified by the name of the tag and
+        further specifications. By default the text will be set on all nodes returned for the specified xpath.
+        If there are no nodes under the specified xpath a tag can be created with `create=True`.
+        The text values are converted automatically according to the types
+        with :py:func:`~masci_tools.util.xml.converters.convert_to_xml()` if they
+        are not `str` already.
+
         :param tag_name: str name of the tag, where the text should be set
         :param text: value or list of values to set
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param create: bool optional (default False), if True the tag is created if is missing
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param create: bool optional (default False), if True the tag is created if is missing
 
         Kwargs:
             :param contains: str, this string has to be in the final path
             :param not_contains: str, this string has to NOT be in the final path
-
         """
         self._validate_arguments('set_first_text', args, kwargs)
         self._tasks.append(ModifierTask('set_first_text', args, kwargs))
@@ -761,14 +835,20 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_attrib_value()` to
         the list of tasks that will be done on the xmltree.
 
+        Sets an attribute in a xmltree to a given value, specified by its name and further
+        specifications.
+        If there are no nodes under the specified xpath a tag can be created with `create=True`.
+        The attribute values are converted automatically according to the types of the attribute
+        with :py:func:`~masci_tools.util.xml.converters.convert_to_xml()` if they
+        are not `str` already.
+
         :param name: the attribute name to set
         :param value: value or list of values to set
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
-        :param create: bool optional (default False), if True the tag is created if is missing
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
+        :param create: bool optional (default False), if True the tag is created if is missing
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -776,7 +856,6 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
             :param exclude: list of str, here specific types of attributes can be excluded
                             valid values are: settable, settable_contains, other
-
         """
         if 'attributename' in kwargs:
             warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
@@ -792,13 +871,19 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_first_attrib_value()` to
         the list of tasks that will be done on the xmltree.
 
+        Sets the first occurrence of an attribute in a xmltree to a given value, specified by its name and further
+        specifications.
+        If there are no nodes under the specified xpath a tag can be created with `create=True`.
+        The attribute values are converted automatically according to the types of the attribute
+        with :py:func:`~masci_tools.util.xml.converters.convert_to_xml()` if they
+        are not `str` already.
+
         :param name: the attribute name to set
         :param value: value or list of values to set
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param create: bool optional (default False), if True the tag is created if is missing
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param create: bool optional (default False), if True the tag is created if is missing
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -806,7 +891,6 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
             :param exclude: list of str, here specific types of attributes can be excluded
                             valid values are: settable, settable_contains, other
-
         """
         if 'attributename' in kwargs:
             warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
@@ -822,16 +906,19 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.add_number_to_attrib()` to
         the list of tasks that will be done on the xmltree.
 
+        Adds a given number to the attribute value in a xmltree specified by the name of the attribute
+        and optional further specification
+        If there are no nodes under the specified xpath an error is raised
+
         :param name: the attribute name to change
         :param number_to_add: number to add/multiply with the old attribute value
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
-        :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
-                    `rel`/`relative` multiplies the old value with `number_to_add`
-                    `abs`/`absolute` adds the old value and `number_to_add`
-        :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
+        :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
+                     `rel`/`relative` multiplies the old value with `number_to_add`
+                     `abs`/`absolute` adds the old value and `number_to_add`
+        :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -839,7 +926,6 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
             :param exclude: list of str, here specific types of attributes can be excluded
                             valid values are: settable, settable_contains, other
-
         """
         if 'attributename' in kwargs:
             warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
@@ -855,15 +941,18 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.add_number_to_first_attrib()` to
         the list of tasks that will be done on the xmltree.
 
+        Adds a given number to the first occurrence of an attribute value in a xmltree specified by the name of the attribute
+        and optional further specification
+        If there are no nodes under the specified xpath an error is raised
+
         :param name: the attribute name to change
         :param number_to_add: number to add/multiply with the old attribute value
         :param complex_xpath: an optional xpath to use instead of the simple xpath for the evaluation
         :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
-                    `rel`/`relative` multiplies the old value with `number_to_add`
-                    `abs`/`absolute` adds the old value and `number_to_add`
+                     `rel`/`relative` multiplies the old value with `number_to_add`
+                     `abs`/`absolute` adds the old value and `number_to_add`
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
-
 
         Kwargs:
             :param tag_name: str, name of the tag where the attribute should be parsed
@@ -871,7 +960,6 @@ class FleurXMLModifier:
             :param not_contains: str, this string has to NOT be in the final path
             :param exclude: list of str, here specific types of attributes can be excluded
                             valid values are: settable, settable_contains, other
-
         """
         if 'attributename' in kwargs:
             warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
@@ -887,12 +975,25 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_basic.xml_create_tag()` to
         the list of tasks that will be done on the xmltree.
 
+        This method evaluates an xpath expression and creates a tag in a xmltree under the
+        returned nodes.
+        If there are no nodes under the specified xpath an error is raised.
+
+        The tag is appended by default, but can be inserted at a certain index (`place_index`)
+        or can be inserted according to a given order of tags
+
         :param xpath: a path where to place a new tag
-        :param element: a tag name or etree Element to be created
+        :param element: a tag name, etree Element or string representing the XML element to be created
         :param place_index: defines the place where to put a created tag
         :param tag_order: defines a tag order
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
+        :param correct_order: bool, if True (default) and a tag_order is given, that does not correspond to the given order
+                              in the xmltree (only order wrong no unknown tags) it will be corrected and a warning is given
+                              This is necessary for some edge cases of the xml schemas of fleur
+        :param several: bool, if True multiple tags od the given name are allowed
+
+        :raises ValueError: If the insertion failed in any way (tag_order does not match, failed to insert, ...)
         """
         self._validate_arguments('xml_create_tag', args, kwargs)
         self._tasks.append(ModifierTask('xml_create_tag', args, kwargs))
@@ -902,8 +1003,10 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_basic.xml_replace_tag()` to
         the list of tasks that will be done on the xmltree.
 
+        Replace XML tags by a given tag on the given XML tree
+
         :param xpath: a path to the tag to be replaced
-        :param element: a new tag
+        :param element: an Element or string representing the Element to replace the found tags with
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
@@ -919,6 +1022,8 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_basic.xml_delete_tag()` to
         the list of tasks that will be done on the xmltree.
 
+        Deletes a tag in the XML tree.
+
         :param xpath: a path to the tag to be deleted
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
@@ -931,8 +1036,10 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_basic.xml_delete_att()` to
         the list of tasks that will be done on the xmltree.
 
+        Deletes an attribute in the XML tree
+
         :param xpath: a path to the attribute to be deleted
-        :param name: the name of an attribute
+        :param name: the name of an attribute to delete
         :param occurrences: int or list of int. Which occurrence of the parent nodes to create a tag.
                             By default all nodes are used.
         """
@@ -947,10 +1054,15 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_basic.xml_set_attrib_value_no_create()` to
         the list of tasks that will be done on the xmltree.
 
+        Sets an attribute in a xmltree to a given value. By default the attribute will be set
+        on all nodes returned for the specified xpath.
+
         :param xpath: a path where to set the attributes
         :param name: the attribute name to set
         :param value: value or list of values to set (if not str they will be converted with `str(value)`)
         :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
+
+        :raises ValueError: If the lengths of attribv or occurrences do not match number of nodes
         """
         if 'attributename' in kwargs:
             warnings.warn('The argument attributename is deprecated. Use name instead', DeprecationWarning)
@@ -966,9 +1078,14 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_basic.xml_set_text_no_create()` to
         the list of tasks that will be done on the xmltree.
 
-        :param xpath: a path where to set the attributes
+        Sets the text of a tag in a xmltree to a given value.
+        By default the text will be set on all nodes returned for the specified xpath.
+
+        :param xpath: a path where to set the text
         :param text: value or list of values to set (if not str they will be converted with `str(value)`)
         :param occurrences: int or list of int. Which occurrence of the node to set. By default all are set.
+
+        :raises ValueError: If the lengths of text or occurrences do not match number of nodes
         """
         self._validate_arguments('xml_set_text_no_create', args, kwargs)
         self._tasks.append(ModifierTask('xml_set_text_no_create', args, kwargs))
@@ -978,16 +1095,22 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_nmmpmat.set_nmmpmat()` to
         the list of tasks that will be done on the xmltree.
 
+        Routine sets the block in the n_mmp_mat file specified by species_name, orbital and spin
+        to the desired density matrix
+
         :param species_name: string, name of the species you want to change
         :param orbital: integer, orbital quantum number of the LDA+U procedure to be modified
         :param spin: integer, specifies which spin block should be modified
         :param state_occupations: list, sets the diagonal elements of the density matrix and everything
-                          else to zero
+                                  else to zero
         :param denmat: matrix, specify the density matrix explicitly
         :param phi: float, optional angle (radian), by which to rotate the density matrix before writing it
         :param theta: float, optional angle (radian), by which to rotate the density matrix before writing it
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
+        :raises ValueError: If something in the input is wrong
+        :raises KeyError: If no LDA+U procedure is found on a species
         """
         self._validate_arguments('set_nmmpmat', args, kwargs)
         self._tasks.append(ModifierTask('set_nmmpmat', args, kwargs))
@@ -997,12 +1120,17 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_nmmpmat.rotate_nmmpmat()` to
         the list of tasks that will be done on the xmltree.
 
+        Rotate the density matrix with the given angles phi and theta
+
         :param species_name: string, name of the species you want to change
         :param orbital: integer or string ('all'), orbital quantum number of the LDA+U procedure to be modified
         :param phi: float, angle (radian), by which to rotate the density matrix
         :param theta: float, angle (radian), by which to rotate the density matrix
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
+        :raises ValueError: If something in the input is wrong
+        :raises KeyError: If no LDA+U procedure is found on a species
         """
         self._validate_arguments('rotate_nmmpmat', args, kwargs)
         self._tasks.append(ModifierTask('rotate_nmmpmat', args, kwargs))
@@ -1012,6 +1140,8 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_nmmpmat.align_nmmpmat_to_sqa()` to
         the list of tasks that will be done on the xmltree.
 
+        Align the density matrix with the given SQA of the associated species
+
         :param species_name: string, name of the species you want to change
         :param orbital: integer or string ('all'), orbital quantum number of the LDA+U procedure to be modified
         :param phi_before: float or list of floats, angle (radian),
@@ -1020,6 +1150,9 @@ class FleurXMLModifier:
                              values for theta for the previous alignment of the density matrix
         :param filters: Dict specifying constraints to apply on the xpath.
                         See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
+
+        :raises ValueError: If something in the input is wrong
+        :raises KeyError: If no LDA+U procedure is found on a species
         """
         self._validate_arguments('align_nmmpmat_to_sqa', args, kwargs)
         self._tasks.append(ModifierTask('align_nmmpmat_to_sqa', args, kwargs))
@@ -1028,6 +1161,9 @@ class FleurXMLModifier:
         """
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_kpointlist()` to
         the list of tasks that will be done on the xmltree.
+
+        Explicitly create a kPointList from the given kpoints and weights. This routine will add the
+        specified kPointList with the given name.
 
         .. warning::
             For input versions Max4 and older **all** keyword arguments are not valid (`name`, `kpoint_type`,
@@ -1050,6 +1186,8 @@ class FleurXMLModifier:
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.switch_kpointset()` to
         the list of tasks that will be done on the xmltree.
 
+        Switch the used k-point set
+
         .. warning::
             This method is only supported for input versions after the Max5 release
 
@@ -1062,6 +1200,8 @@ class FleurXMLModifier:
         """
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_nkpts()` to
         the list of tasks that will be done on the xmltree.
+
+        Sets a k-point mesh directly into inp.xml
 
         .. warning::
             This method is only supported for input versions before the Max5 release
@@ -1077,6 +1217,8 @@ class FleurXMLModifier:
         """
         Appends a :py:func:`~masci_tools.util.xml.xml_setters_names.set_kpath()` to
         the list of tasks that will be done on the xmltree.
+
+        Sets a k-path directly into inp.xml  as a alternative kpoint set with purpose 'bands'
 
         .. warning::
             This method is only supported for input versions before the Max5 release

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -30,7 +30,7 @@ def xml_replace_tag(xmltree: XMLLike,
                     element: str | etree._Element,
                     occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
-    replaces xml tags by another tag on an xmletree in place
+    Replace XML tags by a given tag on the given XML tree
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path to the tag to be replaced
@@ -80,7 +80,7 @@ def xml_delete_att(xmltree: XMLLike,
                    name: str,
                    occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
-    Deletes an xml attribute in an xmletree.
+    Deletes an attribute in the XML tree
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path to the attribute to be deleted
@@ -117,7 +117,7 @@ def xml_delete_att(xmltree: XMLLike,
 
 def xml_delete_tag(xmltree: XMLLike, xpath: XPathLike, occurrences: int | Iterable[int] | None = None) -> XMLLike:
     """
-    Deletes a xml tag in an xmletree.
+    Deletes a tag in the XML tree.
 
     :param xmltree: an xmltree that represents inp.xml
     :param xpath: a path to the tag to be deleted

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -279,6 +279,8 @@ def add_number_to_first_attrib(xmltree: XMLLike,
     :param mode: str (either `rel`/`relative` or `abs`/`absolute`).
                  `rel`/`relative` multiplies the old value with `number_to_add`
                  `abs`/`absolute` adds the old value and `number_to_add`
+    :param filters: Dict specifying constraints to apply on the xpath.
+                    See :py:class:`~masci_tools.util.xml.xpathbuilder.XPathBuilder` for details
 
     Kwargs:
         :param tag_name: str, name of the tag where the attribute should be parsed
@@ -597,7 +599,7 @@ def set_species_label(xmltree: XMLLike,
     :param xmltree: xml etree of the inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
     :param atom_label: string, a label of the atom which specie will be changed. 'all' to change all the species
-    :param attributedict: a python dict specifying what you want to change.
+    :param changes: a python dict specifying what you want to change.
     :param create: bool, if species does not exist create it and all subtags?
 
     :returns: xml etree of the new inp.xml
@@ -648,15 +650,15 @@ def set_species(xmltree: XMLLike,
 
     :return xmltree: xml etree of the new inp.xml
 
-    **attributedict** is a python dictionary containing dictionaries that specify attributes
+    **changes** is a python dictionary containing dictionaries that specify attributes
     to be set inside the certain specie. For example, if one wants to set a MT radius it
     can be done via::
 
-        attributedict = {'mtSphere' : {'radius' : 2.2}}
+        changes = {'mtSphere' : {'radius' : 2.2}}
 
     Another example::
 
-        'attributedict': {'special': {'socscale': 0.0}}
+        'changes': {'special': {'socscale': 0.0}}
 
     that switches SOC terms on a sertain specie. ``mtSphere``, ``atomicCutoffs``,
     ``energyParameters``, ``lo``, ``electronConfig``, ``nocoParams``, ``ldaU`` and
@@ -696,7 +698,7 @@ def clone_species(xmltree: XMLLike,
     :param new_name: new name of the cloned species
     :param changes: a optional python dict specifying what you want to change.
 
-    :return xmltree: xml etree of the new inp.xml
+    :returns xmltree: xml etree of the new inp.xml
     """
     from masci_tools.util.schema_dict_util import evaluate_attribute
     from masci_tools.util.xml.common_functions import eval_xpath
@@ -845,7 +847,7 @@ def set_atomgroup(xmltree: XMLLike,
 
     :param xmltree: xml etree of the inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :param attributedict: a python dict specifying what you want to change.
+    :param changes: a python dict specifying what you want to change.
     :param position: position of an atom group to be changed. If equals to 'all', all species will be changed
     :param species: atom groups, corresponding to the given species will be changed
     :param filters: Dict specifying constraints to apply on the xpath.
@@ -1036,15 +1038,17 @@ def set_inpchanges(xmltree: XMLLike,
 
     :param xmltree: xml tree that represents inp.xml
     :param schema_dict: InputSchemaDict containing all information about the structure of the input
-    :params changes: dictionary {attrib_name : value} with all the wanted changes.
+    :param changes: dictionary {attrib_name : value} with all the wanted changes.
     :param path_spec: dict, with ggf. necessary further specifications for the path of the attribute
 
     An example of changes::
 
-            changes = {'itmax' : 1,
-                       'l_noco': True,
-                       'ctail': False,
-                       'l_ss': True}
+        changes = {
+            'itmax' : 1,
+            'l_noco': True,
+            'ctail': False,
+            'l_ss': True
+        }
 
     :returns: an xmltree of the inp.xml file with changes.
     """

--- a/utils/write_fleurxmlmodifier_docstrings.py
+++ b/utils/write_fleurxmlmodifier_docstrings.py
@@ -1,0 +1,89 @@
+"""
+Script to keep docstrings of XML setter functions and their corresponding methods
+on the FleurXMLModifier in sync
+Is used as a pre-commit hook
+"""
+from masci_tools.util.xml.collect_xml_setters import XPATH_SETTERS, NMMPMAT_SETTERS, SCHEMA_DICT_SETTERS
+import inspect
+import ast
+import sys
+
+from masci_tools.io import fleurxmlmodifier
+
+ALL_SETTERS = {**XPATH_SETTERS, **NMMPMAT_SETTERS, **SCHEMA_DICT_SETTERS}
+INDENT = 4
+
+
+def get_method_docstring(func):
+    """
+    Get the corresponding method docstring of a given XML setter function
+
+    This changes three things.
+        - Strip out references to the arguments handled by the FleurXMLModifier
+        - Add two standardized lines explaining the actual effect of callind the method
+          (append an entry to the tasks)
+        - Indentation is adjusted to two levels (function -> method)
+    """
+
+    lines = [line for line in func.__doc__.split('\n') \
+                if all(x not in line for x in (':param xmltree:', ':param schema_dict:', ':param nmmplines:', ':returns'))]
+
+    module_name = inspect.getmodule(func).__name__
+    additional_lines = [
+        INDENT * ' ' + f'Appends a :py:func:`~{module_name}.{func.__name__}()` to',
+        INDENT * ' ' + 'the list of tasks that will be done on the xmltree.', INDENT * ' '
+    ]
+    if lines[0]:
+        lines[0] = INDENT * ' ' + lines[0]
+        lines.insert(0, '')
+
+    for line in reversed(additional_lines):
+        lines.insert(1, line)
+
+    while all(not line.strip() for line in lines[-2:]):
+        lines.pop()
+    lines = [INDENT * ' ' + line if line.strip() else line.lstrip() for line in lines]
+    lines[-1] = 2 * INDENT * ' '
+    #One level of indentation has to be added since the original docstrings are in functions
+    #and the final ones should be in methods
+    return '\n'.join(lines)
+
+
+def rewrite_docstrings(module_file, modifier_class_name):
+    """
+    Rewrite all the docstrings of the XMl setter methods of the
+    FleurXMLModifier class to be in sync with their corresponding functions
+    """
+
+    with open(module_file, encoding='utf-8') as f:
+        content = f.read()
+        module = ast.parse(content)
+    class_definitions = [node for node in module.body if isinstance(node, ast.ClassDef)]
+    method_definitions = []
+    failed = False
+    for class_def in class_definitions:
+        if class_def.name != modifier_class_name:
+            continue
+        function_definitions = [node for node in class_def.body if isinstance(node, ast.FunctionDef)]
+        for f in function_definitions:
+            if f.name in ALL_SETTERS:
+                try:
+                    docstring = get_method_docstring(ALL_SETTERS[f.name])
+                except Exception as exc:  #pylint: disable=broad-except
+                    print(f'Docstring generation failed for: {f.name} ({exc})')
+                    failed = True
+                    continue
+                old_docstring = ast.get_docstring(f, clean=False)
+                if old_docstring != docstring:
+                    print(f'Rewriting docstring of method: {f.name}')
+                    content = content.replace(old_docstring, docstring)
+
+    with open(module_file, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+    if failed:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    rewrite_docstrings(fleurxmlmodifier.__file__, 'FleurXMLModifier')

--- a/utils/write_fleurxmlmodifier_docstrings.py
+++ b/utils/write_fleurxmlmodifier_docstrings.py
@@ -36,7 +36,6 @@ def get_method_docstring(name, docstring, module):
     for line in reversed(additional_lines):
         lines.insert(1, line)
 
-    print(lines[-2:], all(not line.strip() for line in lines[-2:]))
     while all(not line.strip() for line in lines[-2:]):
         lines.pop()
     lines = [2 * INDENT * ' ' + line if line.strip() else line.lstrip() for line in lines]

--- a/utils/write_fleurxmlmodifier_docstrings.py
+++ b/utils/write_fleurxmlmodifier_docstrings.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 INDENT = 4
+MASCI_TOOLS_PATH = Path(__file__).parent.parent / 'masci_tools'
 
 
 def get_method_docstring(name, docstring, module):
@@ -54,7 +55,7 @@ def rewrite_docstrings(module_file, modifier_class_name, setters, modules):
         content = f.read()
         module = ast.parse(content)
     class_definitions = [node for node in module.body if isinstance(node, ast.ClassDef)]
-    method_definitions = []
+
     failed = False
     for class_def in class_definitions:
         if class_def.name != modifier_class_name:
@@ -85,14 +86,12 @@ def gather_setter_functions(module_names, collection_file):
     Gather all setter functions that are imported in collect_xml_setters
     """
 
-    setter_files = [masci_tools_path / f'util/xml/{name}.py' for name in module_names]
+    setter_files = [MASCI_TOOLS_PATH / f'util/xml/{name}.py' for name in module_names]
     docstrings = {}
 
     for file in setter_files:
         with open(file, encoding='utf-8') as f:
             module = ast.parse(f.read())
-
-        name = file.stem
 
         function_definitions = [node for node in module.body if isinstance(node, ast.FunctionDef)]
         for f in function_definitions:
@@ -107,7 +106,7 @@ def gather_setter_functions(module_names, collection_file):
     modules = {}
 
     for import_stmt in imports:
-        if import_stmt.module in setter_module_names:
+        if import_stmt.module in module_names:
             for alias in import_stmt.names:
                 collected_docstrings[alias.name] = docstrings[alias.name]
                 modules[alias.name] = import_stmt.module
@@ -117,10 +116,8 @@ def gather_setter_functions(module_names, collection_file):
 
 if __name__ == '__main__':
 
-    masci_tools_path = Path(__file__).parent.parent / 'masci_tools'
-
     setter_module_names = ('xml_setters_names', 'xml_setters_nmmpmat', 'xml_setters_basic')
     setter_docstrings, setter_modules = gather_setter_functions(setter_module_names,
-                                                                masci_tools_path / 'util/xml/collect_xml_setters.py')
-    rewrite_docstrings(masci_tools_path / 'io/fleurxmlmodifier.py', 'FleurXMLModifier', setter_docstrings,
+                                                                MASCI_TOOLS_PATH / 'util/xml/collect_xml_setters.py')
+    rewrite_docstrings(MASCI_TOOLS_PATH / 'io/fleurxmlmodifier.py', 'FleurXMLModifier', setter_docstrings,
                        setter_modules)


### PR DESCRIPTION
Changes done to the docstrings of XML setter methods in `FleurXMLModifier` will be overwritten by this hook.
The source of the docstrings is now only the XML setter functions