### PR TITLE
Add runtime type checking of XPath evaluation routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## latest
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.11.3...develop)
 
-Nothing here yet
+### Added
+- Added XPath evaluation functions with runtime tpye checking of the results of the expressions [[#181]](https://github.com/JuDFTteam/masci-tools/pull/181)
 
 ## v.0.11.3
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.11.2...v0.11.3)

--- a/masci_tools/util/xml/common_functions.py
+++ b/masci_tools/util/xml/common_functions.py
@@ -19,7 +19,7 @@ from lxml import etree
 import warnings
 import copy
 import logging
-from typing import cast, Any
+from typing import Any, TypeVar, cast, Type, overload
 
 from .xpathbuilder import FilterType, XPathBuilder
 
@@ -52,10 +52,10 @@ def clear_xml(tree: etree._ElementTree) -> tuple[etree._ElementTree, set[str]]:
         next_sibling = next_sibling.getnext()
 
     #find any include tags
-    include_tags: list[etree._Element] = eval_xpath(cleared_tree,
-                                                    '//xi:include',
-                                                    namespaces={'xi': 'http://www.w3.org/2001/XInclude'},
-                                                    list_return=True)  #type:ignore
+    include_tags = eval_xpath_all(cleared_tree,
+                                  '//xi:include',
+                                  etree._Element,
+                                  namespaces={'xi': 'http://www.w3.org/2001/XInclude'})
 
     parents = []
     known_tags = []
@@ -178,7 +178,7 @@ def eval_xpath(node: XMLLike | etree.XPathElementEvaluator,
                logger: logging.Logger | None = None,
                list_return: bool = False,
                namespaces: dict[str, str] | None = None,
-               **variables: etree._XPathObject) -> etree._XPathObject:
+               **variables: etree._XPathObject) -> Any:
     """
     Tries to evaluate an xpath expression. If it fails it logs it.
     If a absolute path is given (starting with '/') and the tag of the node
@@ -240,9 +240,12 @@ def eval_xpath(node: XMLLike | etree.XPathElementEvaluator,
     if logger is not None:
         logger.debug('XPath Result: %s', return_value)
 
+    if list_return and not isinstance(return_value, list):
+        return [return_value]
+
     if isinstance(return_value, list):
         if len(return_value) == 1 and not list_return:
-            return return_value[0]  #type:ignore
+            return return_value[0]
     return return_value
 
 
@@ -383,8 +386,8 @@ def check_complex_xpath(node: XMLLike | etree.XPathElementEvaluator, base_xpath:
     :raises ValueError: If the complex_xpath does not produce a subset of the results
                         of the base_xpath
     """
-    results_base = set(eval_xpath(node, base_xpath, list_return=True))  #type:ignore
-    results_complex = set(eval_xpath(node, complex_xpath, list_return=True))  #type:ignore
+    results_base = set(eval_xpath_all(node, base_xpath))
+    results_complex = set(eval_xpath_all(node, complex_xpath))
 
     if not results_base.issuperset(results_complex):
         raise ValueError(f"Complex xpath '{complex_xpath!r}' is not compatible with the base_xpath '{base_xpath!r}'")
@@ -461,6 +464,143 @@ def is_valid_tag(tag: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+T = TypeVar('T')
+"""Generic Type"""
+
+
+@overload
+def eval_xpath_all(node: XMLLike | etree.XPathElementEvaluator,
+                   xpath: XPathLike,
+                   expected_type: type[T],
+                   *,
+                   logger: logging.Logger | None = ...,
+                   namespaces: dict[str, str] | None = ...,
+                   **variables: etree._XPathObject) -> list[T]:
+    ...
+
+
+@overload
+def eval_xpath_all(node: XMLLike | etree.XPathElementEvaluator,
+                   xpath: XPathLike,
+                   expected_type: None = ...,
+                   *,
+                   logger: logging.Logger | None = ...,
+                   namespaces: dict[str, str] | None = ...,
+                   **variables: etree._XPathObject) -> list[Any]:
+    ...
+
+
+def eval_xpath_all(node: XMLLike | etree.XPathElementEvaluator,
+                   xpath: XPathLike,
+                   expected_type: type[T] | None = None,
+                   *,
+                   logger: logging.Logger | None = None,
+                   namespaces: dict[str, str] | None = None,
+                   **variables: etree._XPathObject) -> list[T] | list[Any]:
+
+    result = eval_xpath(node, xpath, logger=logger, namespaces=namespaces, list_return=True, **variables)
+
+    if expected_type is not None and not all(isinstance(x, expected_type) for x in result):
+        all_types = {type(x) for x in result}
+        if logger is not None:
+            logger.error(f'Expected XPath results of type {expected_type!r}. Got: {all_types!r}')
+        raise TypeError(f'Expected XPath results of type {expected_type!r}. Got: {all_types!r}')
+
+    return result
+
+
+@overload
+def eval_xpath_first(node: XMLLike | etree.XPathElementEvaluator,
+                     xpath: XPathLike,
+                     expected_type: type[T],
+                     *,
+                     logger: logging.Logger | None = ...,
+                     namespaces: dict[str, str] | None = ...,
+                     **variables: etree._XPathObject) -> T:
+    ...
+
+
+@overload
+def eval_xpath_first(node: XMLLike | etree.XPathElementEvaluator,
+                     xpath: XPathLike,
+                     expected_type: None = ...,
+                     *,
+                     logger: logging.Logger | None = ...,
+                     namespaces: dict[str, str] | None = ...,
+                     **variables: etree._XPathObject) -> Any:
+    ...
+
+
+def eval_xpath_first(node: XMLLike | etree.XPathElementEvaluator,
+                     xpath: XPathLike,
+                     expected_type: type[T] | None = None,
+                     *,
+                     logger: logging.Logger | None = None,
+                     namespaces: dict[str, str] | None = None,
+                     **variables: etree._XPathObject) -> T | Any:
+
+    result = eval_xpath(node, xpath, logger=logger, namespaces=namespaces, list_return=True, **variables)
+    if len(result) == 0:
+        if logger is not None:
+            logger.error(f'Expected atleast one result. Found {len(result)}')
+        raise ValueError(f'Expected atleast one result. Found {len(result)}')
+
+    result = result[0]
+
+    if expected_type is not None and not isinstance(result, expected_type):
+        if logger is not None:
+            logger.error(f'Expected XPath results of type {expected_type!r}. Got: {type(result)}')
+        raise TypeError(f'Expected XPath results of type {expected_type!r}. Got: {type(result)}')
+
+    return result
+
+
+@overload
+def eval_xpath_one(node: XMLLike | etree.XPathElementEvaluator,
+                   xpath: XPathLike,
+                   expected_type: type[T],
+                   *,
+                   logger: logging.Logger | None = ...,
+                   namespaces: dict[str, str] | None = ...,
+                   **variables: etree._XPathObject) -> T:
+    ...
+
+
+@overload
+def eval_xpath_one(node: XMLLike | etree.XPathElementEvaluator,
+                   xpath: XPathLike,
+                   expected_type: None = ...,
+                   *,
+                   logger: logging.Logger | None = ...,
+                   namespaces: dict[str, str] | None = ...,
+                   **variables: etree._XPathObject) -> Any:
+    ...
+
+
+def eval_xpath_one(node: XMLLike | etree.XPathElementEvaluator,
+                   xpath: XPathLike,
+                   expected_type: type[T] | None = None,
+                   *,
+                   logger: logging.Logger | None = None,
+                   namespaces: dict[str, str] | None = None,
+                   **variables: etree._XPathObject) -> T | Any:
+
+    result = eval_xpath(node, xpath, logger=logger, namespaces=namespaces, list_return=True, **variables)
+    if len(result) != 1:
+        if logger is not None:
+            logger.error(f'Expected one result. Found {len(result)}')
+        raise ValueError(f'Expected one result. Found {len(result)}')
+
+    result = result[0]
+
+    if expected_type is not None and not isinstance(result, expected_type):
+        if logger is not None:
+            logger.error(f'Expected XPath results of type {expected_type!r}. Got: {type(result)}')
+        raise TypeError(f'Expected XPath results of type {expected_type!r}. Got: {type(result)}')
+
+    return result
 
 
 def serialize_xml_objects(args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:

--- a/masci_tools/util/xml/converters.py
+++ b/masci_tools/util/xml/converters.py
@@ -14,7 +14,7 @@ Common functions for converting types to and from XML files
 """
 from __future__ import annotations
 
-from typing import Iterable, Any, cast, Union
+from typing import Iterable, Any, Union
 import sys
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -574,20 +574,14 @@ def convert_fleur_electronconfig(econfig_element: etree._Element) -> str:
     """
     Convert electronConfig tag to eConfig string
     """
-    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.common_functions import eval_xpath_one
     from masci_tools.util.econfig import convert_fleur_config_to_econfig
 
-    core_config = eval_xpath(econfig_element, 'coreConfig/text()')
-    valence_config = eval_xpath(econfig_element, 'valenceConfig/text()')
+    core_config = eval_xpath_one(econfig_element, 'coreConfig/text()', str)
+    valence_config = eval_xpath_one(econfig_element, 'valenceConfig/text()', str)
 
-    if not core_config:
-        core_config = ''
-
-    if not valence_config:
-        valence_config = ''
-
-    core_config_str = convert_fleur_config_to_econfig(cast(str, core_config))
-    valence_config_str = convert_fleur_config_to_econfig(cast(str, valence_config))
+    core_config_str = convert_fleur_config_to_econfig(core_config)
+    valence_config_str = convert_fleur_config_to_econfig(valence_config)
 
     return f'{core_config_str} | {valence_config_str}'
 

--- a/masci_tools/util/xml/xml_setters_basic.py
+++ b/masci_tools/util/xml/xml_setters_basic.py
@@ -22,7 +22,7 @@ from lxml import etree
 import warnings
 
 from masci_tools.util.typing import XPathLike, XMLLike
-from masci_tools.util.xml.common_functions import eval_xpath, is_valid_tag
+from masci_tools.util.xml.common_functions import eval_xpath_all, is_valid_tag
 
 
 def xml_replace_tag(xmltree: XMLLike,
@@ -50,7 +50,7 @@ def xml_replace_tag(xmltree: XMLLike,
     if not etree.iselement(element):
         element = etree.fromstring(element)  #type:ignore[arg-type]
 
-    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes = eval_xpath_all(root, xpath, etree._Element)
 
     if len(nodes) == 0:
         warnings.warn(f'No nodes to replace found on xpath: {xpath!r}')
@@ -96,7 +96,7 @@ def xml_delete_att(xmltree: XMLLike,
     else:
         root = xmltree
 
-    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes = eval_xpath_all(root, xpath, etree._Element)
 
     if len(nodes) == 0:
         warnings.warn(f'No nodes to delete attributes on found on xpath: {xpath!r}')
@@ -132,7 +132,7 @@ def xml_delete_tag(xmltree: XMLLike, xpath: XPathLike, occurrences: int | Iterab
     else:
         root = xmltree
 
-    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes = eval_xpath_all(root, xpath, etree._Element)
 
     if len(nodes) == 0:
         warnings.warn(f'No nodes to delete found on xpath: {xpath!r}')
@@ -237,7 +237,7 @@ def xml_create_tag(xmltree: XMLLike,
     else:
         element_name = element.tag
 
-    parent_nodes: list[etree._Element] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+    parent_nodes = eval_xpath_all(xmltree, xpath, etree._Element)
 
     if len(parent_nodes) == 0:
         raise ValueError(f"Could not create tag '{element_name}' because at least one subtag is missing. "
@@ -350,7 +350,7 @@ def xml_set_attrib_value_no_create(xmltree: XMLLike,
     else:
         root = xmltree
 
-    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes = eval_xpath_all(root, xpath, etree._Element)
 
     if len(nodes) == 0:
         warnings.warn(f'No nodes to set attribute {name} on found on xpath: {xpath!r}')
@@ -402,7 +402,7 @@ def xml_set_text_no_create(xmltree: XMLLike,
     else:
         root = xmltree
 
-    nodes: list[etree._Element] = eval_xpath(root, xpath, list_return=True)  #type:ignore
+    nodes = eval_xpath_all(root, xpath, etree._Element)
 
     if len(nodes) == 0:
         warnings.warn(f'No nodes to set text on found on xpath: {xpath!r}')

--- a/masci_tools/util/xml/xml_setters_names.py
+++ b/masci_tools/util/xml/xml_setters_names.py
@@ -701,7 +701,7 @@ def clone_species(xmltree: XMLLike,
     :returns xmltree: xml etree of the new inp.xml
     """
     from masci_tools.util.schema_dict_util import evaluate_attribute
-    from masci_tools.util.xml.common_functions import eval_xpath
+    from masci_tools.util.xml.common_functions import eval_xpath_one
     import copy
 
     existing_names = set(evaluate_attribute(xmltree, schema_dict, 'name', contains='species', list_return=True))
@@ -713,10 +713,7 @@ def clone_species(xmltree: XMLLike,
     xpath_species = schema_dict.tag_xpath('species')
     xpath_species = f'{xpath_species}[@name = "{species_name}"]'
 
-    old_species: etree._Element = eval_xpath(xmltree, xpath_species, list_return=True)  #type:ignore
-    if len(old_species) != 1:
-        raise ValueError('Failed to retrieve species to clone')
-    old_species = old_species[0]
+    old_species = eval_xpath_one(xmltree, xpath_species, etree._Element)
 
     parent = old_species.getparent()
     if parent is None:

--- a/masci_tools/util/xml/xml_setters_nmmpmat.py
+++ b/masci_tools/util/xml/xml_setters_nmmpmat.py
@@ -22,7 +22,7 @@ import numpy as np
 from masci_tools.io.parsers import fleur_schema
 from masci_tools.util.xml.xpathbuilder import XPathBuilder, FilterType
 from masci_tools.util.xml.common_functions import get_xml_attribute
-from masci_tools.util.xml.common_functions import eval_xpath
+from masci_tools.util.xml.common_functions import eval_xpath_all
 from masci_tools.util.typing import XMLLike
 
 from masci_tools.util.schema_dict_util import eval_simple_xpath, evaluate_attribute
@@ -80,7 +80,7 @@ def set_nmmpmat(xmltree: XMLLike,
     elif species_name != 'all':
         species_name_xpath.add_filter('species', {'name': species_name})
 
-    possible_species: set[str] = set(eval_xpath(xmltree, species_name_xpath, list_return=True))  #type:ignore
+    possible_species = set(eval_xpath_all(xmltree, species_name_xpath, str))
 
     nspins = _get_number_of_spin_blocks(xmltree, schema_dict)
     if spin > nspins:
@@ -171,7 +171,7 @@ def align_nmmpmat_to_sqa(xmltree: XMLLike,
     elif species_name != 'all':
         species_name_xpath.add_filter('species', {'name': species_name})
 
-    possible_species: set[str] = set(eval_xpath(xmltree, species_name_xpath, list_return=True))  #type:ignore
+    possible_species = set(eval_xpath_all(xmltree, species_name_xpath, str))
 
     #Extract the SQA for all atom groups
     # (if we have scond variationn SOC it will just set to the same value)
@@ -270,7 +270,7 @@ def rotate_nmmpmat(xmltree: XMLLike,
     elif species_name != 'all':
         species_name_xpath.add_filter('species', {'name': species_name})
 
-    possible_species: set[str] = set(eval_xpath(xmltree, species_name_xpath, list_return=True))  #type:ignore
+    possible_species = set(eval_xpath_all(xmltree, species_name_xpath, str))
 
     nspins = _get_number_of_spin_blocks(xmltree, schema_dict)
     ldau_order = _get_ldau_order(xmltree, schema_dict)

--- a/masci_tools/util/xml/xml_setters_xpaths.py
+++ b/masci_tools/util/xml/xml_setters_xpaths.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from masci_tools.util.xml.xpathbuilder import XPathBuilder
 from masci_tools.util.typing import XPathLike, XMLLike
-from masci_tools.util.xml.common_functions import eval_xpath, add_tag, is_valid_tag
+from masci_tools.util.xml.common_functions import eval_xpath_all, add_tag, is_valid_tag
 from masci_tools.io.parsers import fleur_schema
 
 from lxml import etree
@@ -92,7 +92,7 @@ def xml_create_tag_schema_dict(xmltree: XMLLike,
     if not several_tags and number_nodes > 1:
         raise ValueError(f'Can not create {number_nodes} nodes of tag {element_name}: Tag only allowed once')
 
-    parent_nodes: list[etree._Element] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+    parent_nodes = eval_xpath_all(xmltree, xpath, etree._Element)
 
     if len(parent_nodes) == 0:
         if create_parents:
@@ -141,7 +141,7 @@ def eval_xpath_create(xmltree: XMLLike,
 
     check_complex_xpath(xmltree, base_xpath, xpath)
 
-    nodes: list[etree._Element] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+    nodes = eval_xpath_all(xmltree, xpath, etree._Element)
 
     if len(nodes) == 0:
         parent_xpath, tag_name = split_off_tag(base_xpath)
@@ -154,7 +154,7 @@ def eval_xpath_create(xmltree: XMLLike,
                                              create_parents=create_parents,
                                              number_nodes=number_nodes,
                                              occurrences=occurrences)
-        nodes = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+        nodes = eval_xpath_all(xmltree, xpath, etree._Element)
 
     if len(nodes) == 1 and not list_return:
         nodes = nodes[0]  #type:ignore
@@ -213,16 +213,16 @@ def xml_set_attrib_value(xmltree: XMLLike,
     n_nodes = len(converted_value) if is_sequence(converted_value) else 1
 
     if create:
-        nodes: list[etree._Element] = eval_xpath_create(xmltree,
-                                                        schema_dict,
-                                                        xpath,
-                                                        base_xpath,
-                                                        create_parents=True,
-                                                        occurrences=occurrences,
-                                                        number_nodes=n_nodes,
-                                                        list_return=True)
+        nodes = eval_xpath_create(xmltree,
+                                  schema_dict,
+                                  xpath,
+                                  base_xpath,
+                                  create_parents=True,
+                                  occurrences=occurrences,
+                                  number_nodes=n_nodes,
+                                  list_return=True)
     else:
-        nodes = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+        nodes = eval_xpath_all(xmltree, xpath, etree._Element)
 
     if len(nodes) == 0:
         raise ValueError(f"Could not set attribute '{name}' on path '{xpath!r}' "
@@ -305,16 +305,16 @@ def xml_set_text(xmltree: XMLLike,
     n_nodes = len(converted_text) if is_sequence(converted_text) else 1
 
     if create:
-        nodes: list[etree._Element] = eval_xpath_create(xmltree,
-                                                        schema_dict,
-                                                        xpath,
-                                                        base_xpath,
-                                                        create_parents=True,
-                                                        occurrences=occurrences,
-                                                        number_nodes=n_nodes,
-                                                        list_return=True)
+        nodes = eval_xpath_create(xmltree,
+                                  schema_dict,
+                                  xpath,
+                                  base_xpath,
+                                  create_parents=True,
+                                  occurrences=occurrences,
+                                  number_nodes=n_nodes,
+                                  list_return=True)
     else:
-        nodes = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
+        nodes = eval_xpath_all(xmltree, xpath, etree._Element)
 
     if len(nodes) == 0:
         raise ValueError(f"Could not set text on path '{xpath!r}' because at least one subtag is missing. "
@@ -411,11 +411,9 @@ def xml_add_number_to_attrib(xmltree: XMLLike,
             xpath.append_tag(f'@{name}')
     elif not str(xpath).endswith(f'/@{name}'):
         xpath = '/@'.join([str(xpath), name])
-
-    stringattribute: list[str] = eval_xpath(xmltree, xpath, list_return=True)  #type:ignore
-
     tag_xpath, name = split_off_attrib(xpath)
 
+    stringattribute = eval_xpath_all(xmltree, xpath, str)
     if len(stringattribute) == 0:
         raise ValueError(f"No attribute values found for '{name}'. Cannot add number")
 
@@ -538,7 +536,7 @@ def xml_set_simple_tag(xmltree: XMLLike,
         if isinstance(changes, dict):
             changes = [changes]
 
-        if len(eval_xpath(xmltree, tag_xpath, list_return=True)) > 0:  #type:ignore
+        if len(eval_xpath_all(xmltree, tag_xpath, etree._Element)) > 0:
             # policy: we DELETE all existing tags, and create new ones from the given parameters.
             xml_delete_tag(xmltree, tag_xpath)
 
@@ -554,7 +552,7 @@ def xml_set_simple_tag(xmltree: XMLLike,
             for attrib, value in change.items():
                 occurrences = [
                     k * len(changes) + indx
-                    for k in range(len(eval_xpath(xmltree, tag_xpath, list_return=True)) // len(changes))  #type:ignore
+                    for k in range(len(eval_xpath_all(xmltree, tag_xpath, etree._Element)) // len(changes))
                 ]
                 xml_set_attrib_value(xmltree,
                                      schema_dict,
@@ -649,7 +647,7 @@ def xml_set_complex_tag(xmltree: XMLLike,
             xmltree = xml_set_complex_tag(xmltree, schema_dict, sub_xpath, sub_base_xpath, val, create=create)
 
         else:
-            if len(eval_xpath(xmltree, sub_xpath, list_return=True)) > 0:  #type:ignore
+            if len(eval_xpath_all(xmltree, sub_xpath, etree._Element)) > 0:
                 # policy: we DELETE all existing tags, and create new ones from the given parameters.
                 xml_delete_tag(xmltree, sub_xpath)
 
@@ -660,7 +658,7 @@ def xml_set_complex_tag(xmltree: XMLLike,
                 xml_create_tag_schema_dict(xmltree, schema_dict, xpath, base_xpath, key, create_parents=create)
 
             for indx, tagdict in enumerate(val):
-                for k in range(len(eval_xpath(xmltree, sub_xpath, list_return=True)) // len(val)):  #type:ignore
+                for k in range(len(eval_xpath_all(xmltree, sub_xpath, etree._Element)) // len(val)):
                     current_elem_xpath: XPathLike
                     if isinstance(sub_xpath, XPathBuilder):
                         current_elem_xpath = copy.deepcopy(sub_xpath)

--- a/tests/xml/test_xml_common_functions.py
+++ b/tests/xml/test_xml_common_functions.py
@@ -48,6 +48,91 @@ def test_eval_xpath(caplog, load_inpxml):
     assert 'There was a XpathEvalError on the xpath:' in caplog.text
 
 
+def test_eval_xpath_all(load_inpxml):
+    """
+    Test of the eval_xpath function
+    """
+    from masci_tools.util.xml.common_functions import eval_xpath_all
+
+    xmltree, _ = load_inpxml('fleur/test_clear.xml', absolute=False)
+    root = xmltree.getroot()
+
+    scfLoop = eval_xpath_all(root, '//scfLoop', etree._Element)
+    assert isinstance(scfLoop, list)
+    assert all(isinstance(n, etree._Element) for n in scfLoop)
+
+    include_tags = eval_xpath_all(root,
+                                  '//xi:include',
+                                  etree._Element,
+                                  namespaces={'xi': 'http://www.w3.org/2001/XInclude'})
+    assert len(include_tags) == 2
+    assert isinstance(include_tags[0], etree._Element)
+
+    with pytest.raises(TypeError):
+        eval_xpath_all(root, '//scfLoop', str)
+
+    species_z = eval_xpath_all(root, "//species[@name='Cu-1']/@atomicNumber", str)
+    assert species_z == ['29']
+
+    ldau_tags = eval_xpath_all(root, "//species[@name='Cu-1']/ldaU")
+    assert ldau_tags == []
+
+
+def test_eval_xpath_one(load_inpxml):
+    """
+    Test of the eval_xpath function
+    """
+    from masci_tools.util.xml.common_functions import eval_xpath_one
+
+    xmltree, _ = load_inpxml('fleur/test_clear.xml', absolute=False)
+    root = xmltree.getroot()
+
+    scfLoop = eval_xpath_one(root, '//scfLoop', etree._Element)
+    assert isinstance(scfLoop, etree._Element)
+
+    with pytest.raises(ValueError):
+        eval_xpath_one(root, '//xi:include', etree._Element, namespaces={'xi': 'http://www.w3.org/2001/XInclude'})
+
+    with pytest.raises(TypeError):
+        eval_xpath_one(root, '//scfLoop', str)
+
+    species_z = eval_xpath_one(root, "//species[@name='Cu-1']/@atomicNumber", str)
+    assert species_z == '29'
+
+    with pytest.raises(ValueError):
+        eval_xpath_one(root, "//species[@name='Cu-1']/ldaU")
+
+
+def test_eval_xpath_first(load_inpxml):
+    """
+    Test of the eval_xpath function
+    """
+    from masci_tools.util.xml.common_functions import eval_xpath_first
+
+    xmltree, _ = load_inpxml('fleur/test_clear.xml', absolute=False)
+    root = xmltree.getroot()
+
+    scfLoop = eval_xpath_first(root, '//scfLoop', etree._Element)
+    assert isinstance(scfLoop, etree._Element)
+
+    include_tag = eval_xpath_first(root,
+                                   '//xi:include',
+                                   etree._Element,
+                                   namespaces={'xi': 'http://www.w3.org/2001/XInclude'})
+
+    assert isinstance(include_tag, etree._Element)
+    assert include_tag.attrib['href'] == 'test_include.xml'
+
+    with pytest.raises(TypeError):
+        eval_xpath_first(root, '//scfLoop', str)
+
+    species_z = eval_xpath_first(root, "//species[@name='Cu-1']/@atomicNumber", str)
+    assert species_z == '29'
+
+    with pytest.raises(ValueError):
+        eval_xpath_first(root, "//species[@name='Cu-1']/ldaU")
+
+
 def test_clear_xml(load_inpxml):
     """
     Test of the clear_xml function


### PR DESCRIPTION
Added
- `eval_xpath_all` returns all results
- `eval_xpath_one` returns one result and makes sure there is only one
- `eval_xpath_first` returns the first result

All three accept the argument `expected_type`, which is used to check the results of the XPath evaluation