### PR TITLE
Fix condition in `ensure_relaxation_xinclude`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed `masci-tools fleur-schema add` with `--from-git` flag. Previously it would still check for the existence of the Schema file locally [[#184]](https://github.com/JuDFTteam/masci-tools/pull/184)
 - `get_fleur_modes`: `gw` mode renamed to `spex` and now stores the actual integer value of the attribute [[#185]](https://github.com/JuDFTteam/masci-tools/pull/185)
 - Bugfix in `clear_xml`, when multiple XML comments are present outside the root element [[#193]](https://github.com/JuDFTteam/masci-tools/pull/193)
+- Bugfix in `reverse_xinclude`. This would previously break when reexcluding trees already containing a `relaxation` tag and would end up with two `xi:include` tags for the `relax.xml` [[#194]](https://github.com/JuDFTteam/masci-tools/pull/194)
 
 ## v.0.11.3
 [full changelog](https://github.com/JuDFTteam/masci-tools/compare/v0.11.2...v0.11.3)

--- a/masci_tools/util/schema_dict_util.py
+++ b/masci_tools/util/schema_dict_util.py
@@ -823,7 +823,7 @@ def ensure_relaxation_xinclude(xmltree: etree._ElementTree, schema_dict: fleur_s
 
     INCLUDE_NSMAP = {'xi': 'http://www.w3.org/2001/XInclude'}
     if not tag_exists(xmltree, schema_dict, 'relaxation') and \
-       len(eval_xpath_all(xmltree, '//xi:include[href=$file]', etree._Element, namespaces=INCLUDE_NSMAP, file='relax.xml')) == 0:
+       len(eval_xpath_all(xmltree, '//xi:include[@href=$file]', etree._Element, namespaces=INCLUDE_NSMAP, file='relax.xml')) == 0:
         root = xmltree.getroot()
         root.append(_get_xinclude_elem('relax.xml'))
 


### PR DESCRIPTION
this would not detect when the relax.xml include was already present and would enter a second xi:include tag breaking the inp.xml